### PR TITLE
Add option to refresh cached vpk manifest - v1

### DIFF
--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -55,6 +55,10 @@ namespace Decompiler
             HelpText = "File path filter, example: panorama\\ or \"panorama\\\\\"")]
         public string FileFilter { get; set; }
 
+        [Option('r', "vpk_refresh", DefaultValue = false,
+            HelpText = "Refresh vpk manifest")]
+        public bool Refresh { get; set; }
+
         [HelpOption]
         public string GetUsage()
         {

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -544,7 +544,7 @@ namespace Decompiler
 
                 var manifestPath = string.Concat(path, ".manifest.txt");
 
-                if (File.Exists(manifestPath))
+                if (!Options.Refresh && File.Exists(manifestPath))
                 {
                     var file = new StreamReader(manifestPath);
                     string line;
@@ -632,7 +632,7 @@ namespace Decompiler
                 if (Options.OutputFile != null)
                 {
                     uint oldCrc32;
-                    if (OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
+                    if (!Options.Refresh && OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
                     {
                         continue;
                     }


### PR DESCRIPTION
Filtering is fine, but incomplete, since the initial cached vpk manifest will block any different output from the same source.
Currently, one needs to delete the manifest file before calling Decompiler. 
A built-in option will complete Decompiler functionality as a generic vpk tool:
-r, --vpk_refresh : Refresh vpk manifest

This would not impact GameTracker usage