### PR TITLE
Adding separate image export option for spritesheets

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -86,8 +86,8 @@ namespace Decompiler
         [Option("--gltf_export_materials", "Whether to export materials during glTF exports.", CommandOptionType.NoValue)]
         public bool GltfExportMaterials { get; }
 
-        [Option("-t|--texture_split", "Texture split mode: images (save images, default), json (contains split coords)", CommandOptionType.SingleValue)]
-        public string TextureSplit { get; }
+        [Option("-t|--texture_split", "Whether seperate images should be dumped when compiling texture spritesheets.", CommandOptionType.NoValue)]
+        public bool TextureSplit { get; }
 
         private string[] ExtFilterList;
         private bool IsInputFolder;
@@ -421,6 +421,33 @@ namespace Decompiler
                     var filePath = Path.ChangeExtension(path, extension);
 
                     DumpFile(filePath, data);
+
+                    if (resource.ResourceType == ResourceType.Texture && TextureSplit)
+                    {
+                        var texture = (Texture)resource.DataBlock;
+                        var imageSheet = FileExtract.ExtractTextureSheet(texture);
+
+                        var basePath = Path.ChangeExtension(OutputFile, null);
+
+                        for (int i = 0; i < imageSheet.Sequences.Length; i++)
+                        {
+                            var sequence = imageSheet.Sequences[i];
+                            for (int j = 0; j < sequence.Frames.Length; j++)
+                            {
+                                var frame = sequence.Frames[j];
+                                if (sequence.Frames.Length > 1)
+                                {
+                                    filePath = String.Format("{0}_seq{1:00}_{2}.png", basePath, i, j);
+                                }
+                                else
+                                {
+                                    filePath = String.Format("{0}_seq{1:00}.png", basePath, i);
+                                }
+                                OutputFile = filePath; //not optimal, but only way without DumpFile rewrite
+                                DumpFile(filePath, frame.data);
+                            }
+                        }
+                    }
                 }
             }
             catch (Exception e)
@@ -494,77 +521,6 @@ namespace Decompiler
 
                     Console.WriteLine("--- Data for block \"{0}\" ---", block.Type);
                     Console.WriteLine(block.ToString());
-                }
-            }
-
-            if (resource.ResourceType == ResourceType.Texture && TextureSplit != null)
-            {
-                var texture = (Texture)resource.DataBlock;
-                var spriteSheet = texture.GetSpriteSheetData();
-
-                if (OutputFile == null && TextureSplit != "json")
-                {
-                    Console.WriteLine("\n\n--- No output file given: Could not write any images.");
-                }
-                else if (OutputFile != null && TextureSplit != "json")
-                {
-                    Console.Write("\n\n");
-                    if (spriteSheet == null)
-                    {
-                        Console.WriteLine("--- This texture has no sheet data.");
-                    }
-                }
-
-                if (spriteSheet != null)
-                {
-                    var sequences = spriteSheet.Sequences;
-                    var bitmap = ((Texture)resource.DataBlock).GenerateBitmap();
-                    SKBitmap subset = new SKBitmap();
-                    var basePath = Path.ChangeExtension(OutputFile, null);
-
-                    String output = "{";
-                    for (int i = 0; i < sequences.Length; i++)
-                    {
-                        var sequence = sequences[i];
-                        if (sequence.Frames.Length < 1) continue;
-                        Console.WriteLine(sequence.Frames.Length);
-                        var firstFrame = sequence.Frames[0];
-
-                        output += String.Format("\n\t\"{0}\": ", i) + "{";
-                        output += String.Format("\n\t\t\"StartMins\": [{0}, {1}],", firstFrame.StartMins.X, firstFrame.StartMins.Y);
-                        output += String.Format("\n\t\t\"StartMaxs\": [{0}, {1}],", firstFrame.StartMaxs.X, firstFrame.StartMaxs.Y);
-                        output += String.Format("\n\t\t\"EndMins\": [{0}, {1}],", firstFrame.EndMins.X, firstFrame.EndMins.Y);
-                        output += String.Format("\n\t\t\"EndMaxs\": [{0}, {1}]", firstFrame.EndMaxs.X, firstFrame.EndMaxs.Y);
-                        output += "\n\t},";
-
-                        if (OutputFile != null && TextureSplit != "json")
-                        {
-                            for (int j = 0; j < sequence.Frames.Length; j++)
-                            {
-                                var frame = sequence.Frames[j];
-                                SKRectI imageRect = frame.GetBoundingRect(bitmap.Width, bitmap.Height);
-                                var success = bitmap.ExtractSubset(subset, imageRect);
-
-                                if (success)
-                                {
-                                    using var ms = new MemoryStream();
-                                    subset.PeekPixels().Encode(ms, SKEncodedImageFormat.Png, 100);
-
-                                    ms.TryGetBuffer(out var buffer);
-                                    OutputFile = String.Format("{0}_seq{1:00}_{2}.png", basePath, i, j);
-                                    DumpFile("", buffer);
-                                }
-                            }
-                        }
-                    }
-                    if (TextureSplit == "json")
-                    {
-                        output = output.Remove(output.Length - 1);
-                        output += "\n}";
-
-                        OutputFile = basePath + "_sequences.json";
-                        DumpFile("", Encoding.UTF8.GetBytes(output));
-                    }
                 }
             }
         }

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -13,7 +13,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
 using SteamDatabase.ValvePak;
-using SkiaSharp;
 using ValveResourceFormat;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.CompiledShader;
@@ -437,7 +436,7 @@ namespace Decompiler
                                 var frame = sequence.Frames[j];
                                 if (sequence.Frames.Length > 1)
                                 {
-                                    filePath = String.Format("{0}_seq{1:00}_{2}.png", basePath, i, j);
+                                    filePath = String.Format("{0}_seq{1:00}_{2:00}.png", basePath, i, j);
                                 }
                                 else
                                 {

--- a/ValveResourceFormat.sln
+++ b/ValveResourceFormat.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31825.309
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ValveResourceFormat", "ValveResourceFormat\ValveResourceFormat.csproj", "{E685E563-5F49-4D8D-8342-A7354229E54F}"
 EndProject

--- a/ValveResourceFormat.sln
+++ b/ValveResourceFormat.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31825.309
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ValveResourceFormat", "ValveResourceFormat\ValveResourceFormat.csproj", "{E685E563-5F49-4D8D-8342-A7354229E54F}"
 EndProject

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Text;
-using System.Collections.Generic;
 using SkiaSharp;
 using ValveResourceFormat.ResourceTypes;
 

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -1,11 +1,33 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Collections.Generic;
 using SkiaSharp;
 using ValveResourceFormat.ResourceTypes;
 
 namespace ValveResourceFormat.IO
 {
+    public class SpritesheetImageData
+    {
+        public class Sequence
+        {
+            public class Frame
+            {
+                public byte[] data { get; }
+
+                public Frame(byte[] imageData)
+                {
+                    data = imageData;
+                }
+            }
+
+            public Frame[] Frames { get; set; }
+
+            public float FramesPerSecond { get; set; }
+        }
+
+        public Sequence[] Sequences { get; set; }
+    }
     public static class FileExtract
     {
         public static Span<byte> Extract(Resource resource)
@@ -82,6 +104,51 @@ namespace ValveResourceFormat.IO
             }
 
             return data;
+        }
+
+        public static SpritesheetImageData ExtractTextureSheet(Texture texture)
+        {
+            var imageData = new SpritesheetImageData();
+            var spriteSheet = texture.GetSpriteSheetData();
+            if (spriteSheet == null) return imageData;
+
+            var sequences = spriteSheet.Sequences;
+            var bitmap = texture.GenerateBitmap();
+            SKBitmap subset = new SKBitmap();
+
+            var imageSequences = new SpritesheetImageData.Sequence[sequences.Length];
+
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                var sequence = sequences[i];
+                if (sequence.Frames.Length < 1) continue;
+
+                var imageFrames = new SpritesheetImageData.Sequence.Frame[sequence.Frames.Length];
+
+                for (int j = 0; j < sequence.Frames.Length; j++)
+                {
+                    var frame = sequence.Frames[j];
+                    SKRectI imageRect = frame.GetBoundingRect(bitmap.Width, bitmap.Height);
+                    var success = bitmap.ExtractSubset(subset, imageRect);
+
+                    if (success)
+                    {
+                        using var ms = new MemoryStream();
+                        subset.PeekPixels().Encode(ms, SKEncodedImageFormat.Png, 100);
+                        ms.TryGetBuffer(out var buffer);
+                        imageFrames[j] = new SpritesheetImageData.Sequence.Frame(buffer.Array);
+                    }
+                }
+
+                imageSequences[i] = new SpritesheetImageData.Sequence
+                {
+                    Frames = imageFrames,
+                    FramesPerSecond = sequence.FramesPerSecond
+                };
+            }
+            imageData.Sequences = imageSequences;
+
+            return imageData;
         }
 
         public static string GetExtension(Resource resource)

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -28,6 +28,15 @@ namespace ValveResourceFormat.ResourceTypes
 
                     public Vector2 EndMins { get; set; }
                     public Vector2 EndMaxs { get; set; }
+
+                    public SKRectI GetBoundingRect(int width, int height)
+                    {
+                        int startX = (int)(StartMins.X * width);
+                        int startY = (int)(StartMins.Y * height);
+                        int endX = (int)(StartMaxs.X * width);
+                        int endY = (int)(StartMaxs.Y * height);
+                        return new SKRectI(startX, startY, endX, endY);
+                    }
                 }
 
                 public Frame[] Frames { get; set; }


### PR DESCRIPTION
- Adds the decompiler cli option `-t|--texture_split`
  - if option is given **and** output path is given **and** texture (.vtex_c) file is a spritesheet, it tries to export splitted images
  - exported images will have the same name with the following name signature: `NAME_seqXX_YY.png` (XX is sequence index; YY is frame index [if there are more than 1 frame per sequence])
- Adds `FileExtract.ExtractTextureSheet` function, that exports image data for all available sequences and frames

Known issues:
- Without changes to `DumpFile`, `OutputFile` is overwritten in order to save the files with different names.
- No integration for GUI yet; only works for Decompiler (although `ExtractTextureSheet` could probably be reused there as well)