### PR TITLE
Perfect DXT5nm normalized normalmaps output

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -135,16 +135,20 @@ namespace ValveResourceFormat.ResourceTypes
 
                 case VTexFormat.DXT5:
                     var yCoCg = false;
+                    var normalize = false;
+                    var invert = false;
 
                     if (Resource.EditInfo.Structs.ContainsKey(ResourceEditInfo.REDIStruct.SpecialDependencies))
                     {
                         var specialDeps = (SpecialDependencies)Resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.SpecialDependencies];
 
                         yCoCg = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Image YCoCg Conversion");
+                        normalize = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Image NormalizeNormals");
+                        invert = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version LegacySource1InvertNormals");
                     }
 
                     SkipMipmaps(16);
-                    TextureDecompressors.UncompressDXT5(imageInfo, Reader, data, yCoCg, Width, Height);
+                    TextureDecompressors.UncompressDXT5(imageInfo, Reader, data, Width, Height, yCoCg, normalize, invert);
                     break;
 
                 case VTexFormat.I8:


### PR DESCRIPTION
Fix for #112  

_OP test source (using the cleaned up vtex_c in my zip)_  
![Imgur](https://i.imgur.com/YF2OPDp.png)  
_dota_addons/overthrow/materials/models/courier/lockjaw/lockjaw_normal_  
![Imgur](https://i.imgur.com/LGT4hSv.png)  
_dota_addons/overthrow/materials/models/props_structures/midas_throne/midas_kobold_props_normal
![Imgur](https://i.imgur.com/gzGiidt.png)_   
Last one is also `LegacySource1InvertNormals`  