### PR TITLE
Upgrade/Migrate FxCopAnalyzers to NetAnalyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,15 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 
 [*.cs]
+# CA1002: Do not expose generic lists.
+dotnet_diagnostic.CA1002.severity = none
+
+# CA1003: Use generic event handler instances
+dotnet_diagnostic.CA1003.severity = suggestion
+
+# CA1008: Enums should have zero value
+dotnet_diagnostic.CA1008.severity = none
+
 # CA1010: Type directly or indirectly inherits 'ICollection' without implementing 'ICollection<T>'
 dotnet_diagnostic.CA1010.severity = none
 
@@ -35,11 +44,17 @@ dotnet_diagnostic.CA1307.severity = suggestion
 # CA1310: Specify StringComparison for correctness
 dotnet_diagnostic.CA1310.severity = suggestion
 
+# CA1508: Avoid dead conditional code
+dotnet_diagnostic.CA1508.severity = none
+
 # CA1707: Remove the underscores from member name
 dotnet_diagnostic.CA1707.severity = none
 
 # CA1710: Rename to end in 'Dictionary'.
 dotnet_diagnostic.CA1710.severity = none
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = suggestion
 
 # CA1720: Identifier contains type name
 dotnet_diagnostic.CA1720.severity = none
@@ -65,5 +80,14 @@ dotnet_diagnostic.CA2000.severity = none
 # CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.CA2008.severity = none
 
+# CA2119: Seal methods that satisfy private interfaces
+dotnet_diagnostic.CA2119.severity = none
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.CA2201.severity = suggestion
+
 # CA2214: Do not call overridable methods in constructors
 dotnet_diagnostic.CA2214.severity = none
+
+# CA5394: Do not use insecure randomness
+dotnet_diagnostic.CA5394.severity = suggestion

--- a/Decompiler/AssemblyInfo.cs
+++ b/Decompiler/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(false)]

--- a/Decompiler/Decompiler.csproj
+++ b/Decompiler/Decompiler.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
   </PropertyGroup>
   <PropertyGroup>
     <Authors>SteamDB</Authors>

--- a/GUI/AssemblyInfo.cs
+++ b/GUI/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(false)]

--- a/GUI/Controls/BetterTreeView.cs
+++ b/GUI/Controls/BetterTreeView.cs
@@ -22,9 +22,9 @@ namespace GUI.Controls
             InitializeComponent();
         }
 
-        protected override void OnPaint(PaintEventArgs pe)
+        protected override void OnPaint(PaintEventArgs e)
         {
-            base.OnPaint(pe);
+            base.OnPaint(e);
         }
 
         /// <summary>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -15,7 +15,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/GUI/Types/ParticleRenderer/Initializers/CreateWithinSphere.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/CreateWithinSphere.cs
@@ -52,7 +52,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var randomVector = new Vector3(
                 ((float)random.NextDouble() * 2) - 1,

--- a/GUI/Types/ParticleRenderer/Initializers/PositionOffset.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/PositionOffset.cs
@@ -26,7 +26,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var distance = offsetMax - offsetMin;
             var offset = offsetMin + (distance * new Vector3((float)random.NextDouble(), (float)random.NextDouble(), (float)random.NextDouble()));

--- a/GUI/Types/ParticleRenderer/Initializers/RandomAlpha.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RandomAlpha.cs
@@ -32,7 +32,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var alpha = random.Next(alphaMin, alphaMax) / 255f;
 

--- a/GUI/Types/ParticleRenderer/Initializers/RandomColor.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RandomColor.cs
@@ -28,7 +28,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var t = (float)random.NextDouble();
             particle.ConstantColor = colorMin + (t * (colorMax - colorMin));

--- a/GUI/Types/ParticleRenderer/Initializers/RandomLifeTime.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RandomLifeTime.cs
@@ -25,7 +25,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var lifetime = lifetimeMin + ((lifetimeMax - lifetimeMin) * (float)random.NextDouble());
 

--- a/GUI/Types/ParticleRenderer/Initializers/RandomRadius.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RandomRadius.cs
@@ -25,7 +25,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             particle.ConstantRadius = radiusMin + ((float)random.NextDouble() * (radiusMax - radiusMin));
             particle.Radius = particle.ConstantRadius;

--- a/GUI/Types/ParticleRenderer/Initializers/RandomRotation.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RandomRotation.cs
@@ -46,7 +46,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var degrees = degreesOffset + degreesMin + ((float)random.NextDouble() * (degreesMax - degreesMin));
             if (randomlyFlipDirection && random.NextDouble() > 0.5)

--- a/GUI/Types/ParticleRenderer/Initializers/RemapParticleCountToScalar.cs
+++ b/GUI/Types/ParticleRenderer/Initializers/RemapParticleCountToScalar.cs
@@ -45,7 +45,7 @@ namespace GUI.Types.ParticleRenderer.Initializers
             }
         }
 
-        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemRenderState)
+        public Particle Initialize(ref Particle particle, ParticleSystemRenderState particleSystemState)
         {
             var particleCount = Math.Min(inputMax, Math.Max(inputMin, particle.ParticleCount));
             var t = (particleCount - inputMin) / (float)(inputMax - inputMin);

--- a/Tests/AssemblyInfo.cs
+++ b/Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(false)]

--- a/Tests/KeyValuesTest.cs
+++ b/Tests/KeyValuesTest.cs
@@ -18,6 +18,7 @@ namespace Tests
 
             TestKeyValues3(file);
         }
+
         [Test]
         public void TestKeyValues3_CRLF()
         {
@@ -30,7 +31,7 @@ namespace Tests
             TestKeyValues3(file);
         }
 
-        public void TestKeyValues3(KV3File file)
+        static void TestKeyValues3(KV3File file)
         {
             Assert.AreEqual("text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d}", file.Encoding);
             Assert.AreEqual("generic:version{7412167c-06e9-4698-aff2-e63eb59037e7}", file.Format);

--- a/Tests/Test.cs
+++ b/Tests/Test.cs
@@ -83,7 +83,7 @@ namespace Tests
             Assert.Multiple(() => VerifyResources(resources));
         }
 
-        private void VerifyResources(Dictionary<string, Resource> resources)
+        static void VerifyResources(Dictionary<string, Resource> resources)
         {
             SoundWavCorrectlyExports(resources["beep.vsnd_c"]);
 
@@ -137,17 +137,19 @@ namespace Tests
             }
         }
 
-        private void SoundWavCorrectlyExports(Resource resource)
+        static void SoundWavCorrectlyExports(Resource resource)
         {
             Assert.AreEqual(ResourceType.Sound, resource.ResourceType);
 
+#pragma warning disable CA5350 // Do Not Use Weak Cryptographic Algorithms
             using (var sha1 = new SHA1CryptoServiceProvider())
             {
                 var sound = ((Sound)resource.DataBlock).GetSound();
-                var actualHash = BitConverter.ToString(sha1.ComputeHash(sound)).Replace("-", "");
+                var actualHash = BitConverter.ToString(sha1.ComputeHash(sound)).Replace("-", "", StringComparison.Ordinal);
 
                 Assert.AreEqual("59AC27F1A4395D8D02E4B3ADAA99023F243C8B41", actualHash);
             }
+#pragma warning restore CA5350 // Do Not Use Weak Cryptographic Algorithms
         }
 
         [Test]

--- a/ValveResourceFormat/AssemblyInfo.cs
+++ b/ValveResourceFormat/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(false)]

--- a/ValveResourceFormat/ClosedCaptions/ClosedCaptions.cs
+++ b/ValveResourceFormat/ClosedCaptions/ClosedCaptions.cs
@@ -73,8 +73,7 @@ namespace ValveResourceFormat.ClosedCaptions
 
             for (uint i = 0; i < directorysize; i++)
             {
-                var caption = new ClosedCaption();
-                caption.Hash = reader.ReadUInt32();
+                var caption = new ClosedCaption { Hash = reader.ReadUInt32() };
 
                 if (version >= 2)
                 {

--- a/ValveResourceFormat/CompiledShader/CompiledShader.cs
+++ b/ValveResourceFormat/CompiledShader/CompiledShader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Text;
 using Decoder = SevenZip.Compression.LZMA.Decoder;
@@ -545,7 +545,7 @@ namespace ValveResourceFormat
                                 chunkReader.BaseStream.Position -= 2;
                             }
                         }
-                        else if (modeAndCount == 20)
+                        else 
                         {
                             // Read 40 byte 0xFF chunk
                             chunkReader.ReadBytes(40);

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -41,7 +41,7 @@ namespace ValveResourceFormat.IO
         {
             if (FileLoader == null)
             {
-                throw new NullReferenceException(nameof(FileLoader));
+                throw new InvalidOperationException(nameof(FileLoader) + " must be set first.");
             }
 
             var exportedModel = ModelRoot.CreateModel();
@@ -623,8 +623,8 @@ namespace ValveResourceFormat.IO
 
             x = (x * zSign) - zSignBit;                           // 0..127
             y = (y * tSign) - tSignBit;
-            x = x - 64;                                     // -64..63
-            y = y - 64;
+            x -= 64;                                     // -64..63
+            y -= 64;
 
             float xSignBit = x < 0 ? 1.0f : 0.0f;   // x and y negative bits (like slt asm instruction)
             float ySignBit = y < 0 ? 1.0f : 0.0f;

--- a/ValveResourceFormat/Resource/Blocks/ResourceExtRefList.cs
+++ b/ValveResourceFormat/Resource/Blocks/ResourceExtRefList.cs
@@ -105,8 +105,7 @@ namespace ValveResourceFormat.Blocks
 
             for (var i = 0; i < size; i++)
             {
-                var resInfo = new ResourceReferenceInfo();
-                resInfo.Id = reader.ReadUInt64();
+                var resInfo = new ResourceReferenceInfo { Id = reader.ReadUInt64() };
 
                 var previousPosition = reader.BaseStream.Position;
 

--- a/ValveResourceFormat/Resource/Blocks/ResourceIntrospectionManifest.cs
+++ b/ValveResourceFormat/Resource/Blocks/ResourceIntrospectionManifest.cs
@@ -198,15 +198,17 @@ namespace ValveResourceFormat.Blocks
 
             for (var i = 0; i < entriesCount; i++)
             {
-                var diskStruct = new ResourceDiskStruct();
-                diskStruct.IntrospectionVersion = reader.ReadUInt32();
-                diskStruct.Id = reader.ReadUInt32();
-                diskStruct.Name = reader.ReadOffsetString(Encoding.UTF8);
-                diskStruct.DiskCrc = reader.ReadUInt32();
-                diskStruct.UserVersion = reader.ReadInt32();
-                diskStruct.DiskSize = reader.ReadUInt16();
-                diskStruct.Alignment = reader.ReadUInt16();
-                diskStruct.BaseStructId = reader.ReadUInt32();
+                var diskStruct = new ResourceDiskStruct
+                {
+                    IntrospectionVersion = reader.ReadUInt32(),
+                    Id = reader.ReadUInt32(),
+                    Name = reader.ReadOffsetString(Encoding.UTF8),
+                    DiskCrc = reader.ReadUInt32(),
+                    UserVersion = reader.ReadInt32(),
+                    DiskSize = reader.ReadUInt16(),
+                    Alignment = reader.ReadUInt16(),
+                    BaseStructId = reader.ReadUInt32()
+                };
 
                 var fieldsOffset = reader.ReadUInt32();
                 var fieldsSize = reader.ReadUInt32();
@@ -219,11 +221,12 @@ namespace ValveResourceFormat.Blocks
 
                     for (var y = 0; y < fieldsSize; y++)
                     {
-                        var field = new ResourceDiskStruct.Field();
-
-                        field.FieldName = reader.ReadOffsetString(Encoding.UTF8);
-                        field.Count = reader.ReadInt16();
-                        field.OnDiskOffset = reader.ReadInt16();
+                        var field = new ResourceDiskStruct.Field
+                        {
+                            FieldName = reader.ReadOffsetString(Encoding.UTF8),
+                            Count = reader.ReadInt16(),
+                            OnDiskOffset = reader.ReadInt16()
+                        };
 
                         var indirectionOffset = reader.ReadUInt32();
                         var indirectionSize = reader.ReadUInt32();
@@ -275,12 +278,14 @@ namespace ValveResourceFormat.Blocks
 
             for (var i = 0; i < entriesCount; i++)
             {
-                var diskEnum = new ResourceDiskEnum();
-                diskEnum.IntrospectionVersion = reader.ReadUInt32();
-                diskEnum.Id = reader.ReadUInt32();
-                diskEnum.Name = reader.ReadOffsetString(Encoding.UTF8);
-                diskEnum.DiskCrc = reader.ReadUInt32();
-                diskEnum.UserVersion = reader.ReadInt32();
+                var diskEnum = new ResourceDiskEnum
+                {
+                    IntrospectionVersion = reader.ReadUInt32(),
+                    Id = reader.ReadUInt32(),
+                    Name = reader.ReadOffsetString(Encoding.UTF8),
+                    DiskCrc = reader.ReadUInt32(),
+                    UserVersion = reader.ReadInt32()
+                };
 
                 var fieldsOffset = reader.ReadUInt32();
                 var fieldsSize = reader.ReadUInt32();
@@ -293,10 +298,11 @@ namespace ValveResourceFormat.Blocks
 
                     for (var y = 0; y < fieldsSize; y++)
                     {
-                        var field = new ResourceDiskEnum.Value();
-
-                        field.EnumValueName = reader.ReadOffsetString(Encoding.UTF8);
-                        field.EnumValue = reader.ReadInt32();
+                        var field = new ResourceDiskEnum.Value
+                        {
+                            EnumValueName = reader.ReadOffsetString(Encoding.UTF8),
+                            EnumValue = reader.ReadInt32()
+                        };
 
                         diskEnum.EnumValueIntrospection.Add(field);
                     }

--- a/ValveResourceFormat/Resource/Blocks/SNAP.cs
+++ b/ValveResourceFormat/Resource/Blocks/SNAP.cs
@@ -38,13 +38,13 @@ namespace ValveResourceFormat.Blocks
             }
         }
 
-        public override void Read(BinaryReader resourceReader, Resource resource)
+        public override void Read(BinaryReader reader, Resource resource)
         {
-            resourceReader.BaseStream.Position = Offset;
+            reader.BaseStream.Position = Offset;
 
             // Decompress SNAP block compression
-            using var decompressedStream = BlockCompress.Decompress(resourceReader, Size);
-            using var reader = new BinaryReader(decompressedStream);
+            using var decompressedStream = BlockCompress.Decompress(reader, Size);
+            using var innerReader = new BinaryReader(decompressedStream);
 
             // Get DATA block to know how to read SNAP data
             var data = resource.DataBlock.AsKeyValueCollection();
@@ -62,10 +62,10 @@ namespace ValveResourceFormat.Blocks
 
                 var attributeArray = attributeType switch
                 {
-                    "skinning" => ReadSkinningData(reader, numParticles, stringList),
-                    "string" => ReadStringArray(reader, numParticles, stringList),
-                    "bone" => ReadStringArray(reader, numParticles, stringList),
-                    _ => ReadArrayOfType(reader, numParticles, attributeType),
+                    "skinning" => ReadSkinningData(innerReader, numParticles, stringList),
+                    "string" => ReadStringArray(innerReader, numParticles, stringList),
+                    "bone" => ReadStringArray(innerReader, numParticles, stringList),
+                    _ => ReadArrayOfType(innerReader, numParticles, attributeType),
                 };
 
                 attributeData.Add(attributeName, attributeArray);

--- a/ValveResourceFormat/Resource/Enums/BlockType.cs
+++ b/ValveResourceFormat/Resource/Enums/BlockType.cs
@@ -4,7 +4,6 @@ namespace ValveResourceFormat
 {
     public enum BlockType
     {
-#pragma warning disable 1591
         RERL = 1,
         REDI,
         NTRO,
@@ -20,6 +19,5 @@ namespace ValveResourceFormat
         ASEQ,
         AGRP,
         PHYS,
-#pragma warning restore 1591
     }
 }

--- a/ValveResourceFormat/Resource/Enums/VTexFlags.cs
+++ b/ValveResourceFormat/Resource/Enums/VTexFlags.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 
 namespace ValveResourceFormat
 {
     [Flags]
     public enum VTexFlags
     {
-#pragma warning disable 1591
         SUGGEST_CLAMPS = 0x00000001,
         SUGGEST_CLAMPT = 0x00000002,
         SUGGEST_CLAMPU = 0x00000004,
@@ -13,6 +12,5 @@ namespace ValveResourceFormat
         CUBE_TEXTURE = 0x00000010,
         VOLUME_TEXTURE = 0x00000020,
         TEXTURE_ARRAY = 0x00000040,
-#pragma warning restore 1591
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -151,12 +151,12 @@ namespace ValveResourceFormat.ResourceTypes
 
                         if (int1 != 1 && int1 != 0)
                         {
-                            throw new Exception($"int1 got: {int1}");
+                            throw new InvalidDataException($"int1 got: {int1}");
                         }
 
                         if (int2 != 8)
                         {
-                            throw new Exception($"int2 expected 8 but got: {int2}");
+                            throw new InvalidDataException($"int2 expected 8 but got: {int2}");
                         }
 
                         IsActuallyCompressedMips = int1 == 1; // TODO: Verify whether this int is the one that actually controls compression
@@ -180,68 +180,66 @@ namespace ValveResourceFormat.ResourceTypes
         {
             if (ExtraData.TryGetValue(VTexExtraData.SHEET, out var bytes))
             {
-                using (var memoryStream = new MemoryStream(bytes))
-                using (var reader = new BinaryReader(memoryStream))
+                using var memoryStream = new MemoryStream(bytes);
+                using var reader = new BinaryReader(memoryStream);
+                var version = reader.ReadUInt32();
+                var numSequences = reader.ReadUInt32();
+
+                var sequences = new SpritesheetData.Sequence[numSequences];
+
+                for (var i = 0; i < numSequences; i++)
                 {
-                    var version = reader.ReadUInt32();
-                    var numSequences = reader.ReadUInt32();
+                    var sequenceNumber = reader.ReadUInt32();
+                    var unknown1 = reader.ReadUInt32(); // 1?
+                    var unknown2 = reader.ReadUInt32();
+                    var numFrames = reader.ReadUInt32();
+                    var framesPerSecond = reader.ReadSingle(); // Not too sure about this one
+                    var dataOffset = reader.BaseStream.Position + reader.ReadUInt32();
+                    var unknown4 = reader.ReadUInt32(); // 0?
+                    var unknown5 = reader.ReadUInt32(); // 0?
 
-                    var sequences = new SpritesheetData.Sequence[numSequences];
+                    var endOfHeaderOffset = reader.BaseStream.Position; // Store end of header to return to later
 
-                    for (var i = 0; i < numSequences; i++)
+                    // Seek to start of the sequence data
+                    reader.BaseStream.Position = dataOffset;
+
+                    var sequenceName = reader.ReadNullTermString(Encoding.UTF8);
+
+                    var frameUnknown = reader.ReadUInt16();
+
+                    var frames = new SpritesheetData.Sequence.Frame[numFrames];
+
+                    for (var j = 0; j < numFrames; j++)
                     {
-                        var sequenceNumber = reader.ReadUInt32();
-                        var unknown1 = reader.ReadUInt32(); // 1?
-                        var unknown2 = reader.ReadUInt32();
-                        var numFrames = reader.ReadUInt32();
-                        var framesPerSecond = reader.ReadSingle(); // Not too sure about this one
-                        var dataOffset = reader.BaseStream.Position + reader.ReadUInt32();
-                        var unknown4 = reader.ReadUInt32(); // 0?
-                        var unknown5 = reader.ReadUInt32(); // 0?
+                        var frameUnknown1 = reader.ReadSingle();
+                        var frameUnknown2 = reader.ReadUInt32();
+                        var frameUnknown3 = reader.ReadSingle();
 
-                        var endOfHeaderOffset = reader.BaseStream.Position; // Store end of header to return to later
-
-                        // Seek to start of the sequence data
-                        reader.BaseStream.Position = dataOffset;
-
-                        var sequenceName = reader.ReadNullTermString(Encoding.UTF8);
-
-                        var frameUnknown = reader.ReadUInt16();
-
-                        var frames = new SpritesheetData.Sequence.Frame[numFrames];
-
-                        for (var j = 0; j < numFrames; j++)
-                        {
-                            var frameUnknown1 = reader.ReadSingle();
-                            var frameUnknown2 = reader.ReadUInt32();
-                            var frameUnknown3 = reader.ReadSingle();
-
-                            frames[j] = new SpritesheetData.Sequence.Frame();
-                        }
-
-                        for (var j = 0; j < numFrames; j++)
-                        {
-                            frames[j].StartMins = new Vector2(reader.ReadSingle(), reader.ReadSingle());
-                            frames[j].StartMaxs = new Vector2(reader.ReadSingle(), reader.ReadSingle());
-
-                            frames[j].EndMins = new Vector2(reader.ReadSingle(), reader.ReadSingle());
-                            frames[j].EndMaxs = new Vector2(reader.ReadSingle(), reader.ReadSingle());
-                        }
-
-                        reader.BaseStream.Position = endOfHeaderOffset;
-
-                        sequences[i] = new SpritesheetData.Sequence
-                        {
-                            Frames = frames,
-                            FramesPerSecond = framesPerSecond,
-                        };
+                        frames[j] = new SpritesheetData.Sequence.Frame();
                     }
 
-                    return new SpritesheetData
+                    for (var j = 0; j < numFrames; j++)
                     {
-                        Sequences = sequences,
+                        frames[j].StartMins = new Vector2(reader.ReadSingle(), reader.ReadSingle());
+                        frames[j].StartMaxs = new Vector2(reader.ReadSingle(), reader.ReadSingle());
+
+                        frames[j].EndMins = new Vector2(reader.ReadSingle(), reader.ReadSingle());
+                        frames[j].EndMaxs = new Vector2(reader.ReadSingle(), reader.ReadSingle());
+                    }
+
+                    reader.BaseStream.Position = endOfHeaderOffset;
+
+                    sequences[i] = new SpritesheetData.Sequence
+                    {
+                        Frames = frames,
+                        FramesPerSecond = framesPerSecond,
                     };
                 }
+
+                return new SpritesheetData
+                {
+                    Sequences = sequences,
+                };
             }
 
             return null;
@@ -515,80 +513,79 @@ namespace ValveResourceFormat.ResourceTypes
             return SKBitmap.Decode(Reader.ReadBytes((int)Reader.BaseStream.Length));
         }
 
+#pragma warning disable CA1024 // Use properties where appropriate
         public int GetBlockSize()
         {
-            switch (Format)
+            return Format switch
             {
-                case VTexFormat.DXT1: return 8;
-                case VTexFormat.DXT5: return 16;
-                case VTexFormat.RGBA8888: return 4;
-                case VTexFormat.R16: return 2;
-                case VTexFormat.RG1616: return 4;
-                case VTexFormat.RGBA16161616: return 8;
-                case VTexFormat.R16F: return 2;
-                case VTexFormat.RG1616F: return 4;
-                case VTexFormat.RGBA16161616F: return 8;
-                case VTexFormat.R32F: return 4;
-                case VTexFormat.RG3232F: return 8;
-                case VTexFormat.RGB323232F: return 12;
-                case VTexFormat.RGBA32323232F: return 16;
-                case VTexFormat.BC6H: return 16;
-                case VTexFormat.BC7: return 16;
-                case VTexFormat.IA88: return 2;
-                case VTexFormat.ETC2: return 8;
-                case VTexFormat.ETC2_EAC: return 16;
-                case VTexFormat.BGRA8888: return 4;
-                case VTexFormat.ATI1N: return 8;
-            }
-
-            return 1;
+                VTexFormat.DXT1 => 8,
+                VTexFormat.DXT5 => 16,
+                VTexFormat.RGBA8888 => 4,
+                VTexFormat.R16 => 2,
+                VTexFormat.RG1616 => 4,
+                VTexFormat.RGBA16161616 => 8,
+                VTexFormat.R16F => 2,
+                VTexFormat.RG1616F => 4,
+                VTexFormat.RGBA16161616F => 8,
+                VTexFormat.R32F => 4,
+                VTexFormat.RG3232F => 8,
+                VTexFormat.RGB323232F => 12,
+                VTexFormat.RGBA32323232F => 16,
+                VTexFormat.BC6H => 16,
+                VTexFormat.BC7 => 16,
+                VTexFormat.IA88 => 2,
+                VTexFormat.ETC2 => 8,
+                VTexFormat.ETC2_EAC => 16,
+                VTexFormat.BGRA8888 => 4,
+                VTexFormat.ATI1N => 8,
+                _ => 1,
+            };
         }
+#pragma warning restore CA1024 // Use properties where appropriate
 
         public override string ToString()
         {
-            using (var writer = new IndentedTextWriter())
+            using var writer = new IndentedTextWriter();
+            writer.WriteLine("{0,-12} = {1}", "VTEX Version", Version);
+            writer.WriteLine("{0,-12} = {1}", "Width", Width);
+            writer.WriteLine("{0,-12} = {1}", "Height", Height);
+            writer.WriteLine("{0,-12} = {1}", "Depth", Depth);
+            writer.WriteLine("{0,-12} = {1}", "NonPow2W", NonPow2Width);
+            writer.WriteLine("{0,-12} = {1}", "NonPow2H", NonPow2Height);
+            writer.WriteLine("{0,-12} = ( {1:F6}, {2:F6}, {3:F6}, {4:F6} )", "Reflectivity", Reflectivity[0], Reflectivity[1], Reflectivity[2], Reflectivity[3]);
+            writer.WriteLine("{0,-12} = {1}", "NumMipLevels", NumMipLevels);
+            writer.WriteLine("{0,-12} = {1}", "Picmip0Res", Picmip0Res);
+            writer.WriteLine("{0,-12} = {1} (VTEX_FORMAT_{2})", "Format", (int)Format, Format);
+            writer.WriteLine("{0,-12} = 0x{1:X8}", "Flags", (int)Flags);
+
+            foreach (Enum value in Enum.GetValues(Flags.GetType()))
             {
-                writer.WriteLine("{0,-12} = {1}", "VTEX Version", Version);
-                writer.WriteLine("{0,-12} = {1}", "Width", Width);
-                writer.WriteLine("{0,-12} = {1}", "Height", Height);
-                writer.WriteLine("{0,-12} = {1}", "Depth", Depth);
-                writer.WriteLine("{0,-12} = {1}", "NonPow2W", NonPow2Width);
-                writer.WriteLine("{0,-12} = {1}", "NonPow2H", NonPow2Height);
-                writer.WriteLine("{0,-12} = ( {1:F6}, {2:F6}, {3:F6}, {4:F6} )", "Reflectivity", Reflectivity[0], Reflectivity[1], Reflectivity[2], Reflectivity[3]);
-                writer.WriteLine("{0,-12} = {1}", "NumMipLevels", NumMipLevels);
-                writer.WriteLine("{0,-12} = {1}", "Picmip0Res", Picmip0Res);
-                writer.WriteLine("{0,-12} = {1} (VTEX_FORMAT_{2})", "Format", (int)Format, Format);
-                writer.WriteLine("{0,-12} = 0x{1:X8}", "Flags", (int)Flags);
-
-                foreach (Enum value in Enum.GetValues(Flags.GetType()))
+                if (Flags.HasFlag(value))
                 {
-                    if (Flags.HasFlag(value))
-                    {
-                        writer.WriteLine("{0,-12} | 0x{1:X8} = VTEX_FLAG_{2}", string.Empty, Convert.ToInt32(value), value);
-                    }
+                    writer.WriteLine("{0,-12} | 0x{1:X8} = VTEX_FLAG_{2}", string.Empty, Convert.ToInt32(value), value);
                 }
-
-                writer.WriteLine("{0,-12} = {1} entries:", "Extra Data", ExtraData.Count);
-
-                var entry = 0;
-
-                foreach (var b in ExtraData)
-                {
-                    writer.WriteLine("{0,-12}   [ Entry {1}: VTEX_EXTRA_DATA_{2} - {3} bytes ]", string.Empty, entry++, b.Key, b.Value.Length);
-
-                    if (b.Key == VTexExtraData.COMPRESSED_MIP_SIZE)
-                    {
-                        writer.WriteLine("{0,-16}   [ {1} mips, sized: {2} ]", string.Empty, CompressedMips.Length, string.Join(", ", CompressedMips));
-                    }
-                }
-
-                for (var j = 0; j < NumMipLevels; j++)
-                {
-                    writer.WriteLine($"Mip level {j} - buffer size: {CalculateBufferSizeForMipLevel(j)}");
-                }
-
-                return writer.ToString();
             }
+
+            writer.WriteLine("{0,-12} = {1} entries:", "Extra Data", ExtraData.Count);
+
+            var entry = 0;
+
+            foreach (var b in ExtraData)
+            {
+                writer.WriteLine("{0,-12}   [ Entry {1}: VTEX_EXTRA_DATA_{2} - {3} bytes ]", string.Empty, entry++, b.Key, b.Value.Length);
+
+                if (b.Key == VTexExtraData.COMPRESSED_MIP_SIZE)
+                {
+                    writer.WriteLine("{0,-16}   [ {1} mips, sized: {2} ]", string.Empty, CompressedMips.Length, string.Join(", ", CompressedMips));
+                }
+            }
+
+            for (var j = 0; j < NumMipLevels; j++)
+            {
+                writer.WriteLine($"Mip level {j} - buffer size: {CalculateBufferSizeForMipLevel(j)}");
+            }
+
+            return writer.ToString();
         }
     }
 }

--- a/ValveResourceFormat/Utils/ExtensionAttribute.cs
+++ b/ValveResourceFormat/Utils/ExtensionAttribute.cs
@@ -1,9 +1,9 @@
-﻿using System;
+using System;
 
 namespace ValveResourceFormat
 {
     [AttributeUsage(AttributeTargets.Field)]
-    public class ExtensionAttribute : Attribute
+    public sealed class ExtensionAttribute : Attribute
     {
         public string Extension { get; }
 

--- a/ValveResourceFormat/ValveResourceFormat.csproj
+++ b/ValveResourceFormat/ValveResourceFormat.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Supercedes #316.

I've suppressed the warnings that I think should be fixed at some point as "suggestions" so that they show up in the Error List in VS with code fixes where applicable.

The warnings I don't think are relevant I have either suppressed inline or disabled completely.

Warnings that were easy to fix I have fixed.

Unfortunately I couldn't disable CA1014 so I've added `[assembly: ClsCompliant(false)]` to all projects.