### PR TITLE
Add list resources option to decompiler

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -72,6 +72,9 @@ namespace Decompiler
         [Option("-f|--vpk_filepath", "File path filter, example: panorama\\ or \"panorama\\\\\"", CommandOptionType.SingleValue)]
         public string FileFilter { get; private set; }
 
+        [Option("-l|--vpk_list", "Lists all resources in given VPK. File extension and path filters apply.", CommandOptionType.NoValue)]
+        public bool ListResources { get; }
+
         private string[] ExtFilterList;
         private bool IsInputFolder;
 
@@ -610,6 +613,21 @@ namespace Decompiler
                 if (ExtFilterList != null)
                 {
                     orderedEntries = orderedEntries.Where(x => ExtFilterList.Contains(x.Key)).ToList();
+                }
+
+                if (ListResources)
+                {
+                    var listEntries = orderedEntries.SelectMany(x => x.Value);
+                    foreach (var entry in listEntries)
+                    {
+                        var filePath = FixPathSlashes(entry.GetFullPath());
+                        if (FileFilter != null && !filePath.StartsWith(FileFilter, StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
+                        Console.WriteLine("\t{0}", filePath);
+                    }
+                    return;
                 }
 
                 if (CollectStats)


### PR DESCRIPTION
This PR introduces the `-l` / `--vpk_list` option to the decompiler which – when given – lists resources in the given VPK. Any given file path or file extension filter is taken into account. This option is silently ignored when used in combination with `--output`.

Its listing in help is as follows:

```
  -f|--vpk_filepath    File path filter, example: panorama\ or "panorama\\"
  -l|--vpk_list        Lists all resources in given VPK. File extension and path filters apply.
  -?|-h|--help         Show help information
```

Examples of usage:

```
$ ./Decompiler -i dota/pak01_dir.vpk -e vmdl_c -f models/creeps/roshan/ -l
--- Listing files in package "./dota/pak01_dir.vpk" ---
--- Files in package:
	models/creeps/roshan/aegis.vmdl_c
	models/creeps/roshan/babyroshan_statue.vmdl_c
	models/creeps/roshan/roshan.vmdl_c
	models/creeps/roshan/roshan_hat_fx.vmdl_c
```

```
$ ./Decompiler -i dota/pak01_dir.vpk -e vmesh_c -f models/creeps/roshan/ -l
--- Listing files in package "./dota/pak01_dir.vpk" ---
--- Files in package:
	models/creeps/roshan/aegis_model.vmesh_c
	models/creeps/roshan/babyroshan_statue.vmesh_c
	models/creeps/roshan/roshan_hat_fx_model.vmesh_c
```

Checking the (approximate) total amount of files included by passing the VRF output into `wc`'s line count:

```
$ ./Decompiler -i dota/pak01_dir.vpk -e vmdl_c -f models/creeps/roshan/ -l | wc -l
  293678
```