### PR TITLE
Add glTF export format and export materials options to decompiler

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -75,6 +75,12 @@ namespace Decompiler
         [Option("-l|--vpk_list", "Lists all resources in given VPK. File extension and path filters apply.", CommandOptionType.NoValue)]
         public bool ListResources { get; }
 
+        [Option("--gltf_export_format", "Exports meshes/models in given glTF format. Must be either 'gltf' (default) or 'glb'", CommandOptionType.SingleValue)]
+        public string GltfExportFormat { get; } = "gltf";
+
+        [Option("--gltf_export_materials", "Whether to export materials during glTF exports (warning: slow!)", CommandOptionType.NoValue)]
+        public bool GltfExportMaterials { get; }
+
         private string[] ExtFilterList;
         private bool IsInputFolder;
 
@@ -106,6 +112,13 @@ namespace Decompiler
             if (ExtFilter != null)
             {
                 ExtFilterList = ExtFilter.Split(',');
+            }
+
+            if (GltfExportFormat != "gltf" && GltfExportFormat != "glb")
+            {
+                Console.Error.WriteLine("glTF export format must be either 'gltf' or 'glb'.");
+
+                return 1;
             }
 
             var paths = new List<string>();
@@ -780,13 +793,14 @@ namespace Decompiler
                         // TODO: Hook this up in FileExtract
                         if (resource.ResourceType == ResourceType.Mesh || resource.ResourceType == ResourceType.Model)
                         {
-                            var outputFile = Path.Combine(OutputFile, Path.ChangeExtension(filePath, "gltf"));
+                            var outputExtension = GltfExportFormat;
+                            var outputFile = Path.Combine(OutputFile, Path.ChangeExtension(filePath, outputExtension));
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
 
                             var exporter = new GltfModelExporter
                             {
-                                ExportMaterials = false,
+                                ExportMaterials = GltfExportMaterials,
                                 ProgressReporter = new ConsoleProgressReporter(),
                                 FileLoader = fileLoader
                             };


### PR DESCRIPTION
This PR introduces two glTF export related options to the decompiler:

- `--gltf_export_materials`: export materials during glTF exports
- `--gltf_export_format`: allows specifying glTF export format, either JSON (`gltf`, the default) or binary (`glb`)

The help for these options is as follows:

```
  -f|--vpk_filepath        File path filter, example: panorama\ or "panorama\\"
  -l|--vpk_list            Lists all resources in given VPK. File extension and path filters apply.
  --gltf_export_format     Exports meshes/models in given glTF format. Must be either 'gltf'
                           (default) or 'glb'
  --gltf_export_materials  Whether to export materials during glTF exports (warning: slow!)
  -?|-h|--help             Show help information
```

Exporting materials with the default JSON-based glTF format:

```
$ ./Decompiler -i dota/pak01_dir.vpk --gltf_export_materials -f models/courier/navi_courier/navi_courier_flying.vmdl_c -d -o extract
$ tree extract/models/courier/navi_courier
extract/models/courier/navi_courier
├── navi_courier_flying.bin
├── navi_courier_flying.gltf
├── navi_courier_flying_0.png
├── navi_courier_flying_1.png
├── navi_courier_flying_2.png
├── navi_courier_flying_3.png
└── navi_courier_flying_4.png
```

Exporting to the binary glTF format:

```
$ ./Decompiler -i dota/pak01_dir.vpk --gltf_export_format glb -f models/creeps/roshan/roshan.vmdl -d -o extract
$ tree -h extract/models/creeps/roshan
extract/models/creeps/roshan
└── [7.8M]  roshan.glb
```

Once more, but export materials, too:

```
$ ./Decompiler -i dota/pak01_dir.vpk --gltf_export_format glb --gltf_export_materials -f models/creeps/roshan/roshan.vmdl -d -o extract
$ tree -h extract/models/creeps/roshan
extract/models/creeps/roshan
└── [ 11M]  roshan.glb
```