### PR TITLE
HemiOct impovements

### DIFF
--- a/GUI/Types/Renderer/Shaders/vr_standard.frag
+++ b/GUI/Types/Renderer/Shaders/vr_standard.frag
@@ -45,7 +45,7 @@ vec3 calculateWorldNormal()
 
     //Reconstruct the tangent vector from the map
 #if param_HemiOctIsoRoughness_RG_B == 1
-	vec2 temp = vec2(bumpNormal.x + bumpNormal.y -1.003922, bumpNormal.x - bumpNormal.y);
+    vec2 temp = vec2(bumpNormal.x + bumpNormal.y -1.003922, bumpNormal.x - bumpNormal.y);
     vec3 tangentNormal = oct_to_float32x3(temp);
 #else
     //vec2 temp = vec2(bumpNormal.w, bumpNormal.y) * 2 - 1;

--- a/GUI/Types/Renderer/Shaders/vr_standard.frag
+++ b/GUI/Types/Renderer/Shaders/vr_standard.frag
@@ -3,6 +3,7 @@
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define param_F_ALPHA_TEST 0
 #define param_HemiOctIsoRoughness_RG_B 0
+#define param_LegacySource1InvertNormals 0
 //End of parameter defines
 
 // Render modes -- Switched on/off by code
@@ -30,17 +31,9 @@ uniform sampler2D g_tNormal;
 
 uniform vec3 vLightPosition;
 
-//Returns ±1
-vec2 signNotZero(vec2 v)
-{
-    return vec2((v.x >= 0.0) ? +1.0 : -1.0, (v.y >= 0.0) ? +1.0 : -1.0);
-}
-
 vec3 oct_to_float32x3(vec2 e)
 {
     vec3 v = vec3(e.xy, 1.0 - abs(e.x) - abs(e.y));
-    if (v.z < 0)
-    v.xy = (1.0 - abs(v.yx))*signNotZero(v.xy);
     return normalize(v);
 }
 
@@ -52,11 +45,16 @@ vec3 calculateWorldNormal()
 
     //Reconstruct the tangent vector from the map
 #if param_HemiOctIsoRoughness_RG_B == 1
-    vec3 tangentNormal = oct_to_float32x3(bumpNormal.xy * 2 - 1);
+	vec2 temp = vec2(bumpNormal.x + bumpNormal.y -1.003922, bumpNormal.x - bumpNormal.y);
+    vec3 tangentNormal = oct_to_float32x3(temp);
 #else
     //vec2 temp = vec2(bumpNormal.w, bumpNormal.y) * 2 - 1;
     //vec3 tangentNormal = vec3(temp, sqrt(1 - temp.x * temp.x - temp.y * temp.y));
-    vec3 tangentNormal = oct_to_float32x3(bumpNormal.wy * 2 - 1);
+    vec2 temp = vec2(bumpNormal.w + bumpNormal.y -1.003922, bumpNormal.w - bumpNormal.y);
+    vec3 tangentNormal = oct_to_float32x3(temp);
+#endif
+#if param_LegacySource1InvertNormals == 1
+	tangentNormal.y *= -1.0;
 #endif
 
     vec3 normal = vNormalOut;

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -98,9 +98,15 @@ namespace ValveResourceFormat.ResourceTypes
 
             var specialDeps = (SpecialDependencies)Resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.SpecialDependencies];
             bool hemiOctIsoRoughness_RG_B = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Mip HemiOctIsoRoughness_RG_B");
+            bool invert = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version LegacySource1InvertNormals");
             if (hemiOctIsoRoughness_RG_B)
             {
                 arguments.Add("HemiOctIsoRoughness_RG_B", true);
+            }
+
+            if (invert)
+            {
+                arguments.Add("LegacySource1InvertNormals", true);
             }
 
             return arguments;

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -328,13 +328,15 @@ namespace ValveResourceFormat.ResourceTypes
 
                 case VTexFormat.BC7:
                     bool hemiOctRB = false;
+                    invert = false;
                     if (Resource.EditInfo.Structs.ContainsKey(ResourceEditInfo.REDIStruct.SpecialDependencies))
                     {
                         var specialDeps = (SpecialDependencies)Resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.SpecialDependencies];
                         hemiOctRB = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Mip HemiOctIsoRoughness_RG_B");
+                        invert = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version LegacySource1InvertNormals");
                     }
 
-                    BPTC.BPTCDecoders.UncompressBC7(imageInfo, GetDecompressedBuffer(), data, Width, Height, hemiOctRB);
+                    BPTC.BPTCDecoders.UncompressBC7(imageInfo, GetDecompressedBuffer(), data, Width, Height, hemiOctRB, invert);
                     break;
 
                 case VTexFormat.ATI2N:

--- a/ValveResourceFormat/Resource/ResourceTypes/TextureDecompressors.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/TextureDecompressors.cs
@@ -505,20 +505,9 @@ namespace ValveResourceFormat.ResourceTypes
                             {
                                 if (hemiOct)
                                 {
-                                    float SignNotZero(float v)
-                                    {
-                                        return (v >= 0.0f) ? +1.0f : -1.0f;
-                                    }
-
-                                    float nx = ((data[dataIndex + 3] / 255.0f) * 2) - 1;
-                                    float ny = ((data[dataIndex + 1] / 255.0f) * 2) - 1;
+                                    float nx = ((data[dataIndex + 3] + data[dataIndex + 1]) / 255.0f) - 1.003922f;
+                                    float ny = (data[dataIndex + 3] - data[dataIndex + 1]) / 255.0f;
                                     float nz = 1 - Math.Abs(nx) - Math.Abs(ny);
-                                    if (nz < 0)
-                                    {
-                                        float t = (1 - Math.Abs(ny)) * SignNotZero(nx);
-                                        ny = (1 - Math.Abs(nx)) * SignNotZero(ny);
-                                        nx = t;
-                                    }
 
                                     float l = (float)Math.Sqrt((nx * nx) + (ny * ny) + (nz * nz));
                                     data[dataIndex + 3] = data[dataIndex + 2]; //r to alpha


### PR DESCRIPTION
After examining disassembly of HLA shaders using RenderDoc, i found out that valve used a simplified formula, and not the one that was in the [article](http://jcgt.org/published/0003/02/01/).

Additionally, found a BC7 normal map with an inverted Y component. (materials/models/props_lab/server_09_normal_tga_3881d0a5.vtex_c) Handled that too

BTW RenderDoc is incredible
![hlvrcapture](https://user-images.githubusercontent.com/5416122/77970432-dd621200-72f4-11ea-8fbe-17bb7ebc6e11.png)