### PR TITLE
Texture fixes

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -449,7 +449,7 @@ namespace ValveResourceFormat.ResourceTypes
                 }
                 else
                 {
-                    offset = CalculateBufferSizeForMipLevel(j);
+                    offset = CalculateBufferSizeForMipLevel(j) * (Flags.HasFlag(VTexFlags.CUBE_TEXTURE) ? 6 : 1);
                 }
 
                 Reader.BaseStream.Position += offset;

--- a/ValveResourceFormat/ThirdParty/BPTCDecoders.cs
+++ b/ValveResourceFormat/ThirdParty/BPTCDecoders.cs
@@ -693,34 +693,42 @@ namespace BPTC
 
                             ib >>= BC7IndLength[m] - isAnchor;
 
-                            if (m == 4)
-                            {
-                                aweight = BPTCWeights3[ib2 & (0x7u >> isAnchor)];
-                                ib2 >>= ib2l - isAnchor;
-
-                                if (isb == 1)
-                                {
-                                    byte t = cweight;
-                                    cweight = aweight;
-                                    aweight = t;
-                                }
-                            }
-                            else if (m == 5)
-                            {
-                                aweight = BPTCWeights2[ib2 & (0x3u >> isAnchor)];
-                                ib2 >>= ib2l - isAnchor;
-                            }
-
                             data[pixelIndex] = (byte)BPTCInterpolateFactor(cweight, endpoints[subset, 2], endpoints[subset + 1, 2]);
                             data[pixelIndex + 1] = (byte)BPTCInterpolateFactor(cweight, endpoints[subset, 1], endpoints[subset + 1, 1]);
                             data[pixelIndex + 2] = (byte)BPTCInterpolateFactor(cweight, endpoints[subset, 0], endpoints[subset + 1, 0]);
-                            data[pixelIndex + 3] = (byte)BPTCInterpolateFactor(aweight, endpoints[subset, 3], endpoints[subset + 1, 3]);
 
-                            if ((m == 4 || m == 5) && rb != 0)
+                            if (m < 4)
                             {
-                                byte t = data[pixelIndex + 3];
-                                data[pixelIndex + 3] = data[pixelIndex + 3 - rb];
-                                data[pixelIndex + 3 - rb] = t;
+                                data[pixelIndex + 3] = byte.MaxValue;
+                            }
+                            else
+                            {
+                                if (m == 4)
+                                {
+                                    aweight = BPTCWeights3[ib2 & (0x7u >> isAnchor)];
+                                    ib2 >>= ib2l - isAnchor;
+
+                                    if (isb == 1)
+                                    {
+                                        byte t = cweight;
+                                        cweight = aweight;
+                                        aweight = t;
+                                    }
+                                }
+                                else if (m == 5)
+                                {
+                                    aweight = BPTCWeights2[ib2 & (0x3u >> isAnchor)];
+                                    ib2 >>= ib2l - isAnchor;
+                                }
+
+                                data[pixelIndex + 3] = (byte)BPTCInterpolateFactor(aweight, endpoints[subset, 3], endpoints[subset + 1, 3]);
+
+                                if ((m == 4 || m == 5) && rb != 0)
+                                {
+                                    byte t = data[pixelIndex + 3];
+                                    data[pixelIndex + 3] = data[pixelIndex + 3 - rb];
+                                    data[pixelIndex + 3 - rb] = t;
+                                }
                             }
                         }
                     }

--- a/ValveResourceFormat/ThirdParty/BPTCDecoders.cs
+++ b/ValveResourceFormat/ThirdParty/BPTCDecoders.cs
@@ -411,7 +411,7 @@ namespace BPTC
                             {
                                 ushort factor = BPTCInterpolateFactor(cweight, endpoints[subset, e], endpoints[subset + 1, e]);
                                 //gamma correction and mul 4
-                                factor = (ushort)(Math.Pow(factor / (float)((1U << 16) - 1), 2.2f) * ((1U << 16) - 1) * 4);
+                                factor = (ushort)Math.Min(0xFFFF, Math.Pow(factor / (float)((1U << 16) - 1), 2.2f) * ((1U << 16) - 1) * 4);
                                 data[pixelIndex + 2 - e] = (byte)(factor >> 8);
                             }
 


### PR DESCRIPTION
The BC7 had issues with alpha.
Before:
![img](https://user-images.githubusercontent.com/5416122/77433424-6a3a3680-6df0-11ea-90ec-8102953f2efb.png)
After:
![img](https://user-images.githubusercontent.com/5416122/77433490-7e7e3380-6df0-11ea-84d4-5d080e57cfdd.png)
The BC6H looked wrong on especially bright spots, such as the sun.
Also cubemap textures (skybox and envmaps) had incorrect offset for mips.
Before:
![img](https://user-images.githubusercontent.com/5416122/77432693-796cb480-6def-11ea-9535-5c8bcdaf7bcb.png) 
![img](https://user-images.githubusercontent.com/5416122/77432727-84bfe000-6def-11ea-827f-bb83564f7ec2.png)
After:
![img](https://user-images.githubusercontent.com/5416122/77432758-8be6ee00-6def-11ea-911d-9de9b47709c7.png)
![img](https://user-images.githubusercontent.com/5416122/77432783-92756580-6def-11ea-8d52-9509105051ca.png)
