### PR TITLE
Cap GLViewerControl FPS to 500

### DIFF
--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -237,6 +237,12 @@ namespace GUI.Controls
             if (GLControl.Visible)
             {
                 var frameTime = stopwatch.ElapsedMilliseconds / 1000f;
+
+                if (!float.IsFinite(frameTime) || frameTime < 0.002)
+                {
+                    frameTime = 0.002f;
+                }
+
                 stopwatch.Restart();
 
                 Camera.Tick(frameTime);


### PR DESCRIPTION
In some cases, `stopwatch.ElapsedMilliseconds` could be 0 when a frame is rendered in less than a milisecond. This caused issues with advancing to the next frame and stuttering.