### PR TITLE
Check trailer in older binary kv3 files, match behavior with engine

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/BinaryKV3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/BinaryKV3.cs
@@ -112,6 +112,12 @@ namespace ValveResourceFormat.ResourceTypes
             }
 
             Data = ParseBinaryKV3(outRead, null, true);
+
+            var trailer = outRead.ReadUInt32();
+            if (trailer != 0xFFFFFFFF)
+            {
+                throw new UnexpectedMagicException("Invalid trailer", trailer, nameof(trailer));
+            }
         }
 
         private void ReadVersion3(BinaryReader reader, BinaryWriter outWrite, BinaryReader outRead)


### PR DESCRIPTION
Without this trailer engine reports "Unexpected end of file". If this trailer is something else it reports "Invalid data", even though the data may be perfectly fine. Affects kv3 version 1 (VKV\x03).
