### PR TITLE
Model Animation Updates

### DIFF
--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -158,11 +158,15 @@ namespace GUI.Controls
             return selectionControl.CheckedListBox;
         }
 
-        public TrackBar AddTrackBar(string name, Action<int> changeCallback)
+        public GLViewerTrackBarControl AddTrackBar(string name, Action<int> changeCallback)
         {
             var trackBar = new GLViewerTrackBarControl(name);
             trackBar.TrackBar.ValueChanged += (_, __) =>
             {
+                if (trackBar.IgnoreValueChanged)
+                {
+                    return;
+                }
                 changeCallback(trackBar.TrackBar.Value);
 
                 GLControl.Focus();
@@ -173,7 +177,7 @@ namespace GUI.Controls
 
             RecalculatePositions();
 
-            return trackBar.TrackBar;
+            return trackBar;
         }
 
         public void RecalculatePositions()

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -158,6 +158,24 @@ namespace GUI.Controls
             return selectionControl.CheckedListBox;
         }
 
+        public TrackBar AddTrackBar(string name, Action<int> changeCallback)
+        {
+            var trackBar = new GLViewerTrackBarControl(name);
+            trackBar.TrackBar.ValueChanged += (_, __) =>
+            {
+                changeCallback(trackBar.TrackBar.Value);
+
+                GLControl.Focus();
+            };
+
+            controlsPanel.Controls.Add(trackBar);
+            otherControls.Add(trackBar);
+
+            RecalculatePositions();
+
+            return trackBar.TrackBar;
+        }
+
         public void RecalculatePositions()
         {
             var y = 25;

--- a/GUI/Controls/GLViewerTrackBarControl.Designer.cs
+++ b/GUI/Controls/GLViewerTrackBarControl.Designer.cs
@@ -1,0 +1,76 @@
+namespace GUI.Controls
+{
+    partial class GLViewerTrackBarControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.trackBarLabel = new System.Windows.Forms.Label();
+            this.trackBar = new System.Windows.Forms.TrackBar();
+            this.SuspendLayout();
+            // 
+            // selectionNameLabel
+            // 
+            this.trackBarLabel.AutoSize = true;
+            this.trackBarLabel.Location = new System.Drawing.Point(0, 2);
+            this.trackBarLabel.Name = "trackBarLabel";
+            this.trackBarLabel.Size = new System.Drawing.Size(40, 13);
+            this.trackBarLabel.TabIndex = 0;
+            this.trackBarLabel.Text = "Select:";
+            // 
+            // trackBar
+            // 
+            this.trackBar.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.trackBar.Location = new System.Drawing.Point(4, 4);
+            this.trackBar.Name = "trackBar";
+            this.trackBar.Size = new System.Drawing.Size(172, 21);
+            this.trackBar.MaximumSize = new System.Drawing.Size(172, 21);
+            this.trackBar.TabIndex = 0;
+            this.trackBar.Minimum = 0;
+            this.trackBar.Maximum = 1;
+            // 
+            // GLViewerCheckboxControl
+            // 
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            this.Controls.Add(this.trackBar);
+            this.Controls.Add(this.trackBarLabel);
+            this.Margin = new System.Windows.Forms.Padding(0);
+            this.MinimumSize = new System.Drawing.Size(0, 41);
+            this.Name = "GLViewerTrackBarControl";
+            this.Size = new System.Drawing.Size(180, 41);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label trackBarLabel;
+        private System.Windows.Forms.TrackBar trackBar;
+    }
+}

--- a/GUI/Controls/GLViewerTrackBarControl.Designer.cs
+++ b/GUI/Controls/GLViewerTrackBarControl.Designer.cs
@@ -53,6 +53,7 @@ namespace GUI.Controls
             this.trackBar.TabIndex = 0;
             this.trackBar.Minimum = 0;
             this.trackBar.Maximum = 1;
+            this.trackBar.MouseDown += trackVolume_MouseDown;
             // 
             // GLViewerCheckboxControl
             // 
@@ -65,7 +66,6 @@ namespace GUI.Controls
             this.Size = new System.Drawing.Size(180, 41);
             this.ResumeLayout(false);
             this.PerformLayout();
-
         }
 
         #endregion

--- a/GUI/Controls/GLViewerTrackBarControl.cs
+++ b/GUI/Controls/GLViewerTrackBarControl.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows.Forms;
 
 namespace GUI.Controls
@@ -5,6 +6,7 @@ namespace GUI.Controls
     public partial class GLViewerTrackBarControl : UserControl
     {
         public TrackBar TrackBar => trackBar;
+        public bool IgnoreValueChanged { get; private set; }
 
         private GLViewerTrackBarControl()
         {
@@ -14,8 +16,25 @@ namespace GUI.Controls
         public GLViewerTrackBarControl(string name)
             : this()
         {
+            IgnoreValueChanged = false;
             trackBarLabel.Text = name;
             trackBar.Value = 0;
+        }
+
+        public void UpdateValueSilently(int value)
+        {
+            IgnoreValueChanged = true;
+            trackBar.Value = value;
+            IgnoreValueChanged = false;
+        }
+
+        private void trackVolume_MouseDown(object sender, MouseEventArgs e)
+        {
+            double dblValue;
+
+            // Jump to the clicked location
+            dblValue = ((double)e.X / (double)trackBar.Width) * (trackBar.Maximum - trackBar.Minimum);
+            trackBar.Value = Convert.ToInt32(dblValue);
         }
     }
 }

--- a/GUI/Controls/GLViewerTrackBarControl.cs
+++ b/GUI/Controls/GLViewerTrackBarControl.cs
@@ -1,0 +1,21 @@
+using System.Windows.Forms;
+
+namespace GUI.Controls
+{
+    public partial class GLViewerTrackBarControl : UserControl
+    {
+        public TrackBar TrackBar => trackBar;
+
+        private GLViewerTrackBarControl()
+        {
+            InitializeComponent();
+        }
+
+        public GLViewerTrackBarControl(string name)
+            : this()
+        {
+            trackBarLabel.Text = name;
+            trackBar.Value = 0;
+        }
+    }
+}

--- a/GUI/Controls/GLViewerTrackBarControl.resx
+++ b/GUI/Controls/GLViewerTrackBarControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -40,4 +40,9 @@
       <Name>ValveResourceFormat</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Controls\GLViewerTrackBarControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+  </ItemGroup>
 </Project>

--- a/GUI/Types/Exporter/ExportData.cs
+++ b/GUI/Types/Exporter/ExportData.cs
@@ -7,5 +7,6 @@ namespace GUI.Types.Exporter
     {
         public Resource Resource { get; set; }
         public VrfGuiContext VrfGuiContext { get; set; }
+        public ExportFileType FileType { get; set; } = ExportFileType.Auto;
     }
 }

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -33,8 +33,16 @@ namespace GUI.Types.Exporter
 
             if (resource.ResourceType == ResourceType.Mesh || resource.ResourceType == ResourceType.Model)
             {
-                extension = "gltf";
-                filter = $"glTF file|*.gltf|{filter}";
+                if (exportData.FileType == ExportFileType.GLB)
+                {
+                    extension = "glb";
+                    filter = $"GLB file|*.glb|{filter}";
+                }
+                else
+                {
+                    extension = "gltf";
+                    filter = $"glTF file|*.gltf|{filter}";
+                }
             }
 
             var dialog = new SaveFileDialog

--- a/GUI/Types/Exporter/ExportFileType.cs
+++ b/GUI/Types/Exporter/ExportFileType.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GUI.Types.Exporter
+{
+    public enum ExportFileType
+    {
+        /// <summary>
+        /// Automatically compute file type based on resource type
+        /// </summary>
+        Auto,
+
+        /// <summary>
+        /// Use the GLB format
+        /// </summary>
+        GLB
+    }
+}

--- a/GUI/Types/Renderer/AnimationController.cs
+++ b/GUI/Types/Renderer/AnimationController.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using ValveResourceFormat.ResourceTypes.ModelAnimation;
+
+namespace GUI.Types.Renderer
+{
+    public class AnimationController
+    {
+        private Action<Animation, int> updateHandler;
+        private Animation activeAnimation;
+
+        public float Time { get; private set; }
+        public bool IsPaused { get; set; }
+        public int Frame
+        {
+            get
+            {
+                if (activeAnimation != null)
+                {
+                    return (int)Math.Round(Time * activeAnimation.Fps) % activeAnimation.FrameCount;
+                }
+                return 0;
+            }
+            set
+            {
+                if (activeAnimation != null)
+                {
+                    Time = value / activeAnimation.Fps;
+                }
+            }
+        }
+
+        public void Update(float timeStep)
+        {
+            if (!IsPaused)
+            {
+                Time += timeStep;
+                updateHandler(activeAnimation, Frame);
+            }
+        }
+
+        public void SetAnimation(Animation animation)
+        {
+            activeAnimation = animation;
+            Time = 0f;
+            updateHandler(activeAnimation, Frame);
+        }
+
+        public void RegisterUpdateHandler(Action<Animation, int> handler)
+        {
+            updateHandler = handler;
+        }
+    }
+}

--- a/GUI/Types/Renderer/AnimationGroupLoader.cs
+++ b/GUI/Types/Renderer/AnimationGroupLoader.cs
@@ -13,7 +13,7 @@ namespace GUI.Types.Renderer
     {
         public static IEnumerable<Animation> LoadAnimationGroup(Resource resource, VrfGuiContext vrfGuiContext)
         {
-            var data = GetData(resource);
+            var data = resource.DataBlock.AsKeyValueCollection();
 
             // Get the list of animation files
             var animArray = data.GetArray<string>("m_localHAnimArray").Where(a => a != null);
@@ -33,7 +33,7 @@ namespace GUI.Types.Renderer
 
         public static IEnumerable<Animation> TryLoadSingleAnimationFileFromGroup(Resource resource, string animationName, VrfGuiContext vrfGuiContext)
         {
-            var data = GetData(resource);
+            var data = resource.DataBlock.AsKeyValueCollection();
 
             // Get the list of animation files
             var animArray = data.GetArray<string>("m_localHAnimArray").Where(a => a != null);
@@ -51,11 +51,6 @@ namespace GUI.Types.Renderer
                 return null;
             }
         }
-
-        private static IKeyValueCollection GetData(Resource resource)
-            => resource.DataBlock is NTRO ntro
-                ? ntro.Output as IKeyValueCollection
-                : ((BinaryKV3)resource.DataBlock).Data;
 
         private static IEnumerable<Animation> LoadAnimationFile(string animationFile, IKeyValueCollection decodeKey, VrfGuiContext vrfGuiContext)
         {

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
+using GUI.Controls;
 using GUI.Utils;
 using ValveResourceFormat.ResourceTypes;
 
@@ -16,7 +17,7 @@ namespace GUI.Types.Renderer
         private readonly Mesh mesh;
         private ComboBox animationComboBox;
         private CheckBox animationPlayPause;
-        private TrackBar animationTrackBar; 
+        private GLViewerTrackBarControl animationTrackBar; 
         private CheckedListBox meshGroupListBox;
         private ModelSceneNode modelSceneNode;
         private MeshSceneNode meshSceneNode;
@@ -52,7 +53,6 @@ namespace GUI.Types.Renderer
             {
                 if (modelSceneNode != null)
                 {
-                    // Have thing here to prevent setting this from in code
                     modelSceneNode.AnimationController.Frame = frame;
                 }
             });
@@ -86,13 +86,14 @@ namespace GUI.Types.Renderer
 
                 modelSceneNode.AnimationController.RegisterUpdateHandler((animation, frame) =>
                 {
-                    if (animationTrackBar.Value != frame)
+                    if (animationTrackBar.TrackBar.Value != frame)
                     {
-                        animationTrackBar.Value = frame;
+                        animationTrackBar.UpdateValueSilently(frame);
                     }
-                    if (animationTrackBar.Maximum != animation.FrameCount - 1)
+                    var maximum = animation == null ? 1 : animation.FrameCount - 1;
+                    if (animationTrackBar.TrackBar.Maximum != maximum)
                     {
-                        animationTrackBar.Maximum = animation.FrameCount - 1;
+                        animationTrackBar.TrackBar.Maximum = maximum;
                     }
                     animationTrackBar.Enabled = animation != null;
                     animationPlayPause.Enabled = animation != null;

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -15,6 +15,8 @@ namespace GUI.Types.Renderer
         private readonly Model model;
         private readonly Mesh mesh;
         private ComboBox animationComboBox;
+        private CheckBox animationPlayPause;
+        private TrackBar animationTrackBar; 
         private CheckedListBox meshGroupListBox;
         private ModelSceneNode modelSceneNode;
         private MeshSceneNode meshSceneNode;
@@ -39,6 +41,23 @@ namespace GUI.Types.Renderer
             {
                 modelSceneNode?.SetAnimation(animation);
             });
+            animationPlayPause = ViewerControl.AddCheckBox("Autoplay", true, isChecked =>
+            {
+                if (modelSceneNode != null)
+                {
+                    modelSceneNode.AnimationController.IsPaused = !isChecked;
+                }
+            });
+            animationTrackBar = ViewerControl.AddTrackBar("Animation Frame", frame =>
+            {
+                if (modelSceneNode != null)
+                {
+                    // Have thing here to prevent setting this from in code
+                    modelSceneNode.AnimationController.Frame = frame;
+                }
+            });
+            animationPlayPause.Enabled = false;
+            animationTrackBar.Enabled = false;
         }
 
         protected override void LoadScene()
@@ -64,6 +83,20 @@ namespace GUI.Types.Renderer
                         meshGroupListBox.SetItemChecked(meshGroupListBox.FindStringExact(group), true);
                     }
                 }
+
+                modelSceneNode.AnimationController.RegisterUpdateHandler((animation, frame) =>
+                {
+                    if (animationTrackBar.Value != frame)
+                    {
+                        animationTrackBar.Value = frame;
+                    }
+                    if (animationTrackBar.Maximum != animation.FrameCount - 1)
+                    {
+                        animationTrackBar.Maximum = animation.FrameCount - 1;
+                    }
+                    animationTrackBar.Enabled = animation != null;
+                    animationPlayPause.Enabled = animation != null;
+                });
             }
             else
             {

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -33,20 +33,20 @@ namespace GUI.Types.Renderer
             }
         }
 
+        public AnimationController AnimationController => animationController;
         public IEnumerable<RenderableMesh> RenderableMeshes => activeMeshRenderers;
 
         private readonly List<RenderableMesh> meshRenderers = new List<RenderableMesh>();
         private readonly List<Animation> animations = new List<Animation>();
         private Dictionary<string, string> skinMaterials;
 
+        private AnimationController animationController;
         private Animation activeAnimation;
         private int[] animationTextures;
         private Skeleton[] skeletons;
 
         private ICollection<string> activeMeshGroups = new HashSet<string>();
         private ICollection<RenderableMesh> activeMeshRenderers = new HashSet<RenderableMesh>();
-
-        private float time;
 
         public ModelSceneNode(Scene scene, Model model, string skin = null, bool loadAnimations = true)
             : base(scene)
@@ -76,7 +76,7 @@ namespace GUI.Types.Renderer
                 return;
             }
 
-            time += context.Timestep;
+            animationController.Update(context.Timestep);
 
             for (var i = 0; i < skeletons.Length; i++)
             {
@@ -94,7 +94,7 @@ namespace GUI.Types.Renderer
                     animationMatrices[(j * 16) + 15] = 1.0f;
                 }
 
-                animationMatrices = activeAnimation.GetAnimationMatricesAsArray(time, skeleton);
+                animationMatrices = activeAnimation.GetAnimationMatricesAsArray(animationController.Time, skeleton);
 
                 // Update animation texture
                 GL.BindTexture(TextureTarget.Texture2D, animationTexture);
@@ -210,6 +210,7 @@ namespace GUI.Types.Renderer
 
         private void LoadAnimations()
         {
+            animationController = new AnimationController();
             var animGroupPaths = Model.GetReferencedAnimationGroupNames();
             var emebeddedAnims = Model.GetEmbeddedAnimations();
 
@@ -276,8 +277,8 @@ namespace GUI.Types.Renderer
 
         public void SetAnimation(string animationName)
         {
-            time = 0f;
             activeAnimation = animations.FirstOrDefault(a => a.Name == animationName);
+            animationController.SetAnimation(activeAnimation);
 
             if (activeAnimation != default)
             {

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -160,6 +160,8 @@ namespace GUI.Types.Viewers
                 case ResourceType.Model:
                     Program.MainForm.Invoke(new ExportDel(AddToExport), resTabs, $"Export {Path.GetFileName(vrfGuiContext.FileName)} as glTF",
                         vrfGuiContext.FileName, new ExportData {Resource = resource, VrfGuiContext = vrfGuiContext});
+                    Program.MainForm.Invoke(new ExportDel(AddToExport), resTabs, $"Export {Path.GetFileName(vrfGuiContext.FileName)} as GLB",
+                        vrfGuiContext.FileName, new ExportData { Resource = resource, VrfGuiContext = vrfGuiContext, FileType = ExportFileType.GLB });
 
                     var modelRendererTab = new TabPage("MODEL");
                     modelRendererTab.Controls.Add(new GLModelViewer(vrfGuiContext, (Model) resource.DataBlock)
@@ -176,6 +178,8 @@ namespace GUI.Types.Viewers
 
                     Program.MainForm.Invoke(new ExportDel(AddToExport), resTabs, $"Export {Path.GetFileName(vrfGuiContext.FileName)} as glTF",
                         vrfGuiContext.FileName, new ExportData {Resource = resource, VrfGuiContext = vrfGuiContext});
+                    Program.MainForm.Invoke(new ExportDel(AddToExport), resTabs, $"Export {Path.GetFileName(vrfGuiContext.FileName)} as GLB",
+                        vrfGuiContext.FileName, new ExportData { Resource = resource, VrfGuiContext = vrfGuiContext, FileType = ExportFileType.GLB });
 
                     var meshRendererTab = new TabPage("MESH");
                     meshRendererTab.Controls.Add(new GLModelViewer(vrfGuiContext, new Mesh(resource)).ViewerControl);

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -101,8 +101,8 @@ namespace ValveResourceFormat.IO
                             var node = joints.FirstOrDefault(n => n.Name == bone);
                             if (node != null)
                             {
-                                anim.CreateRotationChannel(node, rotationDict[bone]);
-                                anim.CreateTranslationChannel(node, translationDict[bone]);
+                                anim.CreateRotationChannel(node, rotationDict[bone], true);
+                                anim.CreateTranslationChannel(node, translationDict[bone], true);
                             }
                         }
                     }

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -58,7 +58,7 @@ namespace ValveResourceFormat.IO
                 var hasJoints = skeleton.AnimationTextureSize > 0;
                 var exportedMesh = CreateGltfMesh(name, mesh, exportedModel, hasJoints);
                 var hasVertexJoints = exportedMesh.Primitives.All(primitive => primitive.GetVertexAccessor("JOINTS_0") != null);
-                
+
                 if (hasJoints && hasVertexJoints)
                 {
                     var skeletonNode = scene.CreateNode(name);
@@ -78,7 +78,7 @@ namespace ValveResourceFormat.IO
                         var rotationDict = new Dictionary<string, Dictionary<float, Quaternion>>();
                         var translationDict = new Dictionary<string, Dictionary<float, Vector3>>();
 
-                        var time = (float)0;
+                        var time = 0f;
                         foreach (var frame in animation.Frames)
                         {
                             foreach (var boneFrame in frame.Bones)
@@ -122,8 +122,6 @@ namespace ValveResourceFormat.IO
             {
                 AddMeshNode(meshes[i].Name, meshes[i].Mesh, model.GetSkeleton(i));
             }
-
-
 
             exportedModel.Save(fileName);
         }
@@ -352,7 +350,6 @@ namespace ValveResourceFormat.IO
                 }
             }
 
-
             return mesh;
         }
 
@@ -525,9 +522,7 @@ namespace ValveResourceFormat.IO
                 var animGroup = FileLoader.LoadFile(animGroupPath + "_c");
                 if (animGroup != default)
                 {
-                    var data = animGroup.DataBlock is ResourceTypes.NTRO ntro
-                        ? ntro.Output as IKeyValueCollection
-                        : ((ResourceTypes.BinaryKV3)animGroup.DataBlock).Data;
+                    var data = animGroup.DataBlock.AsKeyValueCollection();
 
                     // Get the list of animation files
                     var animArray = data.GetArray<string>("m_localHAnimArray").Where(a => a != null);

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -12,10 +12,9 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     {
         public string Name { get; private set; }
         public float Fps { get; private set; }
+        public long FrameCount { get; private set; }
 
-        private long FrameCount;
-
-        private Frame[] Frames;
+        public Frame[] Frames { get; private set; }
 
         private Animation(
             IKeyValueCollection animDesc,

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -12,9 +12,8 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     {
         public string Name { get; private set; }
         public float Fps { get; private set; }
-        public long FrameCount { get; private set; }
-
-        public Frame[] Frames { get; private set; }
+        public int FrameCount { get; private set; }
+        public IReadOnlyList<Frame> Frames { get; set; }
 
         private Animation(
             IKeyValueCollection animDesc,
@@ -165,14 +164,15 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 : pDataObject as IKeyValueCollection;
             var frameBlockArray = pData.GetArray("m_frameblockArray");
 
-            FrameCount = pData.GetIntegerProperty("m_nFrames");
-            Frames = new Frame[FrameCount];
+            FrameCount = (int)pData.GetIntegerProperty("m_nFrames");
+            var frameArray = new Frame[FrameCount];
+            Frames = frameArray;
 
             // Figure out each frame
             for (var frame = 0; frame < FrameCount; frame++)
             {
                 // Create new frame object
-                Frames[frame] = new Frame();
+                frameArray[frame] = new Frame();
 
                 // Read all frame blocks
                 foreach (var frameBlock in frameBlockArray)
@@ -188,7 +188,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                         foreach (var segmentIndex in segmentIndexArray)
                         {
                             var segment = segmentArray[segmentIndex];
-                            ReadSegment(frame - startFrame, segment, decodeKey, decoderArray, ref Frames[frame]);
+                            ReadSegment(frame - startFrame, segment, decodeKey, decoderArray, ref frameArray[frame]);
                         }
                     }
                 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -13,7 +13,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public string Name { get; private set; }
         public float Fps { get; private set; }
         public int FrameCount { get; private set; }
-        public IReadOnlyList<Frame> Frames { get; set; }
+        public IReadOnlyList<Frame> Frames { get; private set; }
 
         private Animation(
             IKeyValueCollection animDesc,
@@ -166,7 +166,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             FrameCount = (int)pData.GetIntegerProperty("m_nFrames");
             var frameArray = new Frame[FrameCount];
-            Frames = frameArray;
 
             // Figure out each frame
             for (var frame = 0; frame < FrameCount; frame++)
@@ -193,6 +192,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                     }
                 }
             }
+            Frames = frameArray;
         }
 
         /// <summary>


### PR DESCRIPTION
This pull request implements the following:
- Better access to frames from Animation.cs
- Adds animations to models exported as GLTF
- Adds support for exporting to GLB instead of GLTF as an option in the GUI
- Adds some play controls to the animations in the model viewer for the GUI

Screenshot of new GLB option:
![image](https://user-images.githubusercontent.com/3231343/99497076-389b5000-292a-11eb-850a-0e9856f84459.png)

GIF showing new animation controls:
![animationcontrols](https://user-images.githubusercontent.com/3231343/99497304-9334ac00-292a-11eb-86e4-7be0aa267823.gif)

GIF showing animations exported properly into GLTF and then played via blender:
![animationsworking](https://user-images.githubusercontent.com/3231343/99498604-99c42300-292c-11eb-9e80-2464ee1d0a32.gif)


If one of these features isn't wanted, they're fairly separated in the commits I made so I can revert a commit or 2 if need be.

Ref: #232