### PR TITLE
Unpack textures when exporting vmat_c

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -811,9 +811,18 @@ namespace Decompiler
 
         private void DumpVPK(string parentPath, Package package, string type, Dictionary<string, uint> manifestData)
         {
-            if (ExtFilterList != null && !ExtFilterList.Contains(type))
+            var allowSubFilesFromExternalRefs = true;
+            if (ExtFilterList != null)
             {
-                return;
+                if (!ExtFilterList.Contains(type))
+                {
+                    return;
+                }
+
+                if (type == "vmat_c" && ExtFilterList.Contains("vmat_c") && !ExtFilterList.Contains("vtex_c"))
+                {
+                    allowSubFilesFromExternalRefs = false;
+                }
             }
 
             if (!package.Entries.ContainsKey(type))
@@ -912,7 +921,7 @@ namespace Decompiler
 
                         if (Decompile && contentFile is not null)
                         {
-                            DumpContentFile(filePath, contentFile);
+                            DumpContentFile(filePath, contentFile, allowSubFilesFromExternalRefs);
                         }
                         else
                         {

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -378,7 +378,7 @@ namespace Decompiler
                     if (OutputFile == null)
                     {
                         // Test extraction code flow while collecting stats
-                        using var _ = FileExtract.Extract(resource);
+                        using var _ = FileExtract.Extract(resource, null);
                     }
 
                     if (!string.IsNullOrEmpty(info))
@@ -420,7 +420,7 @@ namespace Decompiler
 
                 if (OutputFile != null)
                 {
-                    using var contentFile = FileExtract.Extract(resource);
+                    using var contentFile = FileExtract.Extract(resource, null);
 
                     path = Path.ChangeExtension(path, extension);
                     var outFilePath = GetOutputPath(path);
@@ -884,7 +884,7 @@ namespace Decompiler
                             continue;
                         }
 
-                        contentFile = FileExtract.Extract(resource);
+                        contentFile = FileExtract.Extract(resource, fileLoader);
                     }
                     catch (Exception e)
                     {

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -75,6 +75,7 @@ namespace GUI.Forms
                         extractProgressBar.Style = ProgressBarStyle.Marquee;
                     }));
 
+                    Console.WriteLine($"Folder export started to \"{path}\"");
                     CalculateFilesToExtract(root);
 
                     Invoke((Action)(() =>
@@ -208,7 +209,7 @@ namespace GUI.Forms
                     {
                         if (contentFile.Data.Length > 0)
                         {
-                            Console.WriteLine($"Writing content file: {outFilePath}");
+                            Console.WriteLine($"+ {outFilePath.Remove(0, path.Length + 1)}");
                             await File.WriteAllBytesAsync(outFilePath, contentFile.Data, cancellationTokenSource.Token).ConfigureAwait(false);
                         }
 
@@ -217,6 +218,7 @@ namespace GUI.Forms
                         {
                             foreach (var (refFileName, refContentFile) in contentFile.ExternalRefsHandled)
                             {
+                                Invoke(() => extractStatusLabel.Text = $"Extracting {refFileName}");
                                 extractedFiles.Add(refFileName);
                                 await ExtractSubfiles(Path.GetDirectoryName(refFileName), refContentFile).ConfigureAwait(false);
                             }

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -169,7 +169,7 @@ namespace GUI.Forms
 
                     using (var resource = new Resource
                     {
-                        FileName = outFilePath,
+                        FileName = packageFile.GetFullPath(),
                     })
                     using (var memory = new MemoryStream(output))
                     {

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -66,7 +66,7 @@ namespace GUI.Types.Exporter
                 }
                 else
                 {
-                    using var contentFile = FileExtract.Extract(resource);
+                    using var contentFile = FileExtract.Extract(resource, exportData.VrfGuiContext?.FileLoader);
                     using var stream = dialog.OpenFile();
                     stream.Write(contentFile.Data);
 

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -411,7 +411,7 @@ namespace GUI.Types.Viewers
                 switch (resource.ResourceType)
                 {
                     case ResourceType.Material:
-                        AddContentTab(resTabs, "Reconstructed vmat", ((Material)block).ToValveMaterial());
+                        AddContentTab(resTabs, "Reconstructed vmat", new MaterialExtract(resource).ToValveMaterial());
                         break;
 
                     case ResourceType.EntityLump:
@@ -429,7 +429,7 @@ namespace GUI.Types.Viewers
                                 break;
                             }
 
-                            var textureExtract = new TextureExtract((Texture)resource.DataBlock, resource.FileName);
+                            var textureExtract = new TextureExtract(resource);
                             AddContentTab(resTabs, "Reconstructed vtex", textureExtract.ToValveTexture());
 
                             if (textureExtract.TryGetMksData(out var _, out var mks))

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -50,6 +50,9 @@ namespace ValveResourceFormat.IO
 
     public class ContentSubFile
     {
+        /// <remarks>
+        /// This is relative to the content file.
+        /// </remarks>
         public string FileName { get; set; }
         public virtual Func<byte[]> Extract { get; set; }
     }
@@ -119,7 +122,7 @@ namespace ValveResourceFormat.IO
                         );
 
                         contentFile.AddSubFile(
-                            fileName: lutFileName,
+                            fileName: Path.GetFileName(lutFileName),
                             extractFunction: () => ((PostProcessing)resource.DataBlock).GetRAWData()
                         );
 

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -11,17 +11,17 @@ namespace ValveResourceFormat.IO
     public class ContentFile : IDisposable
     {
         public byte[] Data { get; set; }
-        public List<ContentSubFile> SubFiles { get; init; } = new List<ContentSubFile>();
+        public List<SubFile> SubFiles { get; init; } = new List<SubFile>();
         public Dictionary<string, ContentFile> ExternalRefsHandled { get; init; } = new();
         public bool SubFilesAreExternal { get; set; }
         protected bool Disposed { get; private set; }
 
-        public void AddSubFile(string fileName, Func<byte[]> extractFunction)
+        public void AddSubFile(string fileName, Func<byte[]> extractMethod)
         {
-            var subFile = new ContentSubFile
+            var subFile = new SubFile
             {
                 FileName = fileName,
-                Extract = extractFunction
+                Extract = extractMethod
             };
 
             SubFiles.Add(subFile);
@@ -48,7 +48,7 @@ namespace ValveResourceFormat.IO
         }
     }
 
-    public class ContentSubFile
+    public class SubFile
     {
         /// <remarks>
         /// This is relative to the content file.
@@ -123,7 +123,7 @@ namespace ValveResourceFormat.IO
 
                         contentFile.AddSubFile(
                             fileName: Path.GetFileName(lutFileName),
-                            extractFunction: () => ((PostProcessing)resource.DataBlock).GetRAWData()
+                            extractMethod: () => ((PostProcessing)resource.DataBlock).GetRAWData()
                         );
 
                         break;

--- a/ValveResourceFormat/IO/MaterialExtract.cs
+++ b/ValveResourceFormat/IO/MaterialExtract.cs
@@ -46,6 +46,13 @@ public sealed class MaterialExtract
         //["multiblend"] = null,
         //["hero"] = null,
 
+        ["generic"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor") },
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal") },
+            ["g_tMetalnessReflectanceFresnel"] = new[] { (Channel.R, "TextureMetalness"), (Channel.G, "TextureReflectance"), (Channel.B, "TextureFresnel") },
+            ["g_tRoughness"] = new[] { (Channel.R, "TextureRoughness"), },
+        },
 
         ["vr_complex"] = new()
         {
@@ -102,6 +109,11 @@ public sealed class MaterialExtract
             ["g_tIrisMask"] = new[] { (Channel.R, "TextureIrisMask") },
             ["g_tSelfIllumMask"] = new[] { (Channel.R, "TextureSelfIllumMask") },
         },
+
+        ["sky"] = new()
+        {
+            ["g_tSkyTexture"] = new[] { (Channel.RGBA, "SkyTexture") },
+        }
     };
 
     public static readonly Dictionary<string, string> CommonTextureSuffixes = new()

--- a/ValveResourceFormat/IO/MaterialExtract.cs
+++ b/ValveResourceFormat/IO/MaterialExtract.cs
@@ -1,0 +1,445 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using ValveKeyValue;
+using ValveResourceFormat.Blocks;
+using ValveResourceFormat.ResourceTypes;
+
+namespace ValveResourceFormat.IO;
+
+using ChannelMapping = ValueTuple<MaterialExtract.Channel, string>;
+
+public sealed class MaterialExtract
+{
+    public struct UnpackInfo
+    {
+        public string TextureType { get; init; }
+        public string FileName { get; init; }
+        public Channel Channel { get; init; }
+    }
+
+    public enum Channel
+    {
+        R,
+        G,
+        B,
+        A,
+        _OneChannel,
+        GA,
+        _TwoChannels,
+        RGB,
+        RGBA
+    }
+
+    public static readonly Dictionary<string, Dictionary<string, ChannelMapping[]>> TextureMappings = new()
+    {
+        ["global_lit_simple"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, "TextureTranslucency") },
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal") },
+            ["g_tSpecular"] = new[] { (Channel.R, "TextureReflectance"), (Channel.G, "TextureSelfIllum"), (Channel.B, "TextureBloom") },
+        },
+
+        //["multiblend"] = null,
+        //["hero"] = null,
+
+
+        ["vr_complex"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, string.Empty) }, // Alpha can be metal or translucency
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal"), (Channel.A, "TextureRoughness") }, // TODO: Figure out anisotropic gloss
+
+            // These all work fine thanks to consistent names, but we can clean them up to save disk size.
+            // E.g. RGBA -> R (Grayscale)
+            ["g_tAmbientOcclusion"] = new[] { (Channel.R, "TextureAmbientOcclusion") },
+            ["g_tTintMask"] = new[] { (Channel.R, "TextureTintMask") },
+
+            ["g_tMetalness"] = new[] { (Channel.R, "TextureMetalness") },
+            ["g_tSelfIllumMask"] = new[] { (Channel.R, "TextureSelfIllumMask") },
+            ["g_tBentNormal"] = new[] { (Channel.RGB, "TextureBentNormal") }, // ATI2N
+
+            ["g_tDetail"] = new[] { (Channel.RGB, "TextureDetail") },
+            ["g_tDetailMask"] = new[] { (Channel.R, "TextureDetailMask") },
+            ["g_tNormalDetail"] = new[] { (Channel.RGB, "TextureNormalDetail") }, // ATI2N
+
+            ["g_tSquishColor"] = new[] { (Channel.RGB, "TextureSquishColor") },
+            ["g_tStretchColor"] = new[] { (Channel.RGB, "TextureStretchColor") },
+            ["g_tSquishNormal"] = new[] { (Channel.RGB, "TextureSquishNormal") },
+            ["g_tStretchNormal"] = new[] { (Channel.RGB, "TextureStretchNormal") },
+            ["g_tSquishAmbientOcclusion"] = new[] { (Channel.R, "TextureSquishAmbientOcclusion") },
+            ["g_tStretchAmbientOcclusion"] = new[] { (Channel.R, "TextureStretchAmbientOcclusion") },
+
+        },
+
+        ["vr_simple"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, string.Empty) }, // Alpha can be ao, metal or nothing at all
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal"), (Channel.A, "TextureRoughness") },
+
+            ["g_tAmbientOcclusion"] = new[] { (Channel.R, "TextureAmbientOcclusion") },
+            ["g_tTintMask"] = new[] { (Channel.R, "TextureTintMask") },
+        },
+
+        ["vr_simple_2way_blend"] = new()
+        {
+            ["g_tColorA"] = new[] { (Channel.RGB, "TextureColorA"), (Channel.A, "TextureMetalnessA") },
+            ["g_tNormalA"] = new[] { (Channel.RGB, "TextureNormalA"), (Channel.A, "TextureRoughnessA") },
+            ["g_tColorB"] = new[] { (Channel.RGB, "TextureColorB"), (Channel.A, "TextureMetalnessB") },
+            ["g_tNormalB"] = new[] { (Channel.RGB, "TextureNormalB"), (Channel.A, "TextureRoughnessB") },
+
+            ["g_tMask"] = new[] { (Channel.R, "TextureMask") },
+        },
+
+        ["vr_eyeball"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, "TextureReflectance") },
+            ["g_tIris"] = new[] { (Channel.RGB, "IrisNormal"), (Channel.A, "IrisRoughness") },
+            ["g_tNormal"] = new[] { (Channel.GA, "TextureNormal") },
+
+            ["g_tIrisMask"] = new[] { (Channel.R, "TextureIrisMask") },
+            ["g_tSelfIllumMask"] = new[] { (Channel.R, "TextureSelfIllumMask") },
+        },
+    };
+
+    public static readonly Dictionary<string, string> CommonTextureSuffixes = new()
+    {
+        { "TextureColor", "_color" },
+        { "TextureNormal", "_normal" },
+        { "TextureRoughness", "_rough" },
+        { "TextureMetalness", "_metal" },
+        { "TextureAmbientOcclusion", "_ao" },
+        { "TextureReflectance", "_refl"}
+    };
+
+    private static bool IsDefaultTexture(string textureFileName)
+        => textureFileName.StartsWith("materials/default/", StringComparison.OrdinalIgnoreCase);
+
+    private readonly Material material;
+    private readonly ResourceEditInfo editInfo;
+    private readonly IFileLoader fileLoader;
+
+    public MaterialExtract(Material material, ResourceEditInfo editInfo, IFileLoader fileLoader)
+    {
+        this.material = material;
+        this.editInfo = editInfo;
+        this.fileLoader = fileLoader;
+    }
+
+    public MaterialExtract(Resource resource, IFileLoader fileLoader = null)
+        : this((Material)resource.DataBlock, resource.EditInfo, fileLoader)
+    {
+    }
+
+    public ContentFile ToContentFile()
+    {
+        var vmat = new ContentFile
+        {
+            Data = Encoding.UTF8.GetBytes(ToValveMaterial())
+        };
+
+        foreach (var (type, filePath) in material.TextureParams)
+        {
+            var texture = fileLoader?.LoadFile(filePath + "_c");
+            if (texture is null)
+            {
+                continue;
+            }
+
+            var images = GetInputImagesForTexture(type, filePath, true, material.IntParams, material.VectorParams);
+            var vtex = new TextureExtract(texture).ToMaterialMaps(images);
+
+            vmat.ExternalRefsHandled.Add(filePath + "_c", vtex);
+            vmat.SubFilesAreExternal = true;
+            vmat.SubFiles.AddRange(vtex.SubFiles);
+        }
+
+        return vmat;
+    }
+
+    public static string OutTextureName(string texturePath, bool keepOriginalExtension, string desiredSuffix = null)
+    {
+        if (!texturePath.EndsWith(".vtex", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new ArgumentException($"{texturePath} must have .vtex", nameof(texturePath));
+        }
+
+        texturePath = Path.ChangeExtension(texturePath, null); // strip '.vtex'
+        if (texturePath.EndsWith(".generated", StringComparison.OrdinalIgnoreCase))
+        {
+            texturePath = Path.ChangeExtension(texturePath, null);
+        }
+
+        var textureParts = Path.GetFileName(texturePath).Split('_');
+        if (textureParts.Length > 2)
+        {
+            if (textureParts[^1].All("0123456789abcdef".Contains)             // This is a hash
+            && (textureParts[^2].Length >= 3 && textureParts[^2].Length <= 4) // This is the original extension
+            && !string.IsNullOrEmpty(string.Join("_", textureParts[..^2])))   // Name of the Input[0] image
+            {
+                texturePath = Path.Combine(Path.GetDirectoryName(texturePath), string.Join("_", textureParts[..^2]));
+                texturePath = texturePath.Replace(Path.DirectorySeparatorChar, '/');
+            }
+            // Also seen "{MAT}_vmat_{G_TPARAM}_{HASH}.vtex"
+        }
+
+        if (desiredSuffix is not null)
+        {
+            // Strip e.g. _color if we want _metal
+            if (!texturePath.EndsWith(desiredSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                foreach (var suffix in CommonTextureSuffixes.Values)
+                {
+                    if (texturePath.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+                    {
+                        texturePath = texturePath[..^suffix.Length];
+                        break;
+                    }
+                }
+            }
+            // Keep the hash to avoid conflicts
+            texturePath += "_" + textureParts[^1] + desiredSuffix;
+        }
+
+        return Path.ChangeExtension(texturePath, keepOriginalExtension ? textureParts[^2] : "png");
+    }
+
+    public IEnumerable<UnpackInfo> GetInputImagesForTexture(string textureType, string texturePath, bool omitDefault,
+            Dictionary<string, long> intParams, Dictionary<string, Vector4> vectorParams)
+    {
+        var shader = material.ShaderName[..^4]; // strip '.vfx'
+
+        if (TextureMappings.TryGetValue(shader, out var mappings) && mappings.TryGetValue(textureType, out var channelMappings))
+        {
+            var isInput0 = true;
+            foreach (var mapping in channelMappings)
+            {
+                var (channel, newTextureType) = mapping;
+                if (newTextureType.Length == 0 && !TryFigureOutNonStaticMap(shader, textureType, intParams, out newTextureType))
+                {
+                    continue;
+                }
+
+                if (vectorParams.ContainsKey(newTextureType))
+                {
+                    continue;
+                }
+
+                string desiredSuffix = null;
+                if (!isInput0)
+                {
+                    desiredSuffix = "-" + channel;
+                    foreach (var (commonType, commonSuffix) in CommonTextureSuffixes)
+                    {
+                        // Allow matching TextureColorB with TextureColor
+                        if (newTextureType.StartsWith(commonType, StringComparison.OrdinalIgnoreCase))
+                        {
+                            desiredSuffix = commonSuffix;
+                            break;
+                        }
+                    }
+                }
+
+                var keepOriginalExtension = false;
+                if (isInput0 && IsDefaultTexture(texturePath))
+                {
+                    if (omitDefault)
+                    {
+                        isInput0 = false;
+                        continue;
+                    }
+
+                    keepOriginalExtension = true;
+                }
+
+                var fileName = OutTextureName(texturePath, keepOriginalExtension, desiredSuffix);
+
+                yield return new UnpackInfo
+                {
+                    TextureType = newTextureType,
+                    FileName = fileName,
+                    Channel = channel
+                };
+
+                isInput0 = false;
+            }
+
+            yield break;
+        }
+
+        // No pack info for this texture, so just clean up filename and try to guess its type.
+        var guessedTextureType = textureType.Replace("g_t", "Texture", StringComparison.Ordinal);
+        if (!vectorParams.ContainsKey(guessedTextureType))
+        {
+            Console.WriteLine($"Missing pack info for {textureType} in {shader}");
+            yield return new UnpackInfo
+            {
+                TextureType = guessedTextureType,
+                FileName = OutTextureName(texturePath, false),
+                Channel = Channel.RGBA
+            };
+        }
+    }
+
+    public static bool TryFigureOutNonStaticMap(string shader, string textureType, Dictionary<string, long> intParams, out string newTextureType)
+    {
+        if (shader == "vr_simple" && textureType == "g_tColor")
+        {
+            if (intParams.GetValueOrDefault("F_METALNESS_TEXTURE") != 0)
+            {
+                newTextureType = "TextureMetalness";
+                return true;
+            }
+
+            if (intParams.GetValueOrDefault("F_AMBIENT_OCCLUSION_TEXTURE") != 0)
+            {
+                newTextureType = "TextureAmbientOcclusion";
+                return true;
+            }
+        }
+
+        else if (shader == "vr_complex" && textureType == "g_tColor")
+        {
+            newTextureType = "TextureMetalness";
+
+            if (intParams.GetValueOrDefault("F_TRANSLUCENT") != 0
+            || intParams.GetValueOrDefault("F_ALPHA_TEST") != 0)
+            {
+                newTextureType = "TextureTranslucency";
+            }
+
+            return true;
+        }
+
+        newTextureType = null;
+        return false;
+    }
+
+    public string ToValveMaterial()
+    {
+        var root = new KVObject("Layer0", new List<KVObject>())
+        {
+            new KVObject("shader", material.ShaderName)
+        };
+
+        foreach (var (key, value) in material.IntParams)
+        {
+            root.Add(new KVObject(key, value));
+        }
+
+        foreach (var (key, value) in material.FloatParams)
+        {
+            root.Add(new KVObject(key, value));
+        }
+
+        foreach (var (key, value) in material.VectorParams)
+        {
+            root.Add(new KVObject(key, $"[{value.X:N6} {value.Y:N6} {value.Z:N6} {value.W:N6}]"));
+        }
+
+        var originalTextures = new KVObject("VRF Original Textures", new List<KVObject>());
+        foreach (var (key, value) in material.TextureParams)
+        {
+            foreach (var unpackInfo in GetInputImagesForTexture(key, value, false, material.IntParams, material.VectorParams))
+            {
+                root.Add(new KVObject(unpackInfo.TextureType, unpackInfo.FileName));
+            }
+
+            originalTextures.Add(new KVObject(key, value));
+        }
+
+        root.Add(originalTextures);
+
+        if (material.DynamicExpressions.Count > 0)
+        {
+            var dynamicExpressionsNode = new KVObject("DynamicParams", new List<KVObject>());
+            root.Add(dynamicExpressionsNode);
+            foreach (var (key, value) in material.DynamicExpressions)
+            {
+                dynamicExpressionsNode.Add(new KVObject(key, value));
+            }
+        }
+
+        var attributes = new List<KVObject>();
+
+        foreach (var (key, value) in material.IntAttributes)
+        {
+            // not defined by user, so skip it
+            if (key.Equals("representativetexturewidth", StringComparison.OrdinalIgnoreCase)
+            || key.Equals("representativetextureheight", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+            attributes.Add(new KVObject(key, value));
+        }
+
+        foreach (var (key, value) in material.FloatAttributes)
+        {
+            // Skip `int` definition if there is a `float` definition
+            attributes = attributes.Where(existing_key => existing_key.Name != key).ToList();
+            attributes.Add(new KVObject(key, value));
+        }
+
+        foreach (var (key, value) in material.VectorAttributes)
+        {
+            attributes.Add(new KVObject(key, $"[{value.X:N6} {value.Y:N6} {value.Z:N6} {value.W:N6}]"));
+        }
+
+        foreach (var (key, value) in material.StringAttributes)
+        {
+            attributes.Add(new KVObject(key, value ?? string.Empty));
+        }
+
+        var attributesThatAreSystemAttributes = new HashSet<string>
+        {
+            "physicssurfaceproperties",
+            "worldmappingwidth",
+            "worldmappingheight"
+        };
+
+        if (attributes.Any())
+        {
+            // Some attributes are actually SystemAttributes
+            var systemAttributes = attributes.Where(attribute => attributesThatAreSystemAttributes.Contains(attribute.Name.ToLower())).ToList();
+            attributes = attributes.Except(systemAttributes).ToList();
+
+            if (attributes.Any())
+            {
+                root.Add(new KVObject("Attributes", attributes));
+            }
+
+            if (systemAttributes.Any())
+            {
+                root.Add(new KVObject("SystemAttributes", systemAttributes));
+            }
+        }
+
+        string subrectDefinition = null;
+
+        if (editInfo is ResourceEditInfo2 redi2)
+        {
+            subrectDefinition = redi2.SearchableUserData.Where(x => x.Key.ToLower() == "subrectdefinition").FirstOrDefault().Value as string;
+        }
+        else
+        {
+            var extraStringData = (Blocks.ResourceEditInfoStructs.ExtraStringData)editInfo.Structs[ResourceEditInfo.REDIStruct.ExtraStringData];
+            subrectDefinition = extraStringData.List.Where(x => x.Name.ToLower() == "subrectdefinition").FirstOrDefault()?.Value;
+        }
+
+        if (subrectDefinition != null)
+        {
+            var toolattributes = new List<KVObject>()
+                {
+                    new KVObject("SubrectDefinition", subrectDefinition)
+                };
+
+            root.Add(new KVObject("ToolAttributes", toolattributes));
+        }
+
+        using var ms = new MemoryStream();
+        KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Serialize(ms, root);
+        return Encoding.UTF8.GetString(ms.ToArray());
+    }
+}

--- a/ValveResourceFormat/IO/MaterialExtract.cs
+++ b/ValveResourceFormat/IO/MaterialExtract.cs
@@ -44,7 +44,25 @@ public sealed class MaterialExtract
         },
 
         //["multiblend"] = null,
-        //["hero"] = null,
+
+        ["hero"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, "TextureTranslucency") },
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal") },
+            ["g_tCubeMap"] = new[] { (Channel.RGBA, "TextureCubeMap") },
+            ["g_tCubeMapSeparateMask"] = new[] { (Channel.G, "TextureCubeMapSeparateMask") },
+            ["g_tFresnelWarp"] = new[] { (Channel.R, "TextureFresnelWarpRim"), (Channel.G, "TextureFresnelWarpColor"), (Channel.B, "TextureFresnelWarpSpec") },
+            ["g_tMasks1"] = new[] { (Channel.R, "TextureDetailMask"), (Channel.G, "TextureDiffuseWarpMask"), (Channel.B, "TextureMetalnessMask"), (Channel.A, "TextureSelfIllumMask") },
+            ["g_tMasks2"] = new[] { (Channel.R, "TextureSpecularMask"), (Channel.G, "TextureRimMask"), (Channel.B, "TextureTintByBaseMask"), (Channel.A, "TextureSpecularExponent") },
+        },
+
+        ["grasstile_preview"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, "TextureTranslucency") },
+            ["g_tTintMask"] = new[] { (Channel.G, "TextureTintMask") },
+            ["g_tSpecular"] = new[] { (Channel.G, "TextureReflectance") },
+            ["g_tSelfIllum"] = new[] { (Channel.G, "TextureSelfIllum") },
+        },
 
         ["generic"] = new()
         {
@@ -118,12 +136,22 @@ public sealed class MaterialExtract
 
     public static readonly Dictionary<string, string> CommonTextureSuffixes = new()
     {
+        { "TextureDetailMask", "_detailmask" },
+        { "TextureDiffuseWarpMask", "_diffusemask" },
+        { "TextureMetalnessMask", "_metalnessmask" },
+        { "TextureSelfIllumMask", "_selfillummask" },
+
+        { "TextureSpecularMask", "_specmask" },
+        { "TextureRimMask", "_rimmask" },
+        { "TextureTintByBaseMask", "_basetintmask" },
+        { "TextureSpecularExponent", "_specexp" },
+
         { "TextureColor", "_color" },
         { "TextureNormal", "_normal" },
         { "TextureRoughness", "_rough" },
         { "TextureMetalness", "_metal" },
         { "TextureAmbientOcclusion", "_ao" },
-        { "TextureReflectance", "_refl"}
+        { "TextureReflectance", "_refl"},
     };
 
     private static bool IsDefaultTexture(string textureFileName)

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -175,20 +175,9 @@ public sealed class TextureExtract
 
         if (channel == Channel.RGB)
         {
-            if (bitmap.Info.IsOpaque)
-            {
-                return EncodePng(bitmap);
-            }
-
-            using var newBitmap = bitmap.Copy();
-            using var newPixelmap = newBitmap.PeekPixels();
-            var newPixels = newPixelmap.GetPixelSpan<SKColor>();
-
-            // expensive transparency workaround for color maps
-            for (var i = 0; i < newPixels.Length; i++)
-            {
-                newPixels[i] = newPixels[i].WithAlpha(255);
-            }
+            using var _bitmap = bitmap.Copy();
+            using var _pixelmap = _bitmap.PeekPixels();
+            using var newPixelmap = _pixelmap.WithAlphaType(SKAlphaType.Opaque);
 
             return EncodePng(newPixelmap);
         }

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -35,7 +35,7 @@ public class TextureContentFile : ContentFile
     }
 }
 
-public sealed class ImageSubFile : ContentSubFile
+public sealed class ImageSubFile : SubFile
 {
     public SKBitmap Bitmap { get; init; }
     public Func<SKBitmap, byte[]> ImageExtract { get; init; }

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -79,17 +79,17 @@ public sealed class TextureExtract
 
         if (TryGetMksData(out var sprites, out var mks))
         {
-            vtex.AddSubFile(GetMksFileName(), () => Encoding.UTF8.GetBytes(mks));
+            vtex.AddSubFile(Path.GetFileName(GetMksFileName()), () => Encoding.UTF8.GetBytes(mks));
 
             foreach (var (spriteRect, spriteFileName) in sprites)
             {
-                vtex.AddImageSubFile(spriteFileName, (bitmap) => SubsetToPngImage(bitmap, spriteRect));
+                vtex.AddImageSubFile(Path.GetFileName(spriteFileName), (bitmap) => SubsetToPngImage(bitmap, spriteRect));
             }
 
             return vtex;
         }
 
-        vtex.AddImageSubFile(GetImageFileName(), ToPngImage);
+        vtex.AddImageSubFile(Path.GetFileName(GetImageFileName()), ToPngImage);
         return vtex;
     }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -3,8 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
-using System.Text;
-using ValveKeyValue;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.Blocks.ResourceEditInfoStructs;
 using ValveResourceFormat.Serialization;
@@ -132,123 +130,6 @@ namespace ValveResourceFormat.ResourceTypes
             }
 
             return arguments;
-        }
-
-        public string ToValveMaterial()
-        {
-            var root = new KVObject("Layer0", new List<KVObject>());
-
-            root.Add(new KVObject("shader", ShaderName));
-
-            foreach (var (key, value) in IntParams)
-            {
-                root.Add(new KVObject(key, value));
-            }
-
-            foreach (var (key, value) in FloatParams)
-            {
-                root.Add(new KVObject(key, value));
-            }
-
-            foreach (var (key, value) in VectorParams)
-            {
-                root.Add(new KVObject(key, $"[{value.X:N6} {value.Y:N6} {value.Z:N6} {value.W:N6}]"));
-            }
-
-            foreach (var (key, value) in TextureParams)
-            {
-                root.Add(new KVObject(key, value));
-            }
-
-            if (DynamicExpressions.Count > 0)
-            {
-                var dynamicExpressionsNode = new KVObject("DynamicParams", new List<KVObject>());
-                root.Add(dynamicExpressionsNode);
-                foreach (var (key, value) in DynamicExpressions)
-                {
-                    dynamicExpressionsNode.Add(new KVObject(key, value));
-                }
-            }
-
-            var attributes = new List<KVObject>();
-
-            foreach (var (key, value) in IntAttributes)
-            {
-                // not defined by user, so skip it
-                if (key.Equals("representativetexturewidth", StringComparison.OrdinalIgnoreCase)
-                || key.Equals("representativetextureheight", StringComparison.OrdinalIgnoreCase))
-                {
-                    continue;
-                }
-                attributes.Add(new KVObject(key, value));
-            }
-
-            foreach (var (key, value) in FloatAttributes)
-            {
-                // Skip `int` definition if there is a `float` definition
-                attributes = attributes.Where(existing_key => existing_key.Name != key).ToList();
-                attributes.Add(new KVObject(key, value));
-            }
-
-            foreach (var (key, value) in VectorAttributes)
-            {
-                attributes.Add(new KVObject(key, $"[{value.X:N6} {value.Y:N6} {value.Z:N6} {value.W:N6}]"));
-            }
-
-            foreach (var (key, value) in StringAttributes)
-            {
-                attributes.Add(new KVObject(key, value ?? string.Empty));
-            }
-
-            var attributesThatAreSystemAttributes = new HashSet<string>
-            {
-                "physicssurfaceproperties",
-                "worldmappingwidth",
-                "worldmappingheight"
-            };
-
-            if (attributes.Any())
-            {
-                // Some attributes are actually SystemAttributes
-                var systemAttributes = attributes.Where(attribute => attributesThatAreSystemAttributes.Contains(attribute.Name.ToLower())).ToList();
-                attributes = attributes.Except(systemAttributes).ToList();
-
-                if (attributes.Any())
-                {
-                    root.Add(new KVObject("Attributes", attributes));
-                }
-
-                if (systemAttributes.Any())
-                {
-                    root.Add(new KVObject("SystemAttributes", systemAttributes));
-                }
-            }
-
-            string subrectDefinition = null;
-
-            if (Resource.EditInfo is ResourceEditInfo2)
-            {
-                subrectDefinition = ((ResourceEditInfo2)Resource.EditInfo).SearchableUserData.Where(x => x.Key.ToLower() == "subrectdefinition").FirstOrDefault().Value as string;
-            }
-            else if (Resource.EditInfo is ResourceEditInfo)
-            {
-                var extraStringData = (ExtraStringData)Resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.ExtraStringData];
-                subrectDefinition = extraStringData.List.Where(x => x.Name.ToLower() == "subrectdefinition").FirstOrDefault()?.Value;
-            }
-
-            if (subrectDefinition != null)
-            {
-                var toolattributes = new List<KVObject>()
-                {
-                    new KVObject("SubrectDefinition", subrectDefinition)
-                };
-
-                root.Add(new KVObject("ToolAttributes", toolattributes));
-            }
-
-            using var ms = new MemoryStream();
-            KVSerializer.Create(KVSerializationFormat.KeyValues1Text).Serialize(ms, root);
-            return Encoding.UTF8.GetString(ms.ToArray());
         }
     }
 }


### PR DESCRIPTION
From asset without content:
<img src="https://user-images.githubusercontent.com/26466974/200870149-205ac42c-f2f0-42a2-bf5b-c2dc66ab49ac.png" width=50%>
To recompiled and working:
<img src="https://user-images.githubusercontent.com/26466974/200870340-69022fa2-56ae-4843-b8fa-6c8a18ef70a5.png" width=50%>
<img src="https://user-images.githubusercontent.com/26466974/200888971-7d834e15-6f43-4436-af82-b60b76b49b6d.png" width=50%>

- [x] Cleanup.
- [ ] Add more shader mappings.
- [ ] Alternatively, gather packing data from actual shader files.
- [ ] Fix any bad color transformations (some BC7 stuff, alpha premul). `gman_pants.vmat`

Folder extracts:
- [x] Extract reused textures only once.
- [x] Extract materials first, then textures, skipping any textures that were first handled by MaterialExtract.
- [x] Textures sitting on a whole different folder get written to that folder, unlike single file extract which places all textures next to the material. This makes links inside materials work 100%. GUI only.
