### PR TITLE
Fix (loose) panorama files not being decompiled properly

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -327,6 +327,14 @@ namespace Decompiler
                             data = ((Panorama)resource.Blocks[BlockType.DATA]).Data;
                             break;
 
+                        case ResourceType.PanoramaLayout:
+                        case ResourceType.PanoramaScript:
+                        case ResourceType.PanoramaStyle:
+                            // .vcss -> .css, .vjs -> .js, .vxml -> .xml
+                            extension = "." + extension.Substring(2, extension.Length - 2);
+                            data = ((Panorama)resource.Blocks[BlockType.DATA]).Data;
+                            break;
+
                         case ResourceType.Sound:
                             var sound = (Sound)resource.Blocks[BlockType.DATA];
 


### PR DESCRIPTION
When decompiling loose Panorama files (not in a VPK), the appropriate `ResourceType`s weren't matched accordingly.

It also handles the file extension special case for layout, script and style. Not sure if it's even valid to do that for `ResourceType.Panorama`, since it seems to mean "unknown Panorama resource type". Resources with this type do even pass the [extension check](https://github.com/SteamDatabase/ValveResourceFormat/blob/d2a3d69323f8049e150d0f05132757a1c7c9a535/Decompiler/Decompiler.cs#L237-L246)?