### PR TITLE
Give stylecop teeth

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/EntityLump.cs
@@ -7,22 +7,22 @@ using ValveResourceFormat.Serialization;
 
 namespace ValveResourceFormat.ResourceTypes
 {
-    public class Entity
-    {
-        public IEnumerable<EntityEntityProperty> Properties { get; set; }
-    }
-
-    public class EntityEntityProperty
-    {
-        public uint Type { get; set; }
-
-        public uint MiscType { get; set; }
-
-        public object Data { get; set; }
-    }
-
     public class EntityLump
     {
+        public class Entity
+        {
+            public IEnumerable<EntityProperty> Properties { get; set; }
+        }
+
+        public class EntityProperty
+        {
+            public uint Type { get; set; }
+
+            public uint MiscType { get; set; }
+
+            public object Data { get; set; }
+        }
+
         private readonly Resource resource;
 
         public EntityLump(Resource resource)
@@ -64,7 +64,7 @@ namespace ValveResourceFormat.ResourceTypes
                 var valuesCount = dataReader.ReadUInt32();
                 var c = dataReader.ReadUInt32(); // always 0? (Its been seen to be 1, footer count?)
 
-                var properties = new List<EntityEntityProperty>();
+                var properties = new List<EntityProperty>();
                 while (dataStream.Position != dataStream.Length)
                 {
                     if (properties.Count == valuesCount)
@@ -79,7 +79,7 @@ namespace ValveResourceFormat.ResourceTypes
                     switch (type)
                     {
                         case 0x06:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -87,7 +87,7 @@ namespace ValveResourceFormat.ResourceTypes
                             }); //1
                             break;
                         case 0x01:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -97,7 +97,7 @@ namespace ValveResourceFormat.ResourceTypes
                         case 0x05:
                         case 0x09:
                         case 0x25: //TODO: figure out the difference
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -105,7 +105,7 @@ namespace ValveResourceFormat.ResourceTypes
                             }); //4
                             break;
                         case 0x1a:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -113,7 +113,7 @@ namespace ValveResourceFormat.ResourceTypes
                             }); //8
                             break;
                         case 0x03:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -121,7 +121,7 @@ namespace ValveResourceFormat.ResourceTypes
                             }); //12
                             break;
                         case 0x27:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,
@@ -129,7 +129,7 @@ namespace ValveResourceFormat.ResourceTypes
                             }); //12
                             break;
                         case 0x1e:
-                            properties.Add(new EntityEntityProperty
+                            properties.Add(new EntityProperty
                             {
                                 Type = type,
                                 MiscType = miscType,

--- a/ValveResourceFormat/ValveResourceFormat.csproj
+++ b/ValveResourceFormat/ValveResourceFormat.csproj
@@ -16,6 +16,10 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.Skia.Linux.Natives" Version="1.60.0.1" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.1.9" />

--- a/ValveResourceFormat/ValveResourceFormat.ruleset
+++ b/ValveResourceFormat/ValveResourceFormat.ruleset
@@ -1,5 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for ValveResourceFormat" Description="Code analysis rules for ValveResourceFormat.csproj." ToolsVersion="14.0">
+<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Rules for ValveResourceFormat" Description="Code analysis rules for ValveResourceFormat.csproj." ToolsVersion="16.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
     <Rule Id="CA1001" Action="Warning" />
     <Rule Id="CA1009" Action="Warning" />
@@ -65,6 +65,7 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1005" Action="None" />
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1200" Action="None" />


### PR DESCRIPTION
Also clean up the only remaining errors in EntityLump

Note, SA0001 is the warning that XML Documentation generation is turned off, but if we turn it on we get 500+ errors from multiple categories instead.