### PR TITLE
s&box shader compatibility

### DIFF
--- a/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
+++ b/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
@@ -37,6 +37,14 @@ namespace ValveResourceFormat.CompiledShader
             if (VcsFileVersion >= 64)
             {
                 psrs_arg = datareader.ReadInt32();
+
+                // S&box - there is no psrs here. Just a 2 and a 0
+                if (psrs_arg == 2)
+                {
+                    psrs_arg = 0;
+                    datareader.BaseStream.Position += 4;
+                    VcsFileVersion = 64;
+                }
             }
 
             if (psrs_arg != 0 && psrs_arg != 1)
@@ -115,7 +123,16 @@ namespace ValveResourceFormat.CompiledShader
             if (vcs_version >= 64)
             {
                 has_psrs_file = DataReader.ReadInt32AtPosition();
-                DataReader.ShowBytes(4, "has_psrs_file = " + (has_psrs_file > 0 ? "True" : "False"));
+                if (has_psrs_file == 2)
+                {
+                    DataReader.ShowBytes(4, "s&box const int 2");
+                    DataReader.ShowBytes(4, "s&box int");
+                    vcs_version = 64;
+                }
+                else
+                {
+                    DataReader.ShowBytes(4, "has_psrs_file = " + (has_psrs_file > 0 ? "True" : "False"));
+                }
             }
             var version = DataReader.ReadInt32AtPosition();
             DataReader.ShowBytes(4, $"Version = {version}");
@@ -221,6 +238,15 @@ namespace ValveResourceFormat.CompiledShader
             if (VcsFileVersion >= 64)
             {
                 psrs_arg = datareader.ReadInt32();
+
+                // S&box - there is no psrs here. Just a 2 and a 0
+                if (psrs_arg == 2)
+                {
+                    psrs_arg = 0;
+                    datareader.BaseStream.Position += 4;
+                    VcsFileVersion = 64;
+                }
+
                 if (psrs_arg != 0 && psrs_arg != 1)
                 {
                     throw new ShaderParserException($"Unexpected value psrs_arg = {psrs_arg}");

--- a/ValveResourceFormat/CompiledShader/ShaderFile.cs
+++ b/ValveResourceFormat/CompiledShader/ShaderFile.cs
@@ -283,8 +283,6 @@ namespace ValveResourceFormat.CompiledShader
         }
 #pragma warning restore CA1024
 
-        private uint zFrameCount;
-
         public void PrintByteDetail(bool shortenOutput = true, HandleOutputWrite outputWriter = null)
         {
             DataReader.OutputWriter = outputWriter ?? ((x) => { Console.Write(x); });
@@ -374,7 +372,7 @@ namespace ValveResourceFormat.CompiledShader
                 DataReader.BreakLine();
             }
 
-            PrintZframes(shortenOutput);
+            PrintZframes(shortenOutput, out var zFrameCount);
             if (shortenOutput && zFrameCount > SKIP_ZFRAMES_IF_MORE_THAN)
             {
                 DataReader.Comment("rest of data contains compressed zframes");
@@ -392,7 +390,7 @@ namespace ValveResourceFormat.CompiledShader
         private const int SKIP_ZFRAMES_IF_MORE_THAN = 10;
         private const int MAX_ZFRAME_BYTES_TO_SHOW = 96;
 
-        private void PrintZframes(bool shortenOutput)
+        private void PrintZframes(bool shortenOutput, out uint zFrameCount)
         {
             //
             // The zFrameIds and zFrameDataOffsets are read as two separate lists before the data section starts

--- a/ValveResourceFormat/Resource/Enums/ResourceType.cs
+++ b/ValveResourceFormat/Resource/Enums/ResourceType.cs
@@ -123,5 +123,8 @@ namespace ValveResourceFormat
 
         [Extension("sbox")] // TODO: Managed resources can have any extension
         SboxManagedResource,
+
+        [Extension("shader")]
+        Shader,
     }
 }

--- a/ValveResourceFormat/Resource/Resource.cs
+++ b/ValveResourceFormat/Resource/Resource.cs
@@ -451,6 +451,9 @@ namespace ValveResourceFormat
                 case ResourceType.ArtifactItem:
                     return new Plaintext();
 
+                case ResourceType.Shader:
+                    return new SboxShader();
+
                 case ResourceType.PhysicsCollisionMesh:
                     return new PhysAggregateData();
 

--- a/ValveResourceFormat/Resource/ResourceTypes/SboxShader.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/SboxShader.cs
@@ -1,0 +1,121 @@
+using System;
+using System.IO;
+using ValveResourceFormat.Blocks;
+using ValveResourceFormat.CompiledShader;
+
+namespace ValveResourceFormat.ResourceTypes
+{
+    public class SboxShader : ResourceData
+    {
+        public ShaderFile Features { get; private set; }
+        public ShaderFile Vertex { get; private set; }
+        public ShaderFile Pixel { get; private set; }
+        public ShaderFile Geometry { get; private set; }
+        public ShaderFile Hull { get; private set; }
+        public ShaderFile Domain { get; private set; }
+        public ShaderFile Compute { get; private set; }
+
+        public override void Read(BinaryReader reader, Resource resource)
+        {
+            reader.BaseStream.Position = Offset;
+
+            var featuresOffset = reader.ReadUInt32();
+            var featuresSize = reader.ReadUInt32();
+            var vertexOffset = reader.ReadUInt32();
+            var vertexSize = reader.ReadUInt32();
+            var pixelOffset = reader.ReadUInt32();
+            var pixelSize = reader.ReadUInt32();
+            var geometryOffset = reader.ReadUInt32();
+            var geometrySize = reader.ReadUInt32();
+            var hullOffset = reader.ReadUInt32();
+            var hullSize = reader.ReadUInt32();
+            var domainOffset = reader.ReadUInt32();
+            var domainSize = reader.ReadUInt32();
+            var computeOffset = reader.ReadUInt32();
+            var computeSize = reader.ReadUInt32();
+
+            var shaderName = Path.GetFileNameWithoutExtension(resource.FileName);
+
+            if (featuresOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + featuresOffset;
+                Features = new ShaderFile();
+                Features.Read(
+                    $"{shaderName}_pc_50_features.vcs",
+                    new MemoryStream(reader.ReadBytes((int)featuresSize))
+                );
+            }
+
+            if (vertexOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + vertexOffset;
+                Vertex = new ShaderFile();
+                Vertex.Read(
+                    $"{shaderName}_pc_50_vs.vcs",
+                    new MemoryStream(reader.ReadBytes((int)vertexSize))
+                );
+            }
+
+            if (pixelOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + pixelOffset;
+                Pixel = new ShaderFile();
+                Pixel.Read(
+                    $"{shaderName}_pc_50_ps.vcs",
+                    new MemoryStream(reader.ReadBytes((int)pixelSize))
+                );
+            }
+
+            if (geometryOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + geometryOffset;
+                Geometry = new ShaderFile();
+                Geometry.Read(
+                    $"{shaderName}_pc_50_gs.vcs",
+                    new MemoryStream(reader.ReadBytes((int)geometrySize))
+                );
+            }
+
+            if (hullOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + hullOffset;
+                Hull = new ShaderFile();
+                Hull.Read(
+                    $"{shaderName}_pc_50_hs.vcs",
+                    new MemoryStream(reader.ReadBytes((int)hullSize))
+                );
+            }
+
+            if (domainOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + domainOffset;
+                Domain = new ShaderFile();
+                Domain.Read(
+                    $"{shaderName}_pc_50_ds.vcs",
+                    new MemoryStream(reader.ReadBytes((int)domainSize))
+                );
+            }
+
+            if (computeOffset != 0)
+            {
+                reader.BaseStream.Position = Offset + computeOffset;
+                Compute = new ShaderFile();
+                Compute.Read(
+                    $"{shaderName}_pc_50_cs.vcs",
+                    new MemoryStream(reader.ReadBytes((int)computeSize))
+                );
+            }
+        }
+
+        public override void WriteText(IndentedTextWriter writer)
+        {
+            Features?.PrintSummary((x) => writer.Write(x));
+            Vertex?.PrintSummary((x) => writer.Write(x));
+            Pixel?.PrintSummary((x) => writer.Write(x));
+            Geometry?.PrintSummary((x) => writer.Write(x));
+            Hull?.PrintSummary((x) => writer.Write(x));
+            Domain?.PrintSummary((x) => writer.Write(x));
+            Compute?.PrintSummary((x) => writer.Write(x));
+        }
+    }
+}


### PR DESCRIPTION
The ShaderFiles are embedded in .shader_c ResourceData. There is also a hack with the ShaderFile itself to make it load (facepunch moved to v65 but its really still just v64). Also note: they seem to serialize the compute shader twice in their resource.