### PR TITLE
Replace uses of FolderBrowserDialog with Ookii.Dialogs' VistaFolderBrowserDialog

### DIFF
--- a/GUI/Forms/SettingsForm.cs
+++ b/GUI/Forms/SettingsForm.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using GUI.Utils;
+using Ookii.Dialogs.WinForms;
 
 namespace GUI.Forms
 {
@@ -69,7 +70,7 @@ namespace GUI.Forms
 
         private void GamePathAddFolder(object sender, EventArgs e)
         {
-            using (var dlg = new FolderBrowserDialog
+            using (var dlg = new VistaFolderBrowserDialog
             {
                 SelectedPath = Settings.Config.OpenDirectory,
             })

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -46,6 +46,9 @@
     <PackageReference Include="NAudio" Version="1.10.0" />
     <PackageReference Include="NLayer" Version="1.13.0" />
     <PackageReference Include="NLayer.NAudioSupport" Version="1.1.0" />
+    <PackageReference Include="Ookii.Dialogs.WinForms">
+      <Version>1.1.0</Version>
+    </PackageReference>
     <PackageReference Include="OpenTK" Version="3.1.0" />
     <PackageReference Include="OpenTK.GLControl" Version="3.1.0" />
     <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="1.68.1.1" />

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -16,6 +16,7 @@ using GUI.Types.Audio;
 using GUI.Types.ParticleRenderer;
 using GUI.Types.Renderer;
 using GUI.Utils;
+using Ookii.Dialogs.WinForms;
 using SkiaSharp;
 using SkiaSharp.Views.Desktop;
 using SteamDatabase.ValvePak;
@@ -1112,7 +1113,7 @@ namespace GUI
             else
             {
                 //We are a folder
-                var dialog = new FolderBrowserDialog();
+                var dialog = new VistaFolderBrowserDialog();
                 if (dialog.ShowDialog() == DialogResult.OK)
                 {
                     var extractDialog = new ExtractProgressForm(package.Package, selectedNode, dialog.SelectedPath, decompile);


### PR DESCRIPTION
The "VistaFolderBrowserDialog" provided by the Ookii.Dialogs library is a lot nicer and easier to use than the default FolderBrowserDialog. It looks a lot more like the file browser dialog and doesn't require the user to manually navigate through the directory tree in such a tedious way.