### PR TITLE
DXT5 reads RGB but can do YCgCo conversion and create straight alpha

### DIFF
--- a/ValveResourceFormat/ThirdParty/DDSImage.cs
+++ b/ValveResourceFormat/ThirdParty/DDSImage.cs
@@ -270,7 +270,9 @@ namespace ValveResourceFormat.ThirdParty
                             finalAlpha = byte.MaxValue;
                         } else if (finalAlpha > 0)
                         {
-
+                            finalR = ClampColor(finalR * byte.MaxValue / finalAlpha);
+                            finalG = ClampColor(finalG * byte.MaxValue / finalAlpha);
+                            finalB = ClampColor(finalB * byte.MaxValue / finalAlpha);
                         }
 
                         image.SetPixel(x + i, y + j, Color.FromArgb(finalAlpha, finalR, finalG, finalB));

--- a/ValveResourceFormat/ThirdParty/DDSImage.cs
+++ b/ValveResourceFormat/ThirdParty/DDSImage.cs
@@ -266,9 +266,14 @@ namespace ValveResourceFormat.ThirdParty
                             finalR = ClampColor(finalAlpha + co - cg);
                             finalG = ClampColor(finalAlpha + cg);
                             finalB = ClampColor(finalAlpha - co - cg);
+
+                            finalAlpha = byte.MaxValue;
+                        } else if (finalAlpha > 0)
+                        {
+
                         }
 
-                        image.SetPixel(x + i, y + j, Color.FromArgb(finalR, finalG, finalB));
+                        image.SetPixel(x + i, y + j, Color.FromArgb(finalAlpha, finalR, finalG, finalB));
                     }
                 }
             }


### PR DESCRIPTION
New pull request that replaces
https://github.com/SteamDatabase/ValveResourceFormat/pull/36

UncompressDXT5 takes two extra bools that enable YCgCo conversion and straight alpha.
