### PR TITLE
Generic vpk dump tool functionality and filters

### DIFF
--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -42,6 +42,26 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
+        [Option("tool", DefaultValue = false,
+            HelpText = "Enable generic vpk dump tool, supporting filters.")]
+        public bool VPKTool { get; set; }
+
+        [Option('x', "extract",
+            HelpText = "Just extract, do not decompile")]
+        public bool Extract { get; set; }
+
+        [Option('f', "filter",
+            HelpText = "Dump filter - full or partial path, example: panorama\\")]
+        public string Filter { get; set; }
+
+        [Option('e', "filter_ext",
+            HelpText = "Dump filter - extension(s), example: vcss_c,vjs_c,vxml_c")]
+        public string FilterExt { get; set; }       
+
+        [Option('s', "silent",
+            HelpText = "Dump without printing file names")]
+        public bool Silent { get; set; }
+
         [HelpOption]
         public string GetUsage()
         {

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using CommandLine;
 using CommandLine.Text;
 
@@ -46,12 +47,12 @@ namespace Decompiler
             HelpText = "Decompile supported files")]
         public bool Decompile { get; set; }
 
-        [Option('e', "vpk_extensions",
-            HelpText = "File extension(s) filter, example: vcss_c,vjs_c,vxml_c")]
-        public string ExtFilter { get; set; }
+        [OptionList('e', "vpk_extensions", Separator = ',', DefaultValue = new string[] { },
+            HelpText = "File extension(s) filter, example: \"vcss_c,vjs_c,vxml_c\"")]
+        public IList<string> ExtFilter { get; set; }
 
         [Option('f', "vpk_filepath",
-            HelpText = "File path filter, example: panorama\\")]
+            HelpText = "File path filter, example: panorama\\ or \"panorama\\\\\"")]
         public string FileFilter { get; set; }
 
         [HelpOption]

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -42,25 +42,17 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
-        [Option("tool", DefaultValue = false,
-            HelpText = "Enable generic vpk dump tool, supporting filters.")]
-        public bool VPKTool { get; set; }
+        [Option('d', "vpk_dump",
+            HelpText = "Dump only, do not decompile")]
+        public bool DumpOnly { get; set; }
 
-        [Option('x', "extract",
-            HelpText = "Just extract, do not decompile")]
-        public bool Extract { get; set; }
+        [Option('e', "vpk_extensions",
+            HelpText = "File extension(s) filter, example: vcss_c,vjs_c,vxml_c")]
+        public string ExtFilter { get; set; }
 
-        [Option('f', "filter",
-            HelpText = "Dump filter - full or partial path, example: panorama\\")]
-        public string Filter { get; set; }
-
-        [Option('e', "filter_ext",
-            HelpText = "Dump filter - extension(s), example: vcss_c,vjs_c,vxml_c")]
-        public string FilterExt { get; set; }       
-
-        [Option('s', "silent",
-            HelpText = "Dump without printing file names")]
-        public bool Silent { get; set; }
+        [Option('f', "vpk_filepath",
+            HelpText = "File path filter, example: panorama\\")]
+        public string FileFilter { get; set; }
 
         [HelpOption]
         public string GetUsage()

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -42,7 +42,70 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
-        [Option('d', "vpk_decompile",
+        [Option('d', "vpk_decompile",﻿using System;
+using CommandLine;
+using CommandLine.Text;
+
+namespace Decompiler
+{
+    class Options
+    {
+        [Option('i', "input", Required = true,
+            HelpText = "Input file to be processed. With no additional arguments, a summary of the input(s) will be displayed.")]
+        public string InputFile { get; set; }
+
+        [Option("recursive", DefaultValue = false,
+            HelpText = "If specified and given input is a folder, all sub directories will be scanned too.")]
+        public bool RecursiveSearch { get; set; }
+
+        [Option('o', "output",
+            HelpText = "Writes DATA output to file.")]
+        public string OutputFile { get; set; }
+
+        [Option('a', "all",
+            HelpText = "Prints the content of each resource block in the file.")]
+        public bool PrintAllBlocks { get; set; }
+
+        [Option('b', "block",
+            HelpText = "Print the content of a specific block. Specify the block via its 4CC name - case matters! (eg. DATA, RERL, REDI, NTRO).")]
+        public string BlockToPrint { get; set; }
+
+        [Option("stats", DefaultValue = false,
+            HelpText = "Collect stats on all input files and then print them.")]
+        public bool CollectStats { get; set; }
+
+        [Option("threads", DefaultValue = 1,
+            HelpText = "If more than 1, files will be processed concurrently.")]
+        public int MaxParallelismThreads { get; set; }
+
+        [Option("vpk_dir", DefaultValue = false,
+            HelpText = "Write a file with files in given VPK and their CRC.")]
+        public bool OutputVPKDir { get; set; }
+
+        [Option("vpk_verify", DefaultValue = false,
+            HelpText = "Verify checksums and signatures.")]
+        public bool VerifyVPKChecksums { get; set; }
+
+        [Option('d', "vpk_decompile", DefaultValue = false,
+            HelpText = "Decompile supported files")]
+        public bool Decompile { get; set; }
+
+        [Option('e', "vpk_extensions",
+            HelpText = "File extension(s) filter, example: vcss_c,vjs_c,vxml_c")]
+        public string ExtFilter { get; set; }
+
+        [Option('f', "vpk_filepath",
+            HelpText = "File path filter, example: panorama\\")]
+        public string FileFilter { get; set; }
+
+        [HelpOption]
+        public string GetUsage()
+        {
+            return HelpText.AutoBuild(this, current => HelpText.DefaultParsingErrorsHandler(this, current));
+        }
+    }
+}
+
             HelpText = "Decompile supported files")]
         public bool Decompile { get; set; }
 

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -42,9 +42,9 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
-        [Option('d', "vpk_dump",
-            HelpText = "Dump only, do not decompile")]
-        public bool DumpOnly { get; set; }
+        [Option('d', "vpk_decompile",
+            HelpText = "Decompile supported files")]
+        public bool Decompile { get; set; }
 
         [Option('e', "vpk_extensions",
             HelpText = "File extension(s) filter, example: vcss_c,vjs_c,vxml_c")]

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -42,70 +42,7 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
-        [Option('d', "vpk_decompile",﻿using System;
-using CommandLine;
-using CommandLine.Text;
-
-namespace Decompiler
-{
-    class Options
-    {
-        [Option('i', "input", Required = true,
-            HelpText = "Input file to be processed. With no additional arguments, a summary of the input(s) will be displayed.")]
-        public string InputFile { get; set; }
-
-        [Option("recursive", DefaultValue = false,
-            HelpText = "If specified and given input is a folder, all sub directories will be scanned too.")]
-        public bool RecursiveSearch { get; set; }
-
-        [Option('o', "output",
-            HelpText = "Writes DATA output to file.")]
-        public string OutputFile { get; set; }
-
-        [Option('a', "all",
-            HelpText = "Prints the content of each resource block in the file.")]
-        public bool PrintAllBlocks { get; set; }
-
-        [Option('b', "block",
-            HelpText = "Print the content of a specific block. Specify the block via its 4CC name - case matters! (eg. DATA, RERL, REDI, NTRO).")]
-        public string BlockToPrint { get; set; }
-
-        [Option("stats", DefaultValue = false,
-            HelpText = "Collect stats on all input files and then print them.")]
-        public bool CollectStats { get; set; }
-
-        [Option("threads", DefaultValue = 1,
-            HelpText = "If more than 1, files will be processed concurrently.")]
-        public int MaxParallelismThreads { get; set; }
-
-        [Option("vpk_dir", DefaultValue = false,
-            HelpText = "Write a file with files in given VPK and their CRC.")]
-        public bool OutputVPKDir { get; set; }
-
-        [Option("vpk_verify", DefaultValue = false,
-            HelpText = "Verify checksums and signatures.")]
-        public bool VerifyVPKChecksums { get; set; }
-
         [Option('d', "vpk_decompile", DefaultValue = false,
-            HelpText = "Decompile supported files")]
-        public bool Decompile { get; set; }
-
-        [Option('e', "vpk_extensions",
-            HelpText = "File extension(s) filter, example: vcss_c,vjs_c,vxml_c")]
-        public string ExtFilter { get; set; }
-
-        [Option('f', "vpk_filepath",
-            HelpText = "File path filter, example: panorama\\")]
-        public string FileFilter { get; set; }
-
-        [HelpOption]
-        public string GetUsage()
-        {
-            return HelpText.AutoBuild(this, current => HelpText.DefaultParsingErrorsHandler(this, current));
-        }
-    }
-}
-
             HelpText = "Decompile supported files")]
         public bool Decompile { get; set; }
 

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -626,7 +626,8 @@ namespace Decompiler
 
                 if (Options.OutputFile != null)
                 {
-                    if (OldPakManifest.TryGetValue(filePath, out uint oldCrc32) && oldCrc32 == file.CRC32)
+                    uint oldCrc32;
+                    if (OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
                     {
                         continue;
                     }
@@ -639,7 +640,7 @@ namespace Decompiler
                 byte[] output;
                 package.ReadEntry(file, out output);
 
-                if (type.EndsWith("_c", StringComparison.Ordinal) && !Options.DumpOnly)
+                if (type.EndsWith("_c", StringComparison.Ordinal) && Options.Decompile)
                 {
                     using (var resource = new Resource())
                     {

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -685,10 +685,10 @@ namespace Decompiler
                                         lock (ConsoleWriterLock)
                                         {
                                             Console.ForegroundColor = ConsoleColor.DarkMagenta;
-                                            Console.WriteLine("--- Resource type " + type + " decompiler not implemented, extracting as-is" );
+                                            Console.WriteLine("\tDecompiler for resource type " + type + " not implemented, extracting as-is");
                                             Console.ResetColor();
                                         }
-                                        package.ReadEntry(file, out output);
+                                        output = memory.ToArray();
                                         newType = type;
                                     }
                                     break;

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -38,6 +38,11 @@ namespace Decompiler
                 Options.OutputFile = FixPathSlahes(Options.OutputFile);
             }
 
+            if (Options.FileFilter != null)
+            {
+                Options.FileFilter = FixPathSlahes(Options.FileFilter);
+            }
+
             var paths = new List<string>();
 
             if (Directory.Exists(Options.InputFile))
@@ -594,7 +599,7 @@ namespace Decompiler
 
         private static void DumpVPK(Package package, string type, string newType)
         {
-            if (!string.IsNullOrEmpty(Options.ExtFilter) && !Options.ExtFilter.Contains(type))
+            if (Options.ExtFilter.Any() && !Options.ExtFilter.Contains(type))
             {
                 return;
             }
@@ -619,7 +624,7 @@ namespace Decompiler
 
                 filePath = FixPathSlahes(filePath);
 
-                if (!string.IsNullOrEmpty(Options.FileFilter) && !filePath.StartsWith(Options.FileFilter, StringComparison.Ordinal))
+                if (Options.FileFilter != null && !filePath.StartsWith(Options.FileFilter, StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -449,9 +449,12 @@ namespace Decompiler
         {
             lock (ConsoleWriterLock)
             {
-                Console.ForegroundColor = ConsoleColor.Green;
-                Console.WriteLine("--- Listing files in package \"{0}\" ---", path);
-                Console.ResetColor();
+                if (!Options.Silent)
+                { 
+                		Console.ForegroundColor = ConsoleColor.Green;
+                		Console.WriteLine("--- Listing files in package \"{0}\" ---", path);
+                		Console.ResetColor();
+            		}
             }
 
             var sw = Stopwatch.StartNew();
@@ -535,7 +538,7 @@ namespace Decompiler
             }
             else
             {
-                Console.WriteLine("--- Dumping decompiled files...");
+                if (!Options.Silent) Console.WriteLine("--- Dumping decompiled files...");
 
                 var manifestPath = string.Concat(path, ".manifest.txt");
 
@@ -557,17 +560,28 @@ namespace Decompiler
                     file.Close();
                 }
 
-                DumpVPK(package, "vxml_c", "xml");
-                DumpVPK(package, "vjs_c", "js");
-                DumpVPK(package, "vcss_c", "css");
-                DumpVPK(package, "vsndevts_c", "vsndevts");
-                DumpVPK(package, "vpcf_c", "vpcf");
+                if (Options.VPKTool)
+                {
+                    if (!Options.Silent) Console.WriteLine("Generic VPK Decompiler tool");
+                    foreach (var type in package.Entries)
+                    {
+                        DumpVPK(package, type.Key, type.Key);
+                    }
+                }
+                else // default GameTracker
+                {
+                    DumpVPK(package, "vxml_c", "xml");
+                    DumpVPK(package, "vjs_c", "js");
+                    DumpVPK(package, "vcss_c", "css");
+                    DumpVPK(package, "vsndevts_c", "vsndevts");
+                    DumpVPK(package, "vpcf_c", "vpcf");
 
-                DumpVPK(package, "txt", "txt");
-                DumpVPK(package, "cfg", "cfg");
-                DumpVPK(package, "res", "res");
-                DumpVPK(package, "png", "png");
-                DumpVPK(package, "jpg", "jpg");
+                    DumpVPK(package, "txt", "txt");
+                    DumpVPK(package, "cfg", "cfg");
+                    DumpVPK(package, "res", "res");
+                    DumpVPK(package, "png", "png");
+                    DumpVPK(package, "jpg", "jpg");                 
+                }
 
                 using (var file = new StreamWriter(manifestPath))
                 {
@@ -596,19 +610,25 @@ namespace Decompiler
 
             sw.Stop();
 
-            Console.WriteLine("Processed in {0}ms", sw.ElapsedMilliseconds);
+            if (!Options.Silent) Console.WriteLine("Processed in {0}ms", sw.ElapsedMilliseconds);
         }
 
         private static void DumpVPK(Package package, string type, string newType)
         {
+            if (!string.IsNullOrEmpty(Options.FilterExt) && !Options.FilterExt.Contains(type))
+            {
+                return;
+            }
+
             if (!package.Entries.ContainsKey(type))
             {
-                Console.WriteLine("There are no files of type \"{0}\".", type);
+                if (!Options.Silent) Console.WriteLine("There are no files of type \"{0}\".", type);
 
                 return;
             }
 
             var entries = package.Entries[type];
+            uint oldCrc32;            
 
             foreach (var file in entries)
             {
@@ -621,9 +641,14 @@ namespace Decompiler
 
                 filePath = FixPathSlahes(filePath);
 
+                if (!string.IsNullOrEmpty(Options.Filter) && !filePath.StartsWith(Options.Filter, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                
                 if (Options.OutputFile != null)
                 {
-                    if (OldPakManifest.TryGetValue(filePath, out uint oldCrc32) && oldCrc32 == file.CRC32)
+                    if (OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
                     {
                         continue;
                     }
@@ -631,31 +656,70 @@ namespace Decompiler
                     OldPakManifest[filePath] = file.CRC32;
                 }
 
-                Console.WriteLine("\t[archive index: {0:D3}] {1}", file.ArchiveIndex, filePath);
+                if (!Options.Silent) Console.WriteLine("\t[archive index: {0:D3}] {1}", file.ArchiveIndex, filePath);
 
                 byte[] output;
                 package.ReadEntry(file, out output);
 
-                if (type.EndsWith("_c", StringComparison.Ordinal))
+                if (type.EndsWith("_c", StringComparison.Ordinal) && !Options.Extract)
                 {
                     using (var resource = new Resource())
                     {
                         using (var memory = new MemoryStream(output))
                         {
                             resource.Read(memory);
-                        }
-                        switch(type)
-                        {
-                            case "vxml_c":
-                            case "vcss_c":
-                            case "vjs_c":
-                                output = ((Panorama)resource.Blocks[BlockType.DATA]).Data;
-                                break;
-                            default:
-                                output = Encoding.UTF8.GetBytes(resource.Blocks[BlockType.DATA].ToString());
-                                break;
-                        }
-                        
+                            if (type == newType) newType = type.Substring(0, type.Length - 2); // VPKTool
+                            switch(type)
+                            {
+                                case "vxml_c":
+                                case "vcss_c":
+                                case "vjs_c":
+                                    output = ((Panorama)resource.Blocks[BlockType.DATA]).Data;
+                                    if (newType.StartsWith("v", StringComparison.Ordinal)) newType = newType.Substring(1); // VPKTool
+                                    break;
+                                case "vpcf_c":
+                                    //Wrap it around a KV3File object to get the header.
+                                    output = Encoding.UTF8.GetBytes(new ValveResourceFormat.KeyValues.KV3File(((BinaryKV3)resource.Blocks[BlockType.DATA]).Data).ToString());
+                                    break;
+                                case "vsnd_c":
+                                    // VPKTool
+                                    var sound = ((Sound)resource.Blocks[BlockType.DATA]);
+                                    if (sound.Type == Sound.AudioFileType.MP3) newType = "mp3";
+                                    else newType = "wav";
+                                    output = sound.GetSound();
+                                    break;
+                                case "vtex_c":
+                                    // VPKTool
+                                    newType = "png";
+                                    var bitmap = ((Texture)resource.Blocks[BlockType.DATA]).GenerateBitmap();
+                                    using (var ms = new MemoryStream())
+                                    {
+                                        bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
+                                        output = ms.ToArray();
+                                    }
+                                    break;
+                                default:
+                                    try
+                                    {
+                                        output = Encoding.UTF8.GetBytes(resource.Blocks[BlockType.DATA].ToString());
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        if (!Options.Silent)
+                                        {
+                                            lock (ConsoleWriterLock)
+                                            {
+                                                Console.ForegroundColor = ConsoleColor.DarkMagenta;
+                                                Console.WriteLine("--- Resource type " + type + " decompiler not implemented, extracting as-is..." );
+                                                Console.ResetColor();
+                                            }
+                                        }
+                                        package.ReadEntry(file, out output);
+                                        newType = type;
+                                    }
+                                    break;
+                            }
+                        }                       
                     }
                 }
 
@@ -679,7 +743,7 @@ namespace Decompiler
 
             File.WriteAllBytes(outputFile, data);
 
-            Console.WriteLine("--- Dump written to \"{0}\"", outputFile);
+            if (!Options.Silent) Console.WriteLine("--- Dump written to \"{0}\"", outputFile);
         }
 
         private static string FixPathSlahes(string path)


### PR DESCRIPTION
 Revised filter options:
-d , --vpk_decompile : Decompile supported files (bool)
-e , --vpk_extensions : File extension(s) filter, example: vxml_c,vjs_c or "vxml_c,vjs_c"
-f , --vpk_filepath : File path filter, example: panorama/ or panorama\ or "panorama\\\\"

Generic vpk decompiler will fallback to extract-only for non-implemented resource types
In my limited tests it works as intended and it is quite fast! Goodbye HLExtract and temporary files. 
Such a wonderful library and tool, thank you!

Usage:
`Decompiler -i "%source_vpk%" -o "decompile_extensions"` **-d -e** "vxml_c,vcss_c" 
`Decompiler -i "%source_vpk%" -o "decompile_filepath"` **-d -f** "soundstacks\\\\" 
`Decompiler -i "%source_vpk%" -o "decompile_ext_within_filepath"` **-d -e** vsndstck_c **-f** soundstacks\ 
`Decompiler -i "%source_vpk%" -o "extract_extensions"` **-e** vpcf_c,psf 
`Decompiler -i "%source_vpk%" -o "extract_one_file"` **-f** scripts/items/items_game.txt 
`Decompiler -i "%source_vpk%" -o "extract_all"`

GameTracker Usage:
`mono ../.support/SourceDecompiler/Decompiler.exe -i "$file" -o "$(echo "$file" | sed -e 's/\.vpk$/\//g')"` **-d -e** "vxml_c,vjs_c,vcss_c,vsndevts_c,vpcf_c,txt,cfg,res,png,jpg"

