### PR TITLE
Fix ReadIndices() to use byte offset instead of element index

### DIFF
--- a/GUI/Types/Exporter/GltfModelExporter.cs
+++ b/GUI/Types/Exporter/GltfModelExporter.cs
@@ -459,15 +459,16 @@ namespace GUI.Types.Exporter
             var indices = new int[count];
 
             var byteCount = count * (int)indexBuffer.Size;
+            var byteStart = start * (int)indexBuffer.Size;
 
             if (indexBuffer.Size == 4)
             {
-                System.Buffer.BlockCopy(indexBuffer.Buffer, start, indices, 0, byteCount);
+                System.Buffer.BlockCopy(indexBuffer.Buffer, byteStart, indices, 0, byteCount);
             }
             else if (indexBuffer.Size == 2)
             {
                 var shortIndices = new short[count];
-                System.Buffer.BlockCopy(indexBuffer.Buffer, start, shortIndices, 0, byteCount);
+                System.Buffer.BlockCopy(indexBuffer.Buffer, byteStart, shortIndices, 0, byteCount);
                 indices = Array.ConvertAll(shortIndices, i => (int)i);
             }
 


### PR DESCRIPTION
It turns out that in `GltfModelExporter.ReadIndices(...)` when calling `System.Buffer.BlockCopy(...);` to copy the indexes out of the buffer, BlockCopy is being passed the start index of the section of the array, rather than the byte offset that BlockCopy() requires.

Changing the two calls in ReadIndices() resolved my issue ([same error as this other user](https://github.com/SteamDatabase/ValveResourceFormat/issues/248)) and fixed the out-of-range indexes that were being copied over. 

(My apologies if there's a better way to do this, I don't use the GitHub web UI very often)