### PR TITLE
Correctly export material attributes

### DIFF
--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
-using System.Text;
 using System.Windows.Forms;
 using GUI.Types.Audio;
 using GUI.Types.Exporter;
@@ -355,7 +354,7 @@ namespace GUI.Types.Viewers
                 {
                     var control = new TextBox();
                     control.Font = new Font(FontFamily.GenericMonospace, control.Font.Size);
-                    control.Text = Utils.Utils.NormalizeLineEndings(Encoding.UTF8.GetString(((Material)block).ToValveMaterial()));
+                    control.Text = Utils.Utils.NormalizeLineEndings(((Material)block).ToValveMaterial());
                     control.Dock = DockStyle.Fill;
                     control.Multiline = true;
                     control.ReadOnly = true;

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -55,7 +55,7 @@ namespace ValveResourceFormat.IO
                     break;
 
                 case ResourceType.Material:
-                    data = ((Material)resource.DataBlock).ToValveMaterial();
+                    data = Encoding.UTF8.GetBytes(((Material)resource.DataBlock).ToValveMaterial());
                     break;
 
                 case ResourceType.EntityLump:


### PR DESCRIPTION
Getting back correct attributes now. Also fixed vec4 params so they all get parsed back correctly (compiler expects floats).
![image](https://user-images.githubusercontent.com/26466974/178841539-4bc7ba98-764f-4726-a0ab-a74d8fa30d3e.png)
