### PR TITLE
Old mesh format support. Additional VBIB information. Tinted materials export

### DIFF
--- a/GUI/Types/Renderer/GPUMeshBufferCache.cs
+++ b/GUI/Types/Renderer/GPUMeshBufferCache.cs
@@ -56,17 +56,17 @@ namespace GUI.Types.Renderer
 
                 var curVertexBuffer = vbib.VertexBuffers[(int)vtxIndex];
                 var texCoordNum = 0;
-                foreach (var attribute in curVertexBuffer.Attributes)
+                foreach (var attribute in curVertexBuffer.InputLayoutFields)
                 {
-                    var attributeName = "v" + attribute.Name;
+                    var attributeName = "v" + attribute.SemanticName;
 
                     // TODO: other params too?
-                    if (attribute.Name == "TEXCOORD" && texCoordNum++ > 0)
+                    if (attribute.SemanticName == "TEXCOORD" && texCoordNum++ > 0)
                     {
                         attributeName += texCoordNum;
                     }
 
-                    BindVertexAttrib(attribute, attributeName, shader.Program, (int)curVertexBuffer.Size);
+                    BindVertexAttrib(attribute, attributeName, shader.Program, (int)curVertexBuffer.ElementSizeInBytes);
                 }
 
                 GL.BindVertexArray(0);
@@ -76,7 +76,7 @@ namespace GUI.Types.Renderer
             }
         }
 
-        private static void BindVertexAttrib(VBIB.VertexAttribute attribute, string attributeName, int shaderProgram, int stride)
+        private static void BindVertexAttrib(VBIB.RenderInputLayoutField attribute, string attributeName, int shaderProgram, int stride)
         {
             var attributeLocation = GL.GetAttribLocation(shaderProgram, attributeName);
 
@@ -88,7 +88,7 @@ namespace GUI.Types.Renderer
 
             GL.EnableVertexAttribArray(attributeLocation);
 
-            switch (attribute.Type)
+            switch (attribute.Format)
             {
                 case DXGI_FORMAT.R32G32B32_FLOAT:
                     GL.VertexAttribPointer(attributeLocation, 3, VertexAttribPointerType.Float, false, stride, (IntPtr)attribute.Offset);
@@ -127,7 +127,7 @@ namespace GUI.Types.Renderer
                     break;
 
                 default:
-                    throw new Exception("Unknown attribute format " + attribute.Type);
+                    throw new Exception("Unknown attribute format " + attribute.Format);
             }
         }
     }

--- a/GUI/Types/Renderer/GPUMeshBuffers.cs
+++ b/GUI/Types/Renderer/GPUMeshBuffers.cs
@@ -27,7 +27,7 @@ namespace GUI.Types.Renderer
             {
                 VertexBuffers[i].Handle = (uint)GL.GenBuffer();
                 GL.BindBuffer(BufferTarget.ArrayBuffer, VertexBuffers[i].Handle);
-                GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vbib.VertexBuffers[i].Count * vbib.VertexBuffers[i].Size), vbib.VertexBuffers[i].Buffer, BufferUsageHint.StaticDraw);
+                GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(vbib.VertexBuffers[i].ElementCount * vbib.VertexBuffers[i].ElementSizeInBytes), vbib.VertexBuffers[i].Data, BufferUsageHint.StaticDraw);
 
                 GL.GetBufferParameter(BufferTarget.ArrayBuffer, BufferParameterName.BufferSize, out VertexBuffers[i].Size);
             }
@@ -36,7 +36,7 @@ namespace GUI.Types.Renderer
             {
                 IndexBuffers[i].Handle = (uint)GL.GenBuffer();
                 GL.BindBuffer(BufferTarget.ElementArrayBuffer, IndexBuffers[i].Handle);
-                GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(vbib.IndexBuffers[i].Count * vbib.IndexBuffers[i].Size), vbib.IndexBuffers[i].Buffer, BufferUsageHint.StaticDraw);
+                GL.BufferData(BufferTarget.ElementArrayBuffer, (IntPtr)(vbib.IndexBuffers[i].ElementCount * vbib.IndexBuffers[i].ElementSizeInBytes), vbib.IndexBuffers[i].Data, BufferUsageHint.StaticDraw);
 
                 GL.GetBufferParameter(BufferTarget.ElementArrayBuffer, BufferParameterName.BufferSize, out IndexBuffers[i].Size);
             }

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -166,12 +166,6 @@ namespace GUI.Types.Renderer
                     continue;
                 }
 
-                if (!newResource.ContainsBlockType(BlockType.VBIB))
-                {
-                    Console.WriteLine("Old style model, no VBIB!");
-                    continue;
-                }
-
                 meshRenderers.Add(new RenderableMesh(new Mesh(newResource), Scene.GuiContext, skinMaterials));
             }
 

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -92,12 +92,7 @@ namespace GUI.Types.Renderer
 
                 foreach (var objectDrawCall in objectDrawCalls)
                 {
-                    var materialName = objectDrawCall.GetProperty<string>("m_material");
-
-                    if(materialName == null)
-                    {
-                        materialName = objectDrawCall.GetProperty<string>("m_pMaterial");
-                    }
+                    var materialName = objectDrawCall.GetProperty<string>("m_material") ?? objectDrawCall.GetProperty<string>("m_pMaterial");
 
                     if (skinMaterials != null && skinMaterials.ContainsKey(materialName))
                     {

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -140,8 +140,8 @@ namespace GUI.Types.Renderer
             {
                 string primitiveTypeString => primitiveTypeString,
                 byte primitiveTypeByte =>
-                (primitiveTypeByte == 5) ? "RENDER_PRIM_TRIANGLES" : "UNKNOWN",
-                _ => throw new Exception("Unknown PrimitiveType in drawCall!")
+                (primitiveTypeByte == 5) ? "RENDER_PRIM_TRIANGLES" : ("UNKNOWN_" + primitiveTypeByte),
+                _ => throw new NotImplementedException("Unknown PrimitiveType in drawCall!")
             };
 
             switch (primitiveType)
@@ -150,7 +150,7 @@ namespace GUI.Types.Renderer
                     drawCall.PrimitiveType = PrimitiveType.Triangles;
                     break;
                 default:
-                    throw new Exception("Unknown PrimitiveType in drawCall! (" + objectDrawCall.GetProperty<string>("m_nPrimitiveType") + ")");
+                    throw new NotImplementedException("Unknown PrimitiveType in drawCall! (" + primitiveType + ")");
             }
 
             drawCall.Material = material;

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -177,7 +177,7 @@ namespace GUI.Types.Renderer
             indexBuffer.Offset = Convert.ToUInt32(indexBufferObject.GetProperty<object>("m_nBindOffsetBytes"));
             drawCall.IndexBuffer = indexBuffer;
 
-            var indexElementSize = vbib.IndexBuffers[(int)drawCall.IndexBuffer.Id].Size;
+            var indexElementSize = vbib.IndexBuffers[(int)drawCall.IndexBuffer.Id].ElementSizeInBytes;
             //drawCall.BaseVertex = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nBaseVertex"));
             //drawCall.VertexCount = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nVertexCount"));
             drawCall.StartIndex = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nStartIndex")) * indexElementSize;

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -170,11 +170,6 @@ namespace GUI.Types.Viewers
                     break;
 
                 case ResourceType.Mesh:
-                    if (!resource.ContainsBlockType(BlockType.VBIB))
-                    {
-                        Console.WriteLine("Old style model, no VBIB!");
-                        break;
-                    }
 
                     Program.MainForm.Invoke(new ExportDel(AddToExport), resTabs, $"Export {Path.GetFileName(vrfGuiContext.FileName)} as glTF",
                         vrfGuiContext.FileName, new ExportData {Resource = resource, VrfGuiContext = vrfGuiContext});

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -323,7 +323,23 @@ namespace ValveResourceFormat.IO
                     var startIndex = (int)drawCall.GetIntegerProperty("m_nStartIndex");
                     var indexCount = (int)drawCall.GetIntegerProperty("m_nIndexCount");
                     var indices = ReadIndices(indexBuffer, startIndex, indexCount);
-                    primitive.WithIndicesAccessor(PrimitiveType.TRIANGLES, indices);//TODO use m_nPrimitiveType
+
+                    string primitiveType = drawCall.GetProperty<object>("m_nPrimitiveType") switch
+                    {
+                        string primitiveTypeString => primitiveTypeString,
+                        byte primitiveTypeByte =>
+                        (primitiveTypeByte == 5) ? "RENDER_PRIM_TRIANGLES" : ("UNKNOWN_" + primitiveTypeByte),
+                        _ => throw new NotImplementedException("Unknown PrimitiveType in drawCall!")
+                    };
+
+                    switch (primitiveType)
+                    {
+                        case "RENDER_PRIM_TRIANGLES":
+                            primitive.WithIndicesAccessor(PrimitiveType.TRIANGLES, indices);
+                            break;
+                        default:
+                            throw new NotImplementedException("Unknown PrimitiveType in drawCall! (" + primitiveType + ")");
+                    }
 
                     // Add material
                     if (!ExportMaterials)

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -513,6 +513,11 @@ namespace ValveResourceFormat.IO
                 }
             }
 
+            if (renderMaterial.VectorParams.TryGetValue("g_vColorTint", out var vColorTint))
+            {
+                material.WithChannelParameter("BaseColor", vColorTint);
+            }
+
             return material;
         }
 

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -217,16 +217,16 @@ namespace ValveResourceFormat.IO
                     var attributeCounters = new Dictionary<string, int>();
 
                     // Set vertex attributes
-                    foreach (var attribute in vertexBuffer.Attributes)
+                    foreach (var attribute in vertexBuffer.InputLayoutFields)
                     {
-                        attributeCounters.TryGetValue(attribute.Name, out var attributeCounter);
-                        attributeCounters[attribute.Name] = attributeCounter + 1;
-                        var accessorName = GetAccessorName(attribute.Name, attributeCounter);
+                        attributeCounters.TryGetValue(attribute.SemanticName, out var attributeCounter);
+                        attributeCounters[attribute.SemanticName] = attributeCounter + 1;
+                        var accessorName = GetAccessorName(attribute.SemanticName, attributeCounter);
 
                         var buffer = ReadAttributeBuffer(vertexBuffer, attribute);
-                        var numComponents = buffer.Length / vertexBuffer.Count;
+                        var numComponents = buffer.Length / vertexBuffer.ElementCount;
 
-                        if (attribute.Name == "BLENDINDICES")
+                        if (attribute.SemanticName == "BLENDINDICES")
                         {
                             if (!includeJoints)
                             {
@@ -246,7 +246,7 @@ namespace ValveResourceFormat.IO
                             continue;
                         }
 
-                        if (attribute.Name == "NORMAL" && VMesh.IsCompressedNormalTangent(drawCall))
+                        if (attribute.SemanticName == "NORMAL" && VMesh.IsCompressedNormalTangent(drawCall))
                         {
                             var vectors = ToVector4Array(buffer);
                             var (normals, tangents) = DecompressNormalTangents(vectors);
@@ -256,7 +256,7 @@ namespace ValveResourceFormat.IO
                             continue;
                         }
 
-                        if (attribute.Name == "TEXCOORD" && numComponents != 2)
+                        if (attribute.SemanticName == "TEXCOORD" && numComponents != 2)
                         {
                             // We are ignoring some data, but non-2-component UVs cause failures in gltf consumers
                             continue;
@@ -269,7 +269,7 @@ namespace ValveResourceFormat.IO
                                     var vectors = ToVector4Array(buffer);
 
                                     // dropship.vmdl in HL:A has a tanget with value of <0, -0, 0>
-                                    if (attribute.Name == "NORMAL" || attribute.Name == "TANGENT")
+                                    if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
                                     {
                                         vectors = FixZeroLengthVectors(vectors);
                                     }
@@ -283,7 +283,7 @@ namespace ValveResourceFormat.IO
                                     var vectors = ToVector3Array(buffer);
 
                                     // dropship.vmdl in HL:A has a normal with value of <0, 0, 0>
-                                    if (attribute.Name == "NORMAL" || attribute.Name == "TANGENT")
+                                    if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
                                     {
                                         vectors = FixZeroLengthVectors(vectors);
                                     }
@@ -306,7 +306,7 @@ namespace ValveResourceFormat.IO
                                 }
 
                             default:
-                                throw new NotImplementedException($"Attribute \"{attribute.Name}\" has {numComponents} components");
+                                throw new NotImplementedException($"Attribute \"{attribute.SemanticName}\" has {numComponents} components");
                         }
                     }
 
@@ -571,26 +571,26 @@ namespace ValveResourceFormat.IO
             return name;
         }
 
-        private static float[] ReadAttributeBuffer(VertexBuffer buffer, VertexAttribute attribute)
-            => Enumerable.Range(0, (int)buffer.Count)
+        private static float[] ReadAttributeBuffer(OnDiskBufferData buffer, RenderInputLayoutField attribute)
+            => Enumerable.Range(0, (int)buffer.ElementCount)
                 .SelectMany(i => VBIB.ReadVertexAttribute(i, buffer, attribute))
                 .ToArray();
 
-        private static int[] ReadIndices(IndexBuffer indexBuffer, int start, int count)
+        private static int[] ReadIndices(OnDiskBufferData indexBuffer, int start, int count)
         {
             var indices = new int[count];
 
-            var byteCount = count * (int)indexBuffer.Size;
-            var byteStart = start * (int)indexBuffer.Size;
+            var byteCount = count * (int)indexBuffer.ElementSizeInBytes;
+            var byteStart = start * (int)indexBuffer.ElementSizeInBytes;
 
-            if (indexBuffer.Size == 4)
+            if (indexBuffer.ElementSizeInBytes == 4)
             {
-                System.Buffer.BlockCopy(indexBuffer.Buffer, byteStart, indices, 0, byteCount);
+                System.Buffer.BlockCopy(indexBuffer.Data, byteStart, indices, 0, byteCount);
             }
-            else if (indexBuffer.Size == 2)
+            else if (indexBuffer.ElementSizeInBytes == 2)
             {
                 var shortIndices = new ushort[count];
-                System.Buffer.BlockCopy(indexBuffer.Buffer, byteStart, shortIndices, 0, byteCount);
+                System.Buffer.BlockCopy(indexBuffer.Data, byteStart, shortIndices, 0, byteCount);
                 indices = Array.ConvertAll(shortIndices, i => (int)i);
             }
 

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -331,12 +331,7 @@ namespace ValveResourceFormat.IO
                         continue;
                     }
 
-                    var materialPath = drawCall.GetProperty<string>("m_material");
-
-                    if (materialPath == null)
-                    {
-                        materialPath = drawCall.GetProperty<string>("m_pMaterial");
-                    }
+                    var materialPath = drawCall.GetProperty<string>("m_material") ?? drawCall.GetProperty<string>("m_pMaterial");
 
                     ProgressReporter?.SetProgress($"Loading material: {materialPath}");
 

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -323,7 +323,7 @@ namespace ValveResourceFormat.IO
                     var startIndex = (int)drawCall.GetIntegerProperty("m_nStartIndex");
                     var indexCount = (int)drawCall.GetIntegerProperty("m_nIndexCount");
                     var indices = ReadIndices(indexBuffer, startIndex, indexCount);
-                    primitive.WithIndicesAccessor(PrimitiveType.TRIANGLES, indices);
+                    primitive.WithIndicesAccessor(PrimitiveType.TRIANGLES, indices);//TODO use m_nPrimitiveType
 
                     // Add material
                     if (!ExportMaterials)
@@ -332,6 +332,11 @@ namespace ValveResourceFormat.IO
                     }
 
                     var materialPath = drawCall.GetProperty<string>("m_material");
+
+                    if (materialPath == null)
+                    {
+                        materialPath = drawCall.GetProperty<string>("m_pMaterial");
+                    }
 
                     ProgressReporter?.SetProgress($"Loading material: {materialPath}");
 

--- a/ValveResourceFormat/Resource/Blocks/VBIB.cs
+++ b/ValveResourceFormat/Resource/Blocks/VBIB.cs
@@ -13,37 +13,34 @@ namespace ValveResourceFormat.Blocks
     {
         public override BlockType Type => BlockType.VBIB;
 
-        public List<VertexBuffer> VertexBuffers { get; }
-        public List<IndexBuffer> IndexBuffers { get; }
+        public List<OnDiskBufferData> VertexBuffers { get; }
+        public List<OnDiskBufferData> IndexBuffers { get; }
 
 #pragma warning disable CA1051 // Do not declare visible instance fields
-        public struct VertexBuffer
+        public struct OnDiskBufferData
         {
-            public uint Count;
-            public uint Size;
-            public List<VertexAttribute> Attributes;
-            public byte[] Buffer;
+            public uint ElementCount;
+            public uint ElementSizeInBytes;
+            public List<RenderInputLayoutField> InputLayoutFields;
+            public byte[] Data;
         }
 
-        public struct VertexAttribute
+        public struct RenderInputLayoutField
         {
-            public string Name;
-            public DXGI_FORMAT Type;
+            public string SemanticName;
+            public int SemanticIndex;
+            public DXGI_FORMAT Format;
             public uint Offset;
-        }
-
-        public struct IndexBuffer
-        {
-            public uint Count;
-            public uint Size;
-            public byte[] Buffer;
+            public int Slot;
+            public RenderSlotType SlotType;
+            public int InstanceStepRate;
         }
 #pragma warning restore CA1051 // Do not declare visible instance fields
 
         public VBIB()
         {
-            VertexBuffers = new List<VertexBuffer>();
-            IndexBuffers = new List<IndexBuffer>();
+            VertexBuffers = new List<OnDiskBufferData>();
+            IndexBuffers = new List<OnDiskBufferData>();
         }
 
         public override void Read(BinaryReader reader, Resource resource)
@@ -58,121 +55,105 @@ namespace ValveResourceFormat.Blocks
             reader.BaseStream.Position = Offset + vertexBufferOffset;
             for (var i = 0; i < vertexBufferCount; i++)
             {
-                var vertexBuffer = default(VertexBuffer);
+                var vertexBuffer = ReadOnDiskBufferData(reader);
 
-                vertexBuffer.Count = reader.ReadUInt32();            //0
-                vertexBuffer.Size = reader.ReadUInt32();             //4
-                var decompressedSize = vertexBuffer.Count * vertexBuffer.Size;
-
-                var refA = reader.BaseStream.Position;
-                var attributeOffset = reader.ReadUInt32();  //8
-                var attributeCount = reader.ReadUInt32();   //12
-
-                //TODO: Read attributes in the future
-                var refB = reader.BaseStream.Position;
-                var dataOffset = reader.ReadUInt32();       //16
-                var totalSize = reader.ReadUInt32();        //20
-
-                vertexBuffer.Attributes = new List<VertexAttribute>();
-
-                reader.BaseStream.Position = refA + attributeOffset;
-                for (var j = 0; j < attributeCount; j++)
+                var decompressedSize = vertexBuffer.ElementCount * vertexBuffer.ElementSizeInBytes;
+                if (vertexBuffer.Data.Length != decompressedSize)
                 {
-                    var previousPosition = reader.BaseStream.Position;
-
-                    var attribute = default(VertexAttribute);
-
-                    attribute.Name = reader.ReadNullTermString(Encoding.UTF8).ToUpperInvariant();
-
-                    // Offset is always 40 bytes from the start
-                    reader.BaseStream.Position = previousPosition + 36;
-
-                    attribute.Type = (DXGI_FORMAT)reader.ReadUInt32();
-                    attribute.Offset = reader.ReadUInt32();
-
-                    // There's unusual amount of padding in attributes
-                    reader.BaseStream.Position = previousPosition + 56;
-
-                    vertexBuffer.Attributes.Add(attribute);
-                }
-
-                reader.BaseStream.Position = refB + dataOffset;
-
-                var vertexBufferBytes = reader.ReadBytes((int)totalSize);
-                if (totalSize == decompressedSize)
-                {
-                    vertexBuffer.Buffer = vertexBufferBytes;
-                }
-                else
-                {
-                    vertexBuffer.Buffer = MeshOptimizerVertexDecoder.DecodeVertexBuffer((int)vertexBuffer.Count, (int)vertexBuffer.Size, vertexBufferBytes);
+                    vertexBuffer.Data = MeshOptimizerVertexDecoder.DecodeVertexBuffer((int)vertexBuffer.ElementCount, (int)vertexBuffer.ElementSizeInBytes, vertexBuffer.Data);
                 }
 
                 VertexBuffers.Add(vertexBuffer);
-
-                reader.BaseStream.Position = refB + 4 + 4; //Go back to the vertex array to read the next iteration
             }
 
             reader.BaseStream.Position = Offset + 8 + indexBufferOffset; //8 to take into account vertexOffset / count
             for (var i = 0; i < indexBufferCount; i++)
             {
-                var indexBuffer = default(IndexBuffer);
+                var indexBuffer = ReadOnDiskBufferData(reader);
 
-                indexBuffer.Count = reader.ReadUInt32();        //0
-                indexBuffer.Size = reader.ReadUInt32();         //4
-                var decompressedSize = indexBuffer.Count * indexBuffer.Size;
-
-                var unknown1 = reader.ReadUInt32();     //8
-                var unknown2 = reader.ReadUInt32();     //12
-
-                var refC = reader.BaseStream.Position;
-                var dataOffset = reader.ReadUInt32();   //16
-                var dataSize = reader.ReadUInt32();     //20
-
-                reader.BaseStream.Position = refC + dataOffset;
-
-                if (dataSize == decompressedSize)
+                var decompressedSize = indexBuffer.ElementCount * indexBuffer.ElementSizeInBytes;
+                if (indexBuffer.Data.Length != decompressedSize)
                 {
-                    indexBuffer.Buffer = reader.ReadBytes((int)dataSize);
-                }
-                else
-                {
-                    indexBuffer.Buffer = MeshOptimizerIndexDecoder.DecodeIndexBuffer((int)indexBuffer.Count, (int)indexBuffer.Size, reader.ReadBytes((int)dataSize));
+                    indexBuffer.Data = MeshOptimizerIndexDecoder.DecodeIndexBuffer((int)indexBuffer.ElementCount, (int)indexBuffer.ElementSizeInBytes, indexBuffer.Data);
                 }
 
                 IndexBuffers.Add(indexBuffer);
-
-                reader.BaseStream.Position = refC + 4 + 4; //Go back to the index array to read the next iteration.
             }
         }
 
-        public static float[] ReadVertexAttribute(int offset, VertexBuffer vertexBuffer, VertexAttribute attribute)
+        private static OnDiskBufferData ReadOnDiskBufferData(BinaryReader reader)
+        {
+            var buffer = default(OnDiskBufferData);
+
+            buffer.ElementCount = reader.ReadUInt32();            //0
+            buffer.ElementSizeInBytes = reader.ReadUInt32();      //4
+
+            var refA = reader.BaseStream.Position;
+            var attributeOffset = reader.ReadUInt32();  //8
+            var attributeCount = reader.ReadUInt32();   //12
+
+            //TODO: Read attributes in the future
+            var refB = reader.BaseStream.Position;
+            var dataOffset = reader.ReadUInt32();       //16
+            var totalSize = reader.ReadUInt32();        //20
+
+            buffer.InputLayoutFields = new List<RenderInputLayoutField>();
+
+            reader.BaseStream.Position = refA + attributeOffset;
+            for (var j = 0; j < attributeCount; j++)
+            {
+                var attribute = default(RenderInputLayoutField);
+
+                var previousPosition = reader.BaseStream.Position;
+                attribute.SemanticName = reader.ReadNullTermString(Encoding.UTF8).ToUpperInvariant();
+                reader.BaseStream.Position = previousPosition + 32;
+
+                attribute.SemanticIndex = reader.ReadInt32();
+                attribute.Format = (DXGI_FORMAT)reader.ReadUInt32();
+                attribute.Offset = reader.ReadUInt32();
+                attribute.Slot = reader.ReadInt32();
+                attribute.SlotType = (RenderSlotType)reader.ReadUInt32();
+                attribute.InstanceStepRate = reader.ReadInt32();
+
+                buffer.InputLayoutFields.Add(attribute);
+            }
+
+            reader.BaseStream.Position = refB + dataOffset;
+
+            buffer.Data = reader.ReadBytes((int)totalSize);
+
+            reader.BaseStream.Position = refB + 8; //Go back to the index array to read the next iteration.
+
+            return buffer;
+        }
+
+        public static float[] ReadVertexAttribute(int offset, OnDiskBufferData vertexBuffer, RenderInputLayoutField attribute)
         {
             float[] result;
 
-            offset = (int)(offset * vertexBuffer.Size) + (int)attribute.Offset;
+            offset = (int)(offset * vertexBuffer.ElementSizeInBytes) + (int)attribute.Offset;
 
             // Useful reference: https://github.com/apitrace/dxsdk/blob/master/Include/d3dx_dxgiformatconvert.inl
-            switch (attribute.Type)
+            switch (attribute.Format)
             {
                 case DXGI_FORMAT.R32G32B32_FLOAT:
                 {
                     result = new float[3];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, result, 0, 12);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, result, 0, 12);
                     break;
                 }
 
                 case DXGI_FORMAT.R32G32B32A32_FLOAT:
                 {
                     result = new float[4];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, result, 0, 16);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, result, 0, 16);
                     break;
                 }
 
                 case DXGI_FORMAT.R16G16_UNORM:
                 {
                     var shorts = new ushort[2];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, shorts, 0, 4);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, shorts, 0, 4);
 
                     result = new[]
                     {
@@ -185,7 +166,7 @@ namespace ValveResourceFormat.Blocks
                 case DXGI_FORMAT.R16G16_FLOAT:
                 {
                     var shorts = new ushort[2];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, shorts, 0, 4);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, shorts, 0, 4);
 
                     result = new[]
                     {
@@ -198,21 +179,21 @@ namespace ValveResourceFormat.Blocks
                 case DXGI_FORMAT.R32_FLOAT:
                 {
                     result = new float[1];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, result, 0, 4);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, result, 0, 4);
                     break;
                 }
 
                 case DXGI_FORMAT.R32G32_FLOAT:
                 {
                     result = new float[2];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, result, 0, 8);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, result, 0, 8);
                     break;
                 }
 
                 case DXGI_FORMAT.R16G16_SINT:
                 {
                     var shorts = new short[2];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, shorts, 0, 4);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, shorts, 0, 4);
 
                     result = new float[2];
                     for (var i = 0; i < 2; i++)
@@ -226,7 +207,7 @@ namespace ValveResourceFormat.Blocks
                 case DXGI_FORMAT.R16G16B16A16_SINT:
                 {
                     var shorts = new short[4];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, shorts, 0, 8);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, shorts, 0, 8);
 
                     result = new float[4];
                     for (var i = 0; i < 4; i++)
@@ -241,12 +222,12 @@ namespace ValveResourceFormat.Blocks
                 case DXGI_FORMAT.R8G8B8A8_UNORM:
                 {
                     var bytes = new byte[4];
-                    Buffer.BlockCopy(vertexBuffer.Buffer, offset, bytes, 0, 4);
+                    Buffer.BlockCopy(vertexBuffer.Data, offset, bytes, 0, 4);
 
                     result = new float[4];
                     for (var i = 0; i < 4; i++)
                     {
-                        result[i] = attribute.Type == DXGI_FORMAT.R8G8B8A8_UNORM
+                        result[i] = attribute.Format == DXGI_FORMAT.R8G8B8A8_UNORM
                             ? bytes[i] / 255f
                             : bytes[i];
                     }
@@ -255,7 +236,7 @@ namespace ValveResourceFormat.Blocks
                 }
 
                 default:
-                    throw new NotImplementedException($"Unsupported \"{attribute.Name}\" DXGI_FORMAT.{attribute.Type}");
+                    throw new NotImplementedException($"Unsupported \"{attribute.SemanticName}\" DXGI_FORMAT.{attribute.Format}");
             }
 
             return result;
@@ -267,15 +248,19 @@ namespace ValveResourceFormat.Blocks
 
             foreach (var vertexBuffer in VertexBuffers)
             {
-                writer.WriteLine($"Count: {vertexBuffer.Count}");
-                writer.WriteLine($"Size: {vertexBuffer.Size}");
+                writer.WriteLine($"Count: {vertexBuffer.ElementCount}");
+                writer.WriteLine($"Size: {vertexBuffer.ElementSizeInBytes}");
 
-                for (var i = 0; i < vertexBuffer.Attributes.Count; i++)
+                for (var i = 0; i < vertexBuffer.InputLayoutFields.Count; i++)
                 {
-                    var vertexAttribute = vertexBuffer.Attributes[i];
-                    writer.WriteLine($"Attribute[{i}].Name = {vertexAttribute.Name}");
+                    var vertexAttribute = vertexBuffer.InputLayoutFields[i];
+                    writer.WriteLine($"Attribute[{i}].SemanticName = {vertexAttribute.SemanticName}");
+                    writer.WriteLine($"Attribute[{i}].SemanticIndex = {vertexAttribute.SemanticIndex}");
                     writer.WriteLine($"Attribute[{i}].Offset = {vertexAttribute.Offset}");
-                    writer.WriteLine($"Attribute[{i}].Type = {vertexAttribute.Type}");
+                    writer.WriteLine($"Attribute[{i}].Format = {vertexAttribute.Format}");
+                    writer.WriteLine($"Attribute[{i}].Slot = {vertexAttribute.Slot}");
+                    writer.WriteLine($"Attribute[{i}].SlotType = {vertexAttribute.SlotType}");
+                    writer.WriteLine($"Attribute[{i}].InstanceStepRate = {vertexAttribute.InstanceStepRate}");
                 }
 
                 writer.WriteLine();
@@ -286,8 +271,8 @@ namespace ValveResourceFormat.Blocks
 
             foreach (var indexBuffer in IndexBuffers)
             {
-                writer.WriteLine($"Count: {indexBuffer.Count}");
-                writer.WriteLine($"Size: {indexBuffer.Size}");
+                writer.WriteLine($"Count: {indexBuffer.ElementCount}");
+                writer.WriteLine($"Size: {indexBuffer.ElementSizeInBytes}");
                 writer.WriteLine();
             }
         }

--- a/ValveResourceFormat/Resource/Enums/RenderSlotType.cs
+++ b/ValveResourceFormat/Resource/Enums/RenderSlotType.cs
@@ -1,0 +1,9 @@
+namespace ValveResourceFormat
+{
+    public enum RenderSlotType
+    {
+        RENDER_SLOT_INVALID = -1,
+        RENDER_SLOT_PER_VERTEX = 0,
+        RENDER_SLOT_PER_INSTANCE = 1
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/Mesh.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Mesh.cs
@@ -17,6 +17,7 @@ namespace ValveResourceFormat.ResourceTypes
         public Mesh(Resource resource)
         {
             Data = resource.DataBlock;
+            //new format has VBIB block, for old format we can get it from NTRO DATA block
             VBIB = resource.VBIB ?? new VBIB(GetData());
             GetBounds();
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/NTRO.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/NTRO.cs
@@ -138,14 +138,22 @@ namespace ValveResourceFormat.ResourceTypes
             //}
             if (field.Count > 0 || field.Indirections.Count > 0)
             {
-                var ntroValues = new NTROArray(field.Type, (int)count, pointer, field.Indirections.Count > 0);
-
-                for (var i = 0; i < count; i++)
+                if (field.Type == DataType.Byte)
                 {
-                    ntroValues[i] = ReadField(field, pointer);
+                    var ntroValues = new NTROValue<byte[]>(field.Type, Reader.ReadBytes((int)count), pointer);
+                    structEntry.Add(field.FieldName, ntroValues);
                 }
+                else
+                {
+                    var ntroValues = new NTROArray(field.Type, (int)count, pointer, field.Indirections.Count > 0);
 
-                structEntry.Add(field.FieldName, ntroValues);
+                    for (var i = 0; i < count; i++)
+                    {
+                        ntroValues[i] = ReadField(field, pointer);
+                    }
+
+                    structEntry.Add(field.FieldName, ntroValues);
+                }
             }
             else
             {

--- a/ValveResourceFormat/Resource/ResourceTypes/NTRO.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/NTRO.cs
@@ -140,6 +140,7 @@ namespace ValveResourceFormat.ResourceTypes
             {
                 if (field.Type == DataType.Byte)
                 {
+                    //special case for byte arrays for faster access
                     var ntroValues = new NTROValue<byte[]>(field.Type, Reader.ReadBytes((int)count), pointer);
                     structEntry.Add(field.FieldName, ntroValues);
                 }

--- a/ValveResourceFormat/Serialization/IKeyValueCollection.cs
+++ b/ValveResourceFormat/Serialization/IKeyValueCollection.cs
@@ -56,6 +56,12 @@ namespace ValveResourceFormat.Serialization
             return Convert.ToUInt64(value);
         }
 
+        public static int GetInt32Property(this IKeyValueCollection collection, string name)
+            => Convert.ToInt32(collection.GetProperty<object>(name));
+
+        public static uint GetUInt32Property(this IKeyValueCollection collection, string name)
+            => Convert.ToUInt32(collection.GetProperty<object>(name));
+
         public static double GetDoubleProperty(this IKeyValueCollection collection, string name)
             => Convert.ToDouble(collection.GetProperty<object>(name));
 

--- a/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
+++ b/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
@@ -183,12 +183,14 @@ namespace ValveResourceFormat.Serialization.NTRO
             {
                 if (value.Type == DataType.Byte)
                 {
+                    //special case for byte arrays for faster access
                     if (typeof(T) == typeof(byte))
                     {
                         return (T[])value.ValueObject;
                     }
                     else
                     {
+                        //still have to do a slow conversion if the requested type is different
                         return ((byte[])value.ValueObject).Select(v => (T)(object)v).ToArray();
                     }
                 }

--- a/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
+++ b/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
@@ -34,6 +34,7 @@ namespace ValveResourceFormat.Serialization.NTRO
             foreach (var entry in Contents)
             {
                 var array = entry.Value as NTROArray;
+                var byteArray = (entry.Value as NTROValue<byte[]>)?.Value;
 
                 if (entry.Value.Pointer)
                 {
@@ -42,29 +43,28 @@ namespace ValveResourceFormat.Serialization.NTRO
                 }
                 else if (array != null)
                 {
-                    // TODO: This is matching Valve's incosistency
-                    if (array.Type == DataType.Byte && array.IsIndirection)
-                    {
-                        writer.WriteLine("{0}[{2}] {1} =", ValveDataType(array.Type), entry.Key, array.Count);
-                    }
-                    else
-                    {
-                        writer.WriteLine("{0} {1}[{2}] =", ValveDataType(array.Type), entry.Key, array.Count);
-                    }
+                    writer.WriteLine("{0} {1}[{2}] =", ValveDataType(array.Type), entry.Key, array.Count);
 
                     writer.WriteLine("[");
                     writer.Indent++;
 
                     foreach (var innerEntry in array)
                     {
-                        if (array.Type == DataType.Byte && array.IsIndirection)
-                        {
-                            writer.WriteLine("{0:X2}", (innerEntry as NTROValue<byte>).Value);
-                        }
-                        else
-                        {
-                            innerEntry.WriteText(writer);
-                        }
+                        innerEntry.WriteText(writer);
+                    }
+
+                    writer.Indent--;
+                    writer.WriteLine("]");
+                }
+                else if (byteArray != null)
+                {
+                    writer.WriteLine("{0}[{2}] {1} =", ValveDataType(entry.Value.Type), entry.Key, byteArray.Length);
+                    writer.WriteLine("[");
+                    writer.Indent++;
+
+                    foreach (var val in byteArray)
+                    {
+                        writer.WriteLine("{0:X2}", val);
                     }
 
                     writer.Indent--;

--- a/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
+++ b/ValveResourceFormat/Serialization/NTRO/NTROStruct.cs
@@ -181,7 +181,21 @@ namespace ValveResourceFormat.Serialization.NTRO
         {
             if (Contents.TryGetValue(name, out var value))
             {
-                return ((NTROArray)value).Select(v => (T)v.ValueObject).ToArray();
+                if (value.Type == DataType.Byte)
+                {
+                    if (typeof(T) == typeof(byte))
+                    {
+                        return (T[])value.ValueObject;
+                    }
+                    else
+                    {
+                        return ((byte[])value.ValueObject).Select(v => (T)(object)v).ToArray();
+                    }
+                }
+                else
+                {
+                    return ((NTROArray)value).Select(v => (T)v.ValueObject).ToArray();
+                }
             }
             else
             {


### PR DESCRIPTION
Old mesh format (NTRO encoded DATA block and without VBIB block) now can be properly rendered and exported.
New field for `VertexAttribute`: `SemanticIndex`, `Slot`, `SlotType` and `InstanceStepRate`.
`VertexAttribute` rendamed to `RenderInputLayoutField`
`VertexBuffer` and` IndexBuffer` merged and renamed to `OnDiskBufferData`
New enum `RenderSlotType`
gltf material export now uses g_vColorTint