### PR TITLE
Export individual texture sequences based on `SpritesheetData`

### DIFF
--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -169,8 +169,11 @@ namespace GUI.Forms
                             continue;
                         }
 
-                        Console.WriteLine($"Writing content subfile: {subFilePath}");
-                        await File.WriteAllBytesAsync(subFilePath, subFileData, cancellationTokenSource.Token).ConfigureAwait(false);
+                        if (subFileData.Length > 0)
+                        {
+                            Console.WriteLine($"Writing content subfile: {subFilePath}");
+                            await File.WriteAllBytesAsync(subFilePath, subFileData, cancellationTokenSource.Token).ConfigureAwait(false);
+                        }
                     }
 
                     continue;


### PR DESCRIPTION
Better implements #437

There is also a simplistic [MakeSheet file](https://developer.valvesoftware.com/wiki/Animated_Particles#Creating_an_MKS_File) that is exported.