### PR TITLE
Implemented file export progress dialog (#111)

### DIFF
--- a/GUI/Forms/ExtractProgressForm.Designer.cs
+++ b/GUI/Forms/ExtractProgressForm.Designer.cs
@@ -1,0 +1,109 @@
+namespace GUI.Forms
+{
+    partial class ExtractProgressForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.extractProgressBar = new System.Windows.Forms.ProgressBar();
+            this.extractStatusLabel = new System.Windows.Forms.Label();
+            this.cancelButton = new System.Windows.Forms.Button();
+            this.tableLayoutPanel1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.ColumnCount = 1;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Controls.Add(this.extractProgressBar, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.extractStatusLabel, 0, 1);
+            this.tableLayoutPanel1.Controls.Add(this.cancelButton, 0, 2);
+            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(0, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 3;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 40F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 30F));
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 30F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(603, 140);
+            this.tableLayoutPanel1.TabIndex = 0;
+            // 
+            // extractProgressBar
+            // 
+            this.extractProgressBar.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.extractProgressBar.Location = new System.Drawing.Point(20, 15);
+            this.extractProgressBar.Margin = new System.Windows.Forms.Padding(20, 15, 20, 15);
+            this.extractProgressBar.Name = "extractProgressBar";
+            this.extractProgressBar.Size = new System.Drawing.Size(563, 26);
+            this.extractProgressBar.TabIndex = 0;
+            // 
+            // extractStatusLabel
+            // 
+            this.extractStatusLabel.AutoSize = true;
+            this.extractStatusLabel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.extractStatusLabel.Location = new System.Drawing.Point(20, 66);
+            this.extractStatusLabel.Margin = new System.Windows.Forms.Padding(20, 10, 20, 10);
+            this.extractStatusLabel.Name = "extractStatusLabel";
+            this.extractStatusLabel.Size = new System.Drawing.Size(563, 22);
+            this.extractStatusLabel.TabIndex = 1;
+            // 
+            // cancelButton
+            // 
+            this.cancelButton.Dock = System.Windows.Forms.DockStyle.Right;
+            this.cancelButton.Location = new System.Drawing.Point(508, 108);
+            this.cancelButton.Margin = new System.Windows.Forms.Padding(0, 10, 20, 10);
+            this.cancelButton.Name = "cancelButton";
+            this.cancelButton.Size = new System.Drawing.Size(75, 22);
+            this.cancelButton.TabIndex = 2;
+            this.cancelButton.Text = "Cancel";
+            this.cancelButton.UseVisualStyleBackColor = true;
+            this.cancelButton.Click += new System.EventHandler(this.CancelButton_Click);
+            // 
+            // ExtractProgressForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(603, 140);
+            this.Controls.Add(this.tableLayoutPanel1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.Name = "ExtractProgressForm";
+            this.Text = "Extracting files...";
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
+        private System.Windows.Forms.ProgressBar extractProgressBar;
+        private System.Windows.Forms.Label extractStatusLabel;
+        private System.Windows.Forms.Button cancelButton;
+    }
+}

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using SteamDatabase.ValvePak;
+
+namespace GUI.Forms
+{
+    public partial class ExtractProgressForm : Form
+    {
+        private CancellationTokenSource cancellationTokenSource;
+        private Package package;
+        private TreeNode root;
+        private string path;
+        private Queue<PackageEntry> filesToExtract;
+        private int initialFileCount;
+
+        public ExtractProgressForm(Package package, TreeNode root, string path)
+        {
+            InitializeComponent();
+
+            cancellationTokenSource = new CancellationTokenSource();
+            filesToExtract = new Queue<PackageEntry>();
+            initialFileCount = 0;
+
+            this.package = package;
+            this.root = root;
+            this.path = path;
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            Task
+                .Run(async () =>
+                {
+                    Invoke((Action)(() =>
+                    {
+                        extractStatusLabel.Text = "Calculating...";
+                        extractProgressBar.Style = ProgressBarStyle.Marquee;
+                    }));
+
+                    await CalculateFilesToExtractAsync(root);
+                    initialFileCount = filesToExtract.Count;
+
+                    Invoke((Action)(() =>
+                    {
+                        extractProgressBar.Style = ProgressBarStyle.Continuous;
+                    }));
+
+                    await ExtractFilesAsync();
+                });
+        }
+
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            cancellationTokenSource.Cancel();
+        }
+
+        private async Task CalculateFilesToExtractAsync(TreeNode root)
+        {
+            if (cancellationTokenSource.IsCancellationRequested)
+            {
+                return;
+            }
+
+            foreach (TreeNode node in root.Nodes)
+            {
+                if (node.Tag.GetType() == typeof(PackageEntry))
+                {
+                    var file = node.Tag as PackageEntry;
+                    filesToExtract.Enqueue(file);
+                }
+                else
+                {
+                    await CalculateFilesToExtractAsync(node);
+                }
+            }
+        }
+
+        private async Task ExtractFilesAsync()
+        {
+            while (filesToExtract.Count > 0)
+            {
+                if (cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                var packageFile = filesToExtract.Dequeue();
+
+                Invoke((Action)(() =>
+                {
+                    extractProgressBar.Value = 100 - (int)(((float)filesToExtract.Count / (float)initialFileCount) * 100.0f);
+                    extractStatusLabel.Text = $"Extracting {packageFile.GetFullPath()}";
+                }));
+
+                var filePath = Path.Combine(path, packageFile.GetFullPath());
+
+                Directory.CreateDirectory(Path.GetDirectoryName(filePath));
+
+                using (var stream = new FileStream(filePath, FileMode.Create))
+                {
+                    package.ReadEntry(packageFile, out var output);
+                    await stream.WriteAsync(output, 0, output.Length, cancellationTokenSource.Token);
+                }
+            }
+        }
+
+        private void CancelButton_Click(object sender, EventArgs e)
+        {
+            Close();
+        }
+    }
+}

--- a/GUI/Forms/ExtractProgressForm.resx
+++ b/GUI/Forms/ExtractProgressForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -38,9 +38,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
     <Reference Include="System.Design" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NAudio" Version="1.9.0" />
@@ -77,6 +79,12 @@
     </Compile>
     <Compile Include="Forms\AboutForm.Designer.cs">
       <DependentUpon>AboutForm.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Forms\ExtractProgressForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\ExtractProgressForm.Designer.cs">
+      <DependentUpon>ExtractProgressForm.cs</DependentUpon>
     </Compile>
     <Compile Include="Forms\LoadingFile.cs">
       <SubType>UserControl</SubType>
@@ -161,6 +169,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\AboutForm.resx">
       <DependentUpon>AboutForm.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Forms\ExtractProgressForm.resx">
+      <DependentUpon>ExtractProgressForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\LoadingFile.resx">
       <DependentUpon>LoadingFile.cs</DependentUpon>

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -973,31 +973,8 @@ namespace GUI
                 var dialog = new FolderBrowserDialog();
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
-                    ExtractFolderFromTree(package, selectedNode, dialog.SelectedPath);
-                }
-            }
-        }
-
-        private void ExtractFolderFromTree(Package package, TreeNode root, string path)
-        {
-            foreach (TreeNode node in root.Nodes)
-            {
-                if (node.Tag.GetType() == typeof(PackageEntry))
-                {
-                    var file = node.Tag as PackageEntry;
-                    var filePath = Path.Combine(path, file.GetFullPath());
-
-                    Directory.CreateDirectory(Path.GetDirectoryName(filePath));
-
-                    using (var stream = new FileStream(filePath, FileMode.Create))
-                    {
-                        package.ReadEntry(file, out var output);
-                        stream.Write(output, 0, output.Length);
-                    }
-                }
-                else
-                {
-                    ExtractFolderFromTree(package, node, path);
+                    var extractDialog = new ExtractProgressForm(package, selectedNode, dialog.SelectedPath);
+                    extractDialog.ShowDialog();
                 }
             }
         }


### PR DESCRIPTION
Added feature for issue #111 - a progress dialog that displays and refreshes while extracting data from the package. It is also cancelable in case the user doesn't want to wait for it to finish.