### PR TITLE
Mention that Dota Patch Notes are not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ vcs      | Compiled Shader         | ❓ Started work in `CompiledShader`, see #
 vfont    | Bitmap Font             | 👍 Decrypts `VFONT1`, supported in Source 1 (CS:GO) and Source 2 (Dota 2).
 dat      | Closed Captions         | 👍 Handled by `ClosedCaptions`
 bin      | Tools Asset Info        | 👍 Partially handled by `ToolsAssetInfo`, see #226
+vdpn     | Dota Patch Notes        | No
 
 Not all formats are 100% supported, some parameters are still unknown and not fully understood.
 


### PR DESCRIPTION
An example of a Dota patch notes file is available in Dota 2's VPKs, at "patchnotes\patchnotes.vdpn_c"