### PR TITLE
Export vmat as kv1 text

### DIFF
--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -40,7 +40,6 @@
     </PackageReference>
     <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0016" />
     <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="1.68.2.1" />
-    <PackageReference Include="ValveKeyValue" Version="0.3.0.144" />
     <PackageReference Include="ValvePak" Version="1.0.2.29" />
   </ItemGroup>
   <ItemGroup>

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -53,6 +53,10 @@ namespace ValveResourceFormat.IO
                     data = Encoding.UTF8.GetBytes(((BinaryKV3)resource.DataBlock).GetKV3File().ToString());
                     break;
 
+                case ResourceType.Material:
+                    data = ((Material)resource.DataBlock).ToValveMaterial();
+                    break;
+
                 // These all just use ToString() and WriteText() to do the job
                 case ResourceType.SoundEventScript:
                 case ResourceType.SoundStackScript:

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text;
+using ValveKeyValue;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.Blocks.ResourceEditInfoStructs;
 using ValveResourceFormat.Serialization;
@@ -110,6 +112,62 @@ namespace ValveResourceFormat.ResourceTypes
             }
 
             return arguments;
+        }
+
+        public byte[] ToValveMaterial()
+        {
+            var root = new KVObject("Layer0", new List<KVObject>());
+            
+            root.Add(new KVObject("shader", ShaderName));
+
+            foreach (var (key, value) in IntParams)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in FloatParams)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in VectorParams)
+            {
+                root.Add(new KVObject(key, $"[{value.X} {value.Y} {value.Z} {value.W}]"));
+            }
+
+            foreach (var (key, value) in TextureParams)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in IntAttributes)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in FloatAttributes)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in FloatAttributes)
+            {
+                root.Add(new KVObject(key, value));
+            }
+
+            foreach (var (key, value) in VectorAttributes)
+            {
+                root.Add(new KVObject(key, $"[{value.X} {value.Y} {value.Z} {value.W}]"));
+            }
+
+            foreach (var (key, value) in StringAttributes)
+            {
+                root.Add(new KVObject(key, value ?? string.Empty));
+            }
+
+            using var ms = new MemoryStream();
+            KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Serialize(ms, root);
+            return ms.ToArray();
         }
     }
 }

--- a/ValveResourceFormat/ValveResourceFormat.csproj
+++ b/ValveResourceFormat/ValveResourceFormat.csproj
@@ -25,6 +25,7 @@
     </PackageReference>
     <PackageReference Include="SkiaSharp" Version="1.68.2.1" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="1.68.2.1" />
+    <PackageReference Include="ValveKeyValue" Version="0.3.1.152" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Icons\Programs\1455069708_api-code-window.png">


### PR DESCRIPTION
Closes #239.

The only problem is that texture paths are to compiled ones, not original sources which may be a problem when opening in material editor.