### PR TITLE
Prevent FC reading unknown resource types

### DIFF
--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -654,7 +654,21 @@ namespace Decompiler
                     {
                         using (var memory = new MemoryStream(output))
                         {
-                            resource.Read(memory);
+                            try
+                            {
+                                resource.Read(memory);
+                            }
+                            catch (Exception)
+                            {
+                                lock (ConsoleWriterLock)
+                                {
+                                    Console.ForegroundColor = ConsoleColor.DarkRed;
+                                    Console.WriteLine("\tDecompiler for resource type " + type + " not implemented, extracting as-is");
+                                    Console.ResetColor();
+                                }
+                                DumpFile(filePath, output);
+                                break;
+                            }
                             if (type == newType) newType = type.Substring(0, type.Length - 2);
                             switch(type)
                             {

--- a/Decompiler/Program.cs
+++ b/Decompiler/Program.cs
@@ -658,17 +658,18 @@ namespace Decompiler
                             {
                                 resource.Read(memory);
                             }
-                            catch (Exception)
+                            catch (Exception e)
                             {
                                 lock (ConsoleWriterLock)
                                 {
                                     Console.ForegroundColor = ConsoleColor.DarkRed;
-                                    Console.WriteLine("\tDecompiler for resource type " + type + " not implemented, extracting as-is");
+                                    Console.WriteLine("\t" + e.Message + " on resource type " + type + ", extracting as-is");
                                     Console.ResetColor();
                                 }
                                 DumpFile(filePath, output);
                                 break;
                             }
+
                             if (type == newType) newType = type.Substring(0, type.Length - 2);
                             switch(type)
                             {


### PR DESCRIPTION
For example, when `--vpk_decompile` a .vpk containing a game map, on non-standard .vvis_c resources 
(partially readable ones like .vrman_c are already handled)

_Unhandled Exception: System.ArgumentException: Unrecognized block type 'VXVS'
   at ValveResourceFormat.Resource.ConstructFromType(String input)
   at ValveResourceFormat.Resource.Read(Stream input)
   at Decompiler.Decompiler.DumpVPK(Package package, String type, String newType)_

Oversight on my part in the previous pull requests.
![decompiler fc](https://user-images.githubusercontent.com/12874843/30266243-68d31290-96e7-11e7-9b7c-6695dceb12c9.png)
![decompiler](https://user-images.githubusercontent.com/12874843/30267091-19500162-96ea-11e7-8a1e-d6ddb56d3a86.png)
