### PR TITLE
Compiled Shader semantic index

### DIFF
--- a/ValveResourceFormat/CompiledShader/CompiledShader.cs
+++ b/ValveResourceFormat/CompiledShader/CompiledShader.cs
@@ -472,9 +472,9 @@ namespace ValveResourceFormat
                         var name = Reader.ReadNullTermString(Encoding.UTF8);
                         var type = Reader.ReadNullTermString(Encoding.UTF8);
                         var option = Reader.ReadNullTermString(Encoding.UTF8);
-                        var unk = Reader.ReadUInt32(); // 0, 1, 2, 13 or 14
+                        var semanticIndex = Reader.ReadUInt32();
 
-                        Console.WriteLine("     Name: {0}, Type: {1}, Option: {2}, Unknown uint: {3}", name, type, option, unk);
+                        Console.WriteLine("     Name: {0}, Type: {1}{2}, Option: {3}", name, type, semanticIndex, option);
                     }
                 }
             }


### PR DESCRIPTION
This index points to the current semantic index, in HLSL it's expressed as SEMANTIC[n], eg `TEXCOORD13`