### PR TITLE
Further improve texture sheet exporting

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -378,7 +378,7 @@ namespace Decompiler
                     if (OutputFile == null)
                     {
                         // Test extraction code flow while collecting stats
-                        FileExtract.Extract(resource);
+                        using FileExtract.Extract(resource);
                     }
 
                     if (!string.IsNullOrEmpty(info))
@@ -849,7 +849,7 @@ namespace Decompiler
                 Console.WriteLine("\t[archive index: {0:D3}] {1}", file.ArchiveIndex, filePath);
 
                 package.ReadEntry(file, out var output);
-                var contentFile = default(ContentFile);
+                ContentFile contentFile;
 
                 if (type.EndsWith("_c", StringComparison.Ordinal) && Decompile)
                 {
@@ -926,9 +926,11 @@ namespace Decompiler
             {
                 foreach (var contentSubFile in contentFile.SubFiles)
                 {
-                    DumpFile(Path.Combine(Path.GetDirectoryName(path), contentSubFile.FileName), contentSubFile.Extract());
+                    DumpFile(Path.Combine(Path.GetDirectoryName(path), contentSubFile.FileName), contentSubFile.Extract.Invoke());
                 }
             }
+
+            contentFile.Dispose();
         }
 
         private static void DumpFile(string path, ReadOnlySpan<byte> data)

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -378,7 +378,7 @@ namespace Decompiler
                     if (OutputFile == null)
                     {
                         // Test extraction code flow while collecting stats
-                        using FileExtract.Extract(resource);
+                        FileExtract.Extract(resource).Dispose();
                     }
 
                     if (!string.IsNullOrEmpty(info))
@@ -849,7 +849,7 @@ namespace Decompiler
                 Console.WriteLine("\t[archive index: {0:D3}] {1}", file.ArchiveIndex, filePath);
 
                 package.ReadEntry(file, out var output);
-                ContentFile contentFile;
+                ContentFile contentFile = null;
 
                 if (type.EndsWith("_c", StringComparison.Ordinal) && Decompile)
                 {

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -378,7 +378,7 @@ namespace Decompiler
                     if (OutputFile == null)
                     {
                         // Test extraction code flow while collecting stats
-                        FileExtract.Extract(resource).Dispose();
+                        using var _ = FileExtract.Extract(resource);
                     }
 
                     if (!string.IsNullOrEmpty(info))

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -420,7 +420,7 @@ namespace Decompiler
 
                 if (OutputFile != null)
                 {
-                    var contentFile = FileExtract.Extract(resource);
+                    using var contentFile = FileExtract.Extract(resource);
 
                     path = Path.ChangeExtension(path, extension);
                     var outFilePath = GetOutputPath(path);
@@ -889,6 +889,7 @@ namespace Decompiler
                     catch (Exception e)
                     {
                         LogException(e, filePath, package.FileName);
+                        contentFile?.Dispose();
                     }
                 }
 
@@ -908,7 +909,10 @@ namespace Decompiler
 
                     if (Decompile)
                     {
-                        DumpContentFile(filePath, contentFile);
+                        using (contentFile)
+                        {
+                            DumpContentFile(filePath, contentFile);
+                        }
                     }
                     else
                     {
@@ -929,8 +933,6 @@ namespace Decompiler
                     DumpFile(Path.Combine(Path.GetDirectoryName(path), contentSubFile.FileName), contentSubFile.Extract.Invoke());
                 }
             }
-
-            contentFile.Dispose();
         }
 
         private static void DumpFile(string path, ReadOnlySpan<byte> data)

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -890,6 +890,7 @@ namespace Decompiler
                     {
                         LogException(e, filePath, package.FileName);
                         contentFile?.Dispose();
+                        contentFile = null;
                     }
                 }
 
@@ -907,7 +908,7 @@ namespace Decompiler
 
                     filePath = GetOutputPath(filePath, useOutputAsDirectory: true);
 
-                    if (Decompile)
+                    if (Decompile && contentFile is not null)
                     {
                         using (contentFile)
                         {

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -894,30 +894,30 @@ namespace Decompiler
                     }
                 }
 
-                if (OutputFile != null)
+                using (contentFile)
                 {
-                    if (RecursiveSearchArchives)
+                    if (OutputFile != null)
                     {
-                        filePath = Path.Combine(parentPath, filePath);
-                    }
+                        if (RecursiveSearchArchives)
+                        {
+                            filePath = Path.Combine(parentPath, filePath);
+                        }
 
-                    if (type != extension)
-                    {
-                        filePath = Path.ChangeExtension(filePath, extension);
-                    }
+                        if (type != extension)
+                        {
+                            filePath = Path.ChangeExtension(filePath, extension);
+                        }
 
-                    filePath = GetOutputPath(filePath, useOutputAsDirectory: true);
+                        filePath = GetOutputPath(filePath, useOutputAsDirectory: true);
 
-                    if (Decompile && contentFile is not null)
-                    {
-                        using (contentFile)
+                        if (Decompile && contentFile is not null)
                         {
                             DumpContentFile(filePath, contentFile);
                         }
-                    }
-                    else
-                    {
-                        DumpFile(filePath, output);
+                        else
+                        {
+                            DumpFile(filePath, output);
+                        }
                     }
                 }
             }

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -178,7 +178,7 @@ namespace GUI.Forms
                         byte[] subFileData;
                         try
                         {
-                            subFileData = contentSubFile.Extract();
+                            subFileData = contentSubFile.Extract.Invoke();
                         }
                         catch (Exception e)
                         {
@@ -193,6 +193,7 @@ namespace GUI.Forms
                         }
                     }
 
+                    contentFile.Dispose();
                     continue;
                 }
 

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -126,7 +126,7 @@ namespace GUI.Forms
 
                 if (Decompile && outFilePath.EndsWith("_c", StringComparison.Ordinal))
                 {
-                    ContentFile contentFile;
+                    ContentFile contentFile = null;
 
                     using (var resource = new Resource
                     {
@@ -148,7 +148,7 @@ namespace GUI.Forms
 
                             if (extension == null)
                             {
-                                outFilePath = outFilePath.Substring(0, outFilePath.Length - 2);
+                                outFilePath = outFilePath[..^2];
                             }
                             else
                             {
@@ -160,40 +160,43 @@ namespace GUI.Forms
                         catch (Exception e)
                         {
                             await Console.Error.WriteLineAsync($"Failed to extract '{packageFile.GetFullPath()}' - {e.Message}").ConfigureAwait(false);
+                            contentFile?.Dispose();
                             continue;
                         }
                     }
 
-                    if (contentFile.Data.Length > 0)
+                    using (contentFile)
                     {
-                        Console.WriteLine($"Writing content file: {outFilePath}");
-                        await File.WriteAllBytesAsync(outFilePath, contentFile.Data, cancellationTokenSource.Token).ConfigureAwait(false);
+                        if (contentFile.Data.Length > 0)
+                        {
+                            Console.WriteLine($"Writing content file: {outFilePath}");
+                            await File.WriteAllBytesAsync(outFilePath, contentFile.Data, cancellationTokenSource.Token).ConfigureAwait(false);
+                        }
+
+                        foreach (var contentSubFile in contentFile.SubFiles)
+                        {
+                            var subFilePath = Path.Combine(outFolder, contentSubFile.FileName);
+                            Directory.CreateDirectory(Path.GetDirectoryName(subFilePath));
+
+                            byte[] subFileData;
+                            try
+                            {
+                                subFileData = contentSubFile.Extract.Invoke();
+                            }
+                            catch (Exception e)
+                            {
+                                await Console.Error.WriteLineAsync($"Failed to extract subfile '{contentSubFile.FileName}' - {e.Message}").ConfigureAwait(false);
+                                continue;
+                            }
+
+                            if (subFileData.Length > 0)
+                            {
+                                Console.WriteLine($"Writing content subfile: {subFilePath}");
+                                await File.WriteAllBytesAsync(subFilePath, subFileData, cancellationTokenSource.Token).ConfigureAwait(false);
+                            }
+                        }
                     }
 
-                    foreach (var contentSubFile in contentFile.SubFiles)
-                    {
-                        var subFilePath = Path.Combine(outFolder, contentSubFile.FileName);
-                        Directory.CreateDirectory(Path.GetDirectoryName(subFilePath));
-
-                        byte[] subFileData;
-                        try
-                        {
-                            subFileData = contentSubFile.Extract.Invoke();
-                        }
-                        catch (Exception e)
-                        {
-                            await Console.Error.WriteLineAsync($"Failed to extract subfile '{contentSubFile.FileName}' - {e.Message}").ConfigureAwait(false);
-                            continue;
-                        }
-
-                        if (subFileData.Length > 0)
-                        {
-                            Console.WriteLine($"Writing content subfile: {subFilePath}");
-                            await File.WriteAllBytesAsync(subFilePath, subFileData, cancellationTokenSource.Token).ConfigureAwait(false);
-                        }
-                    }
-
-                    contentFile.Dispose();
                     continue;
                 }
 

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -66,7 +66,7 @@ namespace GUI.Types.Exporter
                 }
                 else
                 {
-                    var contentFile = FileExtract.Extract(resource);
+                    using var contentFile = FileExtract.Extract(resource);
                     using var stream = dialog.OpenFile();
                     stream.Write(contentFile.Data);
 
@@ -75,7 +75,7 @@ namespace GUI.Types.Exporter
                         Console.WriteLine($"Export for \"{fileName}\" also writing \"{contentSubFile.FileName}\"");
                         var subFilePath = Path.Combine(Path.GetDirectoryName(dialog.FileName), contentSubFile.FileName);
                         using var subFileStream = File.OpenWrite(subFilePath);
-                        subFileStream.Write(contentSubFile.Extract());
+                        subFileStream.Write(contentSubFile.Extract.Invoke());
                     }
                 }
 

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -72,6 +72,7 @@ namespace GUI.Types.Exporter
 
                     foreach (var contentSubFile in contentFile.SubFiles)
                     {
+                        Console.WriteLine($"Export for \"{fileName}\" also writing \"{contentSubFile.FileName}\"");
                         var subFilePath = Path.Combine(Path.GetDirectoryName(dialog.FileName), contentSubFile.FileName);
                         using var subFileStream = File.OpenWrite(subFilePath);
                         subFileStream.Write(contentSubFile.Extract());

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -429,8 +429,12 @@ namespace GUI.Types.Viewers
 
                     case ResourceType.Texture:
                         {
-                            var textureExtract = new TextureExtract(resource.FileName, (Texture)resource.DataBlock);
+                            if (FileExtract.IsChildResource(resource))
+                            {
+                                break;
+                            }
 
+                            var textureExtract = new TextureExtract(resource.FileName, (Texture)resource.DataBlock);
                             AddContentTab(resTabs, "Reconstructed vtex", textureExtract.ToValveTexture());
 
                             if (textureExtract.TryGetMksData(out var _, out var mks))

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -426,6 +426,20 @@ namespace GUI.Types.Viewers
                     case ResourceType.PostProcessing:
                         AddContentTab(resTabs, "Reconstructed vpost", ((PostProcessing)block).ToValvePostProcessing());
                         break;
+
+                    case ResourceType.Texture:
+                        {
+                            var textureExtract = new TextureExtract(resource.FileName, (Texture)resource.DataBlock);
+
+                            AddContentTab(resTabs, "Reconstructed vtex", textureExtract.ToValveTexture());
+
+                            if (textureExtract.TryGetMksData(out var _, out var mks))
+                            {
+                                AddContentTab(resTabs, "Reconstructed mks", mks);
+                            }
+
+                            break;
+                        }
                 }
             }
 

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -434,7 +434,7 @@ namespace GUI.Types.Viewers
                                 break;
                             }
 
-                            var textureExtract = new TextureExtract(resource.FileName, (Texture)resource.DataBlock);
+                            var textureExtract = new TextureExtract((Texture)resource.DataBlock, resource.FileName);
                             AddContentTab(resTabs, "Reconstructed vtex", textureExtract.ToValveTexture());
 
                             if (textureExtract.TryGetMksData(out var _, out var mks))

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -394,46 +394,38 @@ namespace GUI.Types.Viewers
 
                 resTabs.TabPages.Add(tab2);
 
-                if (block.Type == BlockType.DATA && resource.ResourceType == ResourceType.Material)
+                static void AddContentTab(TabControl resTabs, string name, string text)
                 {
                     var control = new TextBox();
                     control.Font = new Font(FontFamily.GenericMonospace, control.Font.Size);
-                    control.Text = Utils.Utils.NormalizeLineEndings(((Material)block).ToValveMaterial());
+                    control.Text = Utils.Utils.NormalizeLineEndings(text);
                     control.Dock = DockStyle.Fill;
                     control.Multiline = true;
                     control.ReadOnly = true;
                     control.ScrollBars = ScrollBars.Both;
-                    var tabVmat = new TabPage("vmat");
-                    tabVmat.Controls.Add(control);
-                    resTabs.TabPages.Add(tabVmat);
+                    var tab = new TabPage(name);
+                    tab.Controls.Add(control);
+                    resTabs.TabPages.Add(tab);
                 }
 
-                if (block.Type == BlockType.DATA && resource.ResourceType == ResourceType.EntityLump)
+                if (block.Type != BlockType.DATA)
                 {
-                    var control = new TextBox();
-                    control.Font = new Font(FontFamily.GenericMonospace, control.Font.Size);
-                    control.Text = Utils.Utils.NormalizeLineEndings(((EntityLump)block).ToEntityDumpString());
-                    control.Dock = DockStyle.Fill;
-                    control.Multiline = true;
-                    control.ReadOnly = true;
-                    control.ScrollBars = ScrollBars.Both;
-                    var tabEntities = new TabPage("Entities");
-                    tabEntities.Controls.Add(control);
-                    resTabs.TabPages.Add(tabEntities);
+                    continue;
                 }
 
-                if (block.Type == BlockType.DATA && resource.ResourceType == ResourceType.PostProcessing)
+                switch (resource.ResourceType)
                 {
-                    var control = new TextBox();
-                    control.Font = new Font(FontFamily.GenericMonospace, control.Font.Size);
-                    control.Text = Utils.Utils.NormalizeLineEndings(((PostProcessing)block).ToValvePostProcessing());
-                    control.Dock = DockStyle.Fill;
-                    control.Multiline = true;
-                    control.ReadOnly = true;
-                    control.ScrollBars = ScrollBars.Both;
-                    var tabVpost = new TabPage("vpost");
-                    tabVpost.Controls.Add(control);
-                    resTabs.TabPages.Add(tabVpost);
+                    case ResourceType.Material:
+                        AddContentTab(resTabs, "Reconstructed vmat", ((Material)block).ToValveMaterial());
+                        break;
+
+                    case ResourceType.EntityLump:
+                        AddContentTab(resTabs, "Entities", ((EntityLump)block).ToEntityDumpString());
+                        break;
+
+                    case ResourceType.PostProcessing:
+                        AddContentTab(resTabs, "Reconstructed vpost", ((PostProcessing)block).ToValvePostProcessing());
+                        break;
                 }
             }
 

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -83,7 +83,7 @@ namespace ValveResourceFormat.IO
                             break;
                         }
 
-                        var textureExtract = new TextureExtract(resource.FileName, (Texture)resource.DataBlock);
+                        var textureExtract = new TextureExtract((Texture)resource.DataBlock, resource.FileName);
                         contentFile = textureExtract.ToContentFile();
                         break;
                     }

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -137,7 +137,7 @@ namespace ValveResourceFormat.IO
             }
 
             var extraIntData = (Blocks.ResourceEditInfoStructs.ExtraIntData)resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.ExtraIntData];
-            return extraIntData.List.Where(x => x.Name == "IsChildResource").Select(x => x.Value).FirstOrDefault() == 1;
+            return extraIntData.List.FirstOrDefault(x => x.Name == "IsChildResource")?.Value == 1;
         }
 
         public static string GetExtension(Resource resource)

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -127,8 +127,19 @@ namespace ValveResourceFormat.IO
                                 var image = frame.Images[0];
                                 SKRectI imageRect = image.GetCroppedRect(bitmap.Width, bitmap.Height);
 
+                                if (imageRect.IsEmpty)
+                                {
+                                    continue;
+                                }
+
+                                var displayTime = frame.DisplayTime;
+                                if (sequence.Clamp && displayTime == 0)
+                                {
+                                    displayTime = 1;
+                                }
+
                                 var addForExtract = rects.TryAdd(imageRect, imageFileName);
-                                mks.AppendLine($"frame {rects[imageRect]} {frame.DisplayTime.ToString(CultureInfo.InvariantCulture)}");
+                                mks.AppendLine($"frame {rects[imageRect]} {displayTime.ToString(CultureInfo.InvariantCulture)}");
 
                                 if (!addForExtract)
                                 {
@@ -139,11 +150,6 @@ namespace ValveResourceFormat.IO
                                 {
                                     using var subset = new SKBitmap();
                                     bitmap.ExtractSubset(subset, imageRect);
-
-                                    if (subset.IsNull)
-                                    {
-                                        return Array.Empty<byte>();
-                                    }
 
                                     using var pixels = subset.PeekPixels();
                                     using var png = pixels.Encode(SKPngEncoderOptions.Default);

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -129,7 +129,7 @@ namespace ValveResourceFormat.IO
             return contentFile;
         }
 
-        private static bool IsChildResource(Resource resource)
+        public static bool IsChildResource(Resource resource)
         {
             if (resource.EditInfo is ResourceEditInfo2 redi2)
             {

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using SkiaSharp;
+using ValveResourceFormat.ResourceTypes;
+
+namespace ValveResourceFormat.IO;
+
+public sealed class TextureExtract
+{
+    private readonly string fileName;
+    private readonly Texture texture;
+    private readonly SKBitmap bitmap;
+    private readonly Texture.SpritesheetData spriteSheetData;
+
+    public TextureExtract(string fileName, Texture texture)
+    {
+        this.fileName = fileName;
+        this.texture = texture;
+        bitmap = texture.GenerateBitmap();
+        spriteSheetData = texture.GetSpriteSheetData();
+    }
+
+    /// <summary>
+    /// The vtex content file. Input image(s) come as subfiles.
+    /// </summary>
+    public ContentFile ToContentFile()
+    {
+        var contentFile = new ContentFile()
+        {
+            Data = Encoding.UTF8.GetBytes(ToValveTexture())
+        };
+
+        if (TryGetMksData(out var sprites, out var mks))
+        {
+            contentFile.AddSubFile(
+                GetMksFileName(),
+                () => Encoding.UTF8.GetBytes(mks)
+            );
+
+            foreach (var (spriteRect, spriteName) in sprites)
+            {
+                contentFile.AddSubFile(
+                    spriteName,
+                    () => GetSpriteImage(spriteRect)
+                );
+            }
+
+            return contentFile;
+        }
+
+        contentFile.AddSubFile(
+            GetImageFileName(),
+            GetImage
+        );
+
+        return contentFile;
+    }
+
+    private string GetImageFileName()
+        => Path.ChangeExtension(fileName, "png");
+
+    private string GetMksFileName()
+        => Path.ChangeExtension(fileName, "mks");
+
+    private static byte[] EncodePng(SKBitmap bitmap)
+    {
+        using var pixels = bitmap.PeekPixels();
+        using var png = pixels.Encode(SKPngEncoderOptions.Default);
+        return png.ToArray();
+    }
+
+    private byte[] GetImage()
+        => EncodePng(bitmap);
+
+    private byte[] GetSpriteImage(SKRectI spriteRect)
+    {
+        using var subset = new SKBitmap();
+        bitmap.ExtractSubset(subset, spriteRect);
+
+        return EncodePng(subset);
+    }
+
+    public bool TryGetMksData(out Dictionary<SKRectI, string> sprites, out string mks)
+    {
+        mks = string.Empty;
+        sprites = new Dictionary<SKRectI, string>();
+
+        if (spriteSheetData is null)
+        {
+            return false;
+        }
+
+        var mksBuilder = new StringBuilder();
+        var textureName = Path.GetFileNameWithoutExtension(fileName);
+        var packmodeNonFlat = false;
+
+        for (var s = 0; s < spriteSheetData.Sequences.Length; s++)
+        {
+            var sequence = spriteSheetData.Sequences[s];
+            mksBuilder.AppendLine();
+
+            switch (sequence.NoColor, sequence.NoAlpha)
+            {
+                case (false, false):
+                    mksBuilder.AppendLine(CultureInfo.InvariantCulture, $"sequence {s}");
+                    break;
+
+                case (false, true):
+                    mksBuilder.AppendLine(CultureInfo.InvariantCulture, $"sequence-rgb {s}");
+                    packmodeNonFlat = true;
+                    break;
+
+                case (true, false):
+                    mksBuilder.AppendLine(CultureInfo.InvariantCulture, $"sequence-a {s}");
+                    packmodeNonFlat = true;
+                    break;
+
+                case (true, true):
+                    throw new InvalidDataException($"Unexpected combination of {nameof(sequence.NoColor)} and {nameof(sequence.NoAlpha)}");
+            }
+
+            if (!sequence.Clamp)
+            {
+                mksBuilder.AppendLine("LOOP");
+            }
+
+            for (var f = 0; f < sequence.Frames.Length; f++)
+            {
+                var frame = sequence.Frames[f];
+
+                var imageFileName = sequence.Frames.Length == 1
+                    ? $"{textureName}_seq{s}.png"
+                    : $"{textureName}_seq{s}_{f}.png";
+
+                // These images seem to be duplicates. So only extract the first one.
+                var image = frame.Images[0];
+                var imageRect = image.GetCroppedRect(bitmap.Width, bitmap.Height);
+
+                if (imageRect.IsEmpty)
+                {
+                    continue;
+                }
+
+                var displayTime = frame.DisplayTime;
+                if (sequence.Clamp && displayTime == 0)
+                {
+                    displayTime = 1;
+                }
+
+                sprites.TryAdd(imageRect, imageFileName);
+                mksBuilder.AppendLine(CultureInfo.InvariantCulture, $"frame {sprites[imageRect]} {displayTime.ToString(CultureInfo.InvariantCulture)}");
+            }
+        }
+
+        if (packmodeNonFlat)
+        {
+            mksBuilder.Insert(0, "packmode rgb+a\n");
+        }
+
+        mksBuilder.Insert(0, "// Reconstructed with VRF - https://vrf.steamdb.info/\n\n");
+        mks = mksBuilder.ToString();
+        return true;
+    }
+
+    private string GetInputFileNameForVtex()
+    {
+        return GetImageFileName();
+    }
+
+    public string ToValveTexture()
+    {
+        var inputTextureFileName = GetInputFileNameForVtex();
+        var outputFormat = texture.Format.ToString();
+
+        var template = @"<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->
+""CDmeVtex""
+{
+	""m_inputTextureArray"" ""element_array"" 
+	[
+		""CDmeInputTexture""
+		{
+			""m_name"" ""string"" ""InputTexture0""
+			""m_fileName"" ""string"" ""{0}""
+			""m_colorSpace"" ""string"" ""srgb""
+			""m_typeString"" ""string"" ""2D""
+			""m_imageProcessorArray"" ""element_array"" 
+			[
+				""CDmeImageProcessor""
+				{
+					""m_algorithm"" ""string"" ""None""
+					""m_stringArg"" ""string"" """"
+					""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
+				}
+			]
+		}
+	]
+	""m_outputTypeString"" ""string"" ""2D""
+	""m_outputFormat"" ""string"" ""{1}""
+	""m_outputClearColor"" ""vector4"" ""0 0 0 0""
+	""m_nOutputMinDimension"" ""int"" ""0""
+	""m_nOutputMaxDimension"" ""int"" ""0""
+	""m_textureOutputChannelArray"" ""element_array"" 
+	[
+		""CDmeTextureOutputChannel""
+		{
+			""m_inputTextureArray"" ""string_array"" [ ""InputTexture0"" ]
+			""m_srcChannels"" ""string"" ""rgba""
+			""m_dstChannels"" ""string"" ""rgba""
+			""m_mipAlgorithm"" ""CDmeImageProcessor""
+			{
+				""m_algorithm"" ""string"" ""Box""
+				""m_stringArg"" ""string"" """"
+				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
+			}
+			""m_outputColorSpace"" ""string"" ""srgb""
+		}
+	]
+	""m_vClamp"" ""vector3"" ""0 0 0""
+	""m_bNoLod"" ""bool"" ""0""
+}";
+
+        return template;
+        //return string.Format(CultureInfo.InvariantCulture, template, inputTextureFileName, outputFormat);
+    }
+}
+

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -224,8 +224,6 @@ public sealed class TextureExtract
         @"            ""m_outputColorSpace"" ""string"" ""srgb""",
         @"        }",
         @"    ]",
-        @"    ""m_vClamp"" ""vector3"" ""0 0 0""",
-        @"    ""m_bNoLod"" ""bool"" """"",
         @"}");
     }
 }

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -139,7 +139,7 @@ public sealed class TextureExtract
                 var image = frame.Images[0];
                 var imageRect = image.GetCroppedRect(texture.ActualWidth, texture.ActualHeight);
 
-                if (imageRect.IsEmpty)
+                if (imageRect.Size.IsEmpty)
                 {
                     continue;
                 }

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -44,7 +44,7 @@ public sealed class TextureExtract
             {
                 contentFile.AddSubFile(
                     spriteName,
-                    () => GetSpriteImage(spriteRect)
+                    () => SubsetToPngImage(spriteRect)
                 );
             }
 
@@ -53,7 +53,7 @@ public sealed class TextureExtract
 
         contentFile.AddSubFile(
             GetImageFileName(),
-            GetImage
+            ToPngImage
         );
 
         return contentFile;
@@ -72,10 +72,10 @@ public sealed class TextureExtract
         return png.ToArray();
     }
 
-    private byte[] GetImage()
+    public byte[] ToPngImage()
         => EncodePng(bitmap);
 
-    private byte[] GetSpriteImage(SKRectI spriteRect)
+    private byte[] SubsetToPngImage(SKRectI spriteRect)
     {
         using var subset = new SKBitmap();
         bitmap.ExtractSubset(subset, spriteRect);
@@ -137,7 +137,7 @@ public sealed class TextureExtract
 
                 // These images seem to be duplicates. So only extract the first one.
                 var image = frame.Images[0];
-                var imageRect = image.GetCroppedRect(bitmap.Width, bitmap.Height);
+                var imageRect = image.GetCroppedRect(texture.ActualWidth, texture.ActualHeight);
 
                 if (imageRect.IsEmpty)
                 {

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -33,14 +33,14 @@ public sealed class ImageSubfile : ContentSubFile
 
 public sealed class TextureExtract
 {
-    private readonly string fileName;
     private readonly Texture texture;
+    private readonly string fileName;
     private readonly bool isSpriteSheet;
 
-    public TextureExtract(string fileName, Texture texture)
+    public TextureExtract(Texture texture, string fileName)
     {
-        this.fileName = fileName;
         this.texture = texture;
+        this.fileName = fileName;
 
         if (texture.ExtraData.ContainsKey(VTexExtraData.SHEET))
         {

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -167,7 +167,12 @@ public sealed class TextureExtract
 
     private string GetInputFileNameForVtex()
     {
-        return GetImageFileName();
+        if (spriteSheetData is not null)
+        {
+            return GetMksFileName().Replace(Path.DirectorySeparatorChar, '/');
+        }
+
+        return GetImageFileName().Replace(Path.DirectorySeparatorChar, '/');
     }
 
     public string ToValveTexture()
@@ -175,55 +180,53 @@ public sealed class TextureExtract
         var inputTextureFileName = GetInputFileNameForVtex();
         var outputFormat = texture.Format.ToString();
 
-        var template = @"<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->
-""CDmeVtex""
-{
-	""m_inputTextureArray"" ""element_array"" 
-	[
-		""CDmeInputTexture""
-		{
-			""m_name"" ""string"" ""InputTexture0""
-			""m_fileName"" ""string"" ""{0}""
-			""m_colorSpace"" ""string"" ""srgb""
-			""m_typeString"" ""string"" ""2D""
-			""m_imageProcessorArray"" ""element_array"" 
-			[
-				""CDmeImageProcessor""
-				{
-					""m_algorithm"" ""string"" ""None""
-					""m_stringArg"" ""string"" """"
-					""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-				}
-			]
-		}
-	]
-	""m_outputTypeString"" ""string"" ""2D""
-	""m_outputFormat"" ""string"" ""{1}""
-	""m_outputClearColor"" ""vector4"" ""0 0 0 0""
-	""m_nOutputMinDimension"" ""int"" ""0""
-	""m_nOutputMaxDimension"" ""int"" ""0""
-	""m_textureOutputChannelArray"" ""element_array"" 
-	[
-		""CDmeTextureOutputChannel""
-		{
-			""m_inputTextureArray"" ""string_array"" [ ""InputTexture0"" ]
-			""m_srcChannels"" ""string"" ""rgba""
-			""m_dstChannels"" ""string"" ""rgba""
-			""m_mipAlgorithm"" ""CDmeImageProcessor""
-			{
-				""m_algorithm"" ""string"" ""Box""
-				""m_stringArg"" ""string"" """"
-				""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""
-			}
-			""m_outputColorSpace"" ""string"" ""srgb""
-		}
-	]
-	""m_vClamp"" ""vector3"" ""0 0 0""
-	""m_bNoLod"" ""bool"" ""0""
-}";
-
-        return template;
-        //return string.Format(CultureInfo.InvariantCulture, template, inputTextureFileName, outputFormat);
+        return string.Join(Environment.NewLine,
+        "<!-- dmx encoding keyvalues2_noids 1 format vtex 1 -->",
+        @"""CDmeVtex""",
+        @"{",
+        @"    ""m_inputTextureArray"" ""element_array""",
+        @"    [",
+        @"        ""CDmeInputTexture""",
+        @"        {",
+        @"            ""m_name"" ""string"" ""InputTexture0""",
+        $@"            ""m_fileName"" ""string"" ""{inputTextureFileName}""",
+        @"            ""m_colorSpace"" ""string"" ""srgb""",
+        @"            ""m_typeString"" ""string"" ""2D""",
+        @"            ""m_imageProcessorArray"" ""element_array""",
+        @"            [",
+        @"                ""CDmeImageProcessor""",
+        @"                {",
+        @"                    ""m_algorithm"" ""string"" ""None""",
+        @"                    ""m_stringArg"" ""string"" """"",
+        @"                    ""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""",
+        @"                }",
+        @"            ]",
+        @"        }",
+        @"    ]",
+        @"    ""m_outputTypeString"" ""string"" ""2D""",
+        $@"    ""m_outputFormat"" ""string"" ""{outputFormat}""",
+        @"    ""m_outputClearColor"" ""vector4"" ""0 0 0 0""",
+        @"    ""m_nOutputMinDimension"" ""int"" ""0""",
+        @"    ""m_nOutputMaxDimension"" ""int"" ""0""",
+        @"    ""m_textureOutputChannelArray"" ""element_array"" ",
+        @"    [",
+        @"        ""CDmeTextureOutputChannel""",
+        @"        {",
+        @"            ""m_inputTextureArray"" ""string_array"" [ ""InputTexture0"" ]",
+        @"            ""m_srcChannels"" ""string"" ""rgba""",
+        @"            ""m_dstChannels"" ""string"" ""rgba""",
+        @"            ""m_mipAlgorithm"" ""CDmeImageProcessor""",
+        @"            {",
+        @"                ""m_algorithm"" ""string"" ""Box""",
+        @"                ""m_stringArg"" ""string"" """"",
+        @"                ""m_vFloat4Arg"" ""vector4"" ""0 0 0 0""",
+        @"            }",
+        @"            ""m_outputColorSpace"" ""string"" ""srgb""",
+        @"        }",
+        @"    ]",
+        @"    ""m_vClamp"" ""vector3"" ""0 0 0""",
+        @"    ""m_bNoLod"" ""bool"" """"",
+        @"}");
     }
 }
 

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -13,14 +13,18 @@ public sealed class TextureExtract
     private readonly string fileName;
     private readonly Texture texture;
     private readonly SKBitmap bitmap;
-    private readonly Texture.SpritesheetData spriteSheetData;
+    private readonly bool isSpriteSheet;
 
     public TextureExtract(string fileName, Texture texture)
     {
         this.fileName = fileName;
         this.texture = texture;
         bitmap = texture.GenerateBitmap();
-        spriteSheetData = texture.GetSpriteSheetData();
+
+        if (texture.ExtraData.ContainsKey(VTexExtraData.SHEET))
+        {
+            isSpriteSheet = true;
+        }
     }
 
     /// <summary>
@@ -88,10 +92,12 @@ public sealed class TextureExtract
         mks = string.Empty;
         sprites = new Dictionary<SKRectI, string>();
 
-        if (spriteSheetData is null)
+        if (!isSpriteSheet)
         {
             return false;
         }
+
+        var spriteSheetData = texture.GetSpriteSheetData();
 
         var mksBuilder = new StringBuilder();
         var textureName = Path.GetFileNameWithoutExtension(fileName);
@@ -167,7 +173,7 @@ public sealed class TextureExtract
 
     private string GetInputFileNameForVtex()
     {
-        if (spriteSheetData is not null)
+        if (isSpriteSheet)
         {
             return GetMksFileName().Replace(Path.DirectorySeparatorChar, '/');
         }


### PR DESCRIPTION
- [x] Only export unique frames.
- [x] Write correct mks for sheets with `packmode rgb+a`.
- [x] Display the mks on a GUI tab.
- [x] Sprite textures (non-child) write .vtex as their main content file, also display on a GUI tab.
    - [x] Child textures such as material maps export the png only (behaviur pre this PR).
 - [x] Free bitmap off memory when exporting sheets too.