### PR TITLE
Add option to refresh cached vpk manifest - v2

### DIFF
--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -44,7 +44,7 @@ namespace Decompiler
         public bool VerifyVPKChecksums { get; set; }
 
         [Option('c', "vpk_cache", DefaultValue = false,
-            HelpText = "Use cached VPK manifest")]
+            HelpText = "Use cached VPK manifest.")]
         public bool CachedManifest { get; set; }
 
         [Option('d', "vpk_decompile", DefaultValue = false,

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -43,8 +43,8 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
-        [Option('c', "vpk_cache", DefaultValue = false,
-            HelpText = "Use cached VPK manifest.")]
+        [Option("vpk_cache", DefaultValue = false,
+            HelpText = "Use cached VPK manifest to keep track of updates. Only changed files will be written to disk.")]
         public bool CachedManifest { get; set; }
 
         [Option('d', "vpk_decompile", DefaultValue = false,

--- a/Decompiler/Options.cs
+++ b/Decompiler/Options.cs
@@ -43,6 +43,10 @@ namespace Decompiler
             HelpText = "Verify checksums and signatures.")]
         public bool VerifyVPKChecksums { get; set; }
 
+        [Option('c', "vpk_cache", DefaultValue = false,
+            HelpText = "Use cached VPK manifest")]
+        public bool CachedManifest { get; set; }
+
         [Option('d', "vpk_decompile", DefaultValue = false,
             HelpText = "Decompile supported files")]
         public bool Decompile { get; set; }

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -567,16 +567,19 @@ namespace Decompiler
                     DumpVPK(package, type.Key, type.Key);
                 }
 
-                using (var file = new StreamWriter(manifestPath))
+                if (Options.CachedManifest)
                 {
-                    foreach (var hash in OldPakManifest)
+                    using (var file = new StreamWriter(manifestPath))
                     {
-                        if (package.FindEntry(hash.Key) == null)
+                        foreach (var hash in OldPakManifest)
                         {
-                            Console.WriteLine("\t{0} no longer exists in VPK", hash.Key);
-                        }
+                            if (package.FindEntry(hash.Key) == null)
+                            {
+                                Console.WriteLine("\t{0} no longer exists in VPK", hash.Key);
+                            }
 
-                        file.WriteLine("{0} {1}", hash.Value, hash.Key);
+                            file.WriteLine("{0} {1}", hash.Value, hash.Key);
+                        }
                     }
                 }
             }

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -544,7 +544,7 @@ namespace Decompiler
 
                 var manifestPath = string.Concat(path, ".manifest.txt");
 
-                if (File.Exists(manifestPath))
+                if (Options.CachedManifest && File.Exists(manifestPath))
                 {
                     var file = new StreamReader(manifestPath);
                     string line;
@@ -632,7 +632,7 @@ namespace Decompiler
                 if (Options.OutputFile != null)
                 {
                     uint oldCrc32;
-                    if (OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
+                    if (Options.CachedManifest && OldPakManifest.TryGetValue(filePath, out oldCrc32) && oldCrc32 == file.CRC32)
                     {
                         continue;
                     }


### PR DESCRIPTION
Filtering is fine, but incomplete, since the initial cached vpk manifest will block any different output from the same source.
Currently, one needs to delete the manifest file before calling Decompiler. 
_I remember thinking about Decompiler a while ago: "such a good tool, too bad it isn't working for extracting from vpk" - and going back to HLExtract._

Decompiler would work as a generic vpk tool and skip creating the vpk manifest file - by default.

For GameTracker usage, an extra option would be added to create and reuse a cached vpk manifest file:
-c, --vpk_cache : Use cached VPK manifest