### PR TITLE
glTF materials: metal texture & merge some logic with MaterialExtract

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -85,6 +85,9 @@ namespace Decompiler
         [Option("--gltf_export_materials", "Whether to export materials during glTF exports.", CommandOptionType.NoValue)]
         public bool GltfExportMaterials { get; }
 
+        [Option("--gltf_textures_adapt", "Whether to perform any glTF spec adaptations on textures (e.g. split metallic map).", CommandOptionType.NoValue)]
+        public bool GltfExportAdaptTextures { get; }
+
         private string[] ExtFilterList;
         private bool IsInputFolder;
 
@@ -836,6 +839,7 @@ namespace Decompiler
                             var gltfModelExporter = new GltfModelExporter
                             {
                                 ExportMaterials = GltfExportMaterials,
+                                AdaptTextures = GltfExportAdaptTextures,
                                 ProgressReporter = new Progress<string>(progress => Console.WriteLine($"--- {progress}")),
                                 FileLoader = fileLoader
                             };

--- a/Tests/ExtractTest.cs
+++ b/Tests/ExtractTest.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using ValveResourceFormat.IO;
+using ValveResourceFormat.ResourceTypes;
+
+namespace Tests
+{
+    public class MaterialExtractTest
+    {
+        [Test]
+        public void TextureInputsForFeatureState([Values(false, true)] bool translucent)
+        {
+            var featureState = new Dictionary<string, long>
+            {
+                ["F_TRANSLUCENT"] = translucent ? 1 : 0
+            };
+
+            var vr_complex_expected_inputs = new[] {
+                (MaterialExtract.Channel.RGB, "TextureColor"),
+                (MaterialExtract.Channel.A, translucent ? "TextureTranslucency" : "TextureMetalness")
+            };
+
+            var result = MaterialExtract.GetTextureInputs("vr_complex.vfx", "g_tColor", featureState);
+            Assert.That(result, Is.EquivalentTo(vr_complex_expected_inputs));
+        }
+
+        [Test]
+        public void TextureInputPaths([Values(false, true)] bool translucent)
+        {
+            var mockMaterial = new Material()
+            {
+                ShaderName = "vr_complex.vfx",
+            };
+
+            mockMaterial.IntParams["F_TRANSLUCENT"] = translucent ? 1 : 0;
+
+            var vr_complex_expected_inputs = new[] {
+                new MaterialExtract.UnpackInfo()
+                {
+                    TextureType = "TextureColor",
+                    FileName = "test_color.png",
+                    Channel = MaterialExtract.Channel.RGB
+                },
+                new MaterialExtract.UnpackInfo()
+                {
+                    TextureType = translucent ? "TextureTranslucency" : "TextureMetalness",
+                    FileName = translucent ? "test_65b7aff5-A.png" : "test_65b7aff5_metal.png",
+                    Channel = MaterialExtract.Channel.A
+                }
+            };
+
+            var result = MaterialExtract.GetTextureUnpackInfos("g_tColor", "test_color_jpg_65b7aff5.vtex", mockMaterial, false, false);
+            Assert.That(result, Is.EquivalentTo(vr_complex_expected_inputs));
+        }
+    }
+}

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Numerics;
 using SharpGLTF.IO;
 using SharpGLTF.Schema2;
-using SkiaSharp;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
 using ValveResourceFormat.Serialization;
@@ -45,7 +44,6 @@ namespace ValveResourceFormat.IO
 
         private string DstDir;
         private readonly IDictionary<string, Node> LoadedUnskinnedMeshDictionary = new Dictionary<string, Node>();
-
 
         public static bool CanExport(Resource resource)
             => ResourceTypesThatAreGltfExportable.Contains(resource.ResourceType);
@@ -839,70 +837,100 @@ namespace ValveResourceFormat.IO
             }
 
             material.WithPBRMetallicRoughness(baseColor, null, metallicFactor: metalValue);
+            using var ormTexture = new TextureExtract.TexturePacker { DefaultColor = new SkiaSharp.SKColor(255, 255, 0, 255) };
+
+            var allGltfInputs = MaterialExtract.GltfTextureMappings.Values.SelectMany(x => x);
+            var blendNameComparer = new MaterialExtract.LayeredTextureNameComparer(new HashSet<string>(allGltfInputs.Select(x => x.Item2)));
+            var blendInputComparer = new MaterialExtract.ChannelMappingComparer(blendNameComparer);
 
             //share sampler for all textures
             var sampler = model.UseTextureSampler(TextureWrapMode.REPEAT, TextureWrapMode.REPEAT, TextureMipMapFilter.LINEAR_MIPMAP_LINEAR, TextureInterpolationFilter.LINEAR);
 
-            foreach (var renderTexture in renderMaterial.TextureParams)
+            void TrySetupTexture(string textureName, Resource textureResource, List<ValueTuple<MaterialExtract.Channel, string>> renderTextureInputs)
             {
-                var texturePath = renderTexture.Value;
+                ProgressReporter?.Report($"Exporting texture: {textureResource.FileName}");
+                var fileName = Path.GetFileName(textureResource.FileName);
+                var ormFileName = Path.GetFileNameWithoutExtension(fileName) + "_rm.png";
+                var exportedTexturePath = Path.ChangeExtension(Path.Join(DstDir, fileName), "png");
 
-                var fileName = Path.GetFileNameWithoutExtension(texturePath);
+                using var bitmap = ((ResourceTypes.Texture)textureResource.DataBlock).GenerateBitmap();
+                using var pixels = bitmap.PeekPixels();
 
-                ProgressReporter?.Report($"Exporting texture: {texturePath}");
+                string gltfBestMatch = null;
 
-                var textureResource = FileLoader.LoadFile(texturePath + "_c");
-
-                if (textureResource == null)
+                void WriteTexture(ReadOnlySpan<byte> pngData, string gltfName, int index, int count)
                 {
-                    continue;
+                    gltfBestMatch = gltfName;
+                    renderTextureInputs.RemoveRange(index, count);
+                    using var fs = File.Open(exportedTexturePath, FileMode.Create);
+                    fs.Write(pngData);
                 }
 
-                var exportedTexturePath = Path.Join(DstDir, fileName);
-                exportedTexturePath = Path.ChangeExtension(exportedTexturePath, "png");
-
-                using (var bitmap = ((ResourceTypes.Texture)textureResource.DataBlock).GenerateBitmap())
+                // Try to find a glTF entry that best matches this texture
+                foreach (var (gltfTexture, gltfInputs) in MaterialExtract.GltfTextureMappings)
                 {
-                    using var pixels = bitmap.PeekPixels();
-
-                    if (renderTexture.Key.StartsWith("g_tColor", StringComparison.Ordinal) && material.Alpha == AlphaMode.OPAQUE)
+                    // Render texture matches the glTF spec.
+                    if (Enumerable.SequenceEqual(renderTextureInputs, gltfInputs, blendInputComparer))
                     {
-                        var bitmapSpan = pixels.GetPixelSpan<SKColor>();
-
-                        // expensive transparency workaround for color maps
-                        for (var i = 0; i < bitmapSpan.Length; i++)
-                        {
-                            bitmapSpan[i] = bitmapSpan[i].WithAlpha(255);
-                        }
+                        WriteTexture(TextureExtract.ToPngImage(bitmap), gltfTexture, 0, renderTextureInputs.Count);
+                        break;
                     }
 
-                    using var fs = File.Open(exportedTexturePath, FileMode.Create);
-                    pixels.Encode(fs, SKEncodedImageFormat.Png, 100);
+                    // RGB matches, alpha differs/missing, so write RGB.
+                    if (gltfInputs[0].Item1 == MaterialExtract.Channel.RGB && blendInputComparer.Equals(renderTextureInputs[0], gltfInputs[0]))
+                    {
+                        var png = renderTextureInputs.Count == 1
+                            ? TextureExtract.ToPngImage(bitmap)
+                            : TextureExtract.ToPngImageChannels(bitmap, renderTextureInputs[0].Item1);
+
+                        WriteTexture(png, gltfTexture, 0, 1);
+                        break;
+                    }
+
+                    // Render texture likely missing unpack info, otherwise texture types match.
+                    if (renderTextureInputs[0].Item1 == MaterialExtract.Channel.RGBA && blendNameComparer.Equals(renderTextureInputs[0].Item2, gltfInputs[0].Item2))
+                    {
+                        var png = gltfInputs[0].Item1 > MaterialExtract.Channel._Single
+                            ? TextureExtract.ToPngImage(bitmap)
+                            : TextureExtract.ToPngImageChannels(bitmap, gltfInputs[0].Item1);
+
+                        WriteTexture(png, gltfTexture, 0, 1);
+                        break;
+                    }
                 }
 
-                var image = model.UseImage(exportedTexturePath);
-                image.Name = fileName + $"_{model.LogicalImages.Count - 1}";
-
-                var tex = model.UseTexture(image);
-                tex.Name = fileName + $"_{model.LogicalTextures.Count - 1}";
-                tex.Sampler = sampler;
-
-                switch (renderTexture.Key)
+                // Collect any leftover channel/maps to new images
+                foreach (var (channel, textureType) in renderTextureInputs)
                 {
-                    case "g_tColor":
-                    case "g_tColor1":
-                    case "g_tColor2":
-                    case "g_tColorA":
-                    case "g_tColorB":
-                    case "g_tColorC":
-                        var channel = material.FindChannel("BaseColor");
-                        if (channel?.Texture != null && renderTexture.Key != "g_tColor")
+                    if (gltfBestMatch != "MetallicRoughness")
+                    {
+                        if (blendNameComparer.Equals(textureType, "TextureRoughness"))
                         {
-                            break;
+                            ormTexture.Collect(pixels, ormFileName, channel, MaterialExtract.Channel.G);
                         }
+                        else if (blendNameComparer.Equals(textureType, "TextureSpecularMask"))
+                        {
+                            ormTexture.Collect(pixels, ormFileName, channel, MaterialExtract.Channel.G, invert: true);
+                        }
+                        else if (blendNameComparer.Equals(textureType, "TextureMetalness") || blendNameComparer.Equals(textureType, "TextureMetalnessMask"))
+                        {
+                            ormTexture.Collect(pixels, ormFileName, channel, MaterialExtract.Channel.B);
+                        }
+                    }
+                }
 
-                        channel?.SetTexture(0, tex);
+                if (gltfBestMatch is not null)
+                {
+                    var image = model.UseImage(exportedTexturePath);
+                    image.Name = $"{fileName}_{model.LogicalImages.Count - 1}";
 
+                    var tex = model.UseTexture(image, sampler);
+                    tex.Name = $"{fileName}_{model.LogicalTextures.Count - 1}";
+
+                    material.FindChannel(gltfBestMatch)?.SetTexture(0, tex);
+
+                    if (gltfBestMatch == "BaseColor")
+                    {
                         material.Extras = JsonContent.CreateFrom(new Dictionary<string, object>
                         {
                             ["baseColorTexture"] = new Dictionary<string, object>
@@ -910,43 +938,43 @@ namespace ValveResourceFormat.IO
                                 { "index", image.LogicalIndex },
                             },
                         });
-
-                        break;
-                    case "g_tNormal":
-                        material.FindChannel("Normal")?.SetTexture(0, tex);
-                        break;
-                    case "g_tAmbientOcclusion":
-                        material.FindChannel("Occlusion")?.SetTexture(0, tex);
-                        break;
-                    case "g_tEmissive":
-                        material.FindChannel("Emissive")?.SetTexture(0, tex);
-                        break;
-                    case "g_tShadowFalloff":
-                    // example: tongue_gman, materials/default/default_skin_shadowwarp_tga_f2855b6e.vtex
-                    case "g_tCombinedMasks":
-                    // example: models/characters/gman/materials/gman_head_mouth_mask_tga_bb35dc38.vtex
-                    case "g_tDiffuseFalloff":
-                    // example: materials/default/default_skin_diffusewarp_tga_e58a9ed.vtex
-                    case "g_tIris":
-                    // example:
-                    case "g_tIrisMask":
-                    // example: models/characters/gman/materials/gman_eye_iris_mask_tga_a5bb4a1e.vtex
-                    case "g_tTintColor":
-                    // example: models/characters/lazlo/eyemeniscus_vmat_g_ttintcolor_a00ef19e.vtex
-                    case "g_tAnisoGloss":
-                    // example: gordon_beard, models/characters/gordon/materials/gordon_hair_normal_tga_272a44e9.vtex
-                    case "g_tBentNormal":
-                    // example: gman_teeth, materials/default/default_skin_shadowwarp_tga_f2855b6e.vtex
-                    case "g_tFresnelWarp":
-                    // example: brewmaster_color, materials/default/default_fresnelwarprim_tga_d9279d65.vtex
-                    case "g_tMasks1":
-                    // example: brewmaster_color, materials/models/heroes/brewmaster/brewmaster_base_metalnessmask_psd_58eaa40f.vtex
-                    case "g_tMasks2":
-                    // example: brewmaster_color,materials/models/heroes/brewmaster/brewmaster_base_specmask_psd_63e9fb90.vtex
-                    default:
-                        Console.Error.WriteLine($"Warning: Unsupported Texture Type {renderTexture.Key}");
-                        break;
+                    }
                 }
+            }
+
+            foreach (var renderTexture in renderMaterial.TextureParams)
+            {
+                var texturePath = renderTexture.Value;
+                var textureResource = FileLoader.LoadFile(texturePath + "_c");
+
+                if (textureResource == null)
+                {
+                    continue;
+                }
+
+                // TODO: get the signature directly instead of forming UnpackInfos
+                var inputImages = MaterialExtract.GetInputImagesForTexture(renderTexture.Key, texturePath, renderMaterial, false, false).Select(x => x.ToValueTuple()).ToList();
+
+                // Preemptive check so as to not perform any unnecessary GenerateBitmap
+                if (inputImages.Count == 0 || !inputImages.Any(input => allGltfInputs.Any(gltfInput => blendNameComparer.Equals(input.Item2, gltfInput.Item2))))
+                {
+                    continue;
+                }
+
+                TrySetupTexture(renderTexture.Key, textureResource, inputImages);
+            }
+
+            if (ormTexture.Bitmap is not null)
+            {
+                var finalDest = Path.Combine(DstDir, ormTexture.FileName);
+                using (var fs = File.Open(finalDest, FileMode.Create))
+                {
+                    fs.Write(TextureExtract.ToPngImage(ormTexture.Bitmap));
+                }
+
+                var metallicRoughness = material.FindChannel("MetallicRoughness");
+                metallicRoughness?.SetTexture(0, model.UseTexture(model.UseImage(finalDest), sampler));
+                metallicRoughness?.SetFactor("MetallicFactor", 1.0f); // Ignore g_flMetalness
             }
 
             return material;

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -979,8 +979,7 @@ namespace ValveResourceFormat.IO
                     continue;
                 }
 
-                // TODO: get the signature directly instead of forming UnpackInfos
-                var inputImages = MaterialExtract.GetInputImagesForTexture(renderTexture.Key, texturePath, renderMaterial, false, false).Select(x => x.ToValueTuple()).ToList();
+                var inputImages = MaterialExtract.GetTextureInputs(renderMaterial.ShaderName, renderTexture.Key, renderMaterial.IntParams).ToList();
 
                 // Preemptive check so as to not perform any unnecessary GenerateBitmap
                 if (inputImages.Count == 0 || !inputImages.Any(input => allGltfInputs.Any(gltfInput => blendNameComparer.Equals(input.Item2, gltfInput.Item2))))

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -820,6 +820,11 @@ namespace ValveResourceFormat.IO
                 material.DoubleSided = true;
             }
 
+            if (renderMaterial.IntParams.GetValueOrDefault("F_UNLIT") > 0)
+            {
+                material.WithUnlit();
+            }
+
             // assume non-metallic unless prompted
             float metalValue = 0;
 

--- a/ValveResourceFormat/IO/MaterialExtract.cs
+++ b/ValveResourceFormat/IO/MaterialExtract.cs
@@ -87,6 +87,13 @@ public sealed class MaterialExtract
             ["g_tRoughness"] = new[] { (Channel.R, "TextureRoughness"), },
         },
 
+        ["vr_standard"] = new()
+        {
+            ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, "TextureTranslucency") },
+            ["g_tColor2"] = new[] { (Channel.RGB, "TextureColor") },
+            ["g_tNormal"] = new[] { (Channel.RGB, "TextureNormal") },
+        },
+
         ["vr_complex"] = new()
         {
             ["g_tColor"] = new[] { (Channel.RGB, "TextureColor"), (Channel.A, string.Empty) }, // Alpha can be metal or translucency

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -96,6 +96,7 @@ public sealed class TextureExtract
     public TextureContentFile ToMaterialMaps(IEnumerable<MaterialExtract.UnpackInfo> mapsToUnpack)
     {
         var bitmap = texture.GenerateBitmap();
+        bitmap.SetImmutable();
 
         var vtex = new TextureContentFile()
         {
@@ -176,11 +177,12 @@ public sealed class TextureExtract
         // Wipes out the alpha channel
         if (channel == Channel.RGB)
         {
-            using var _bitmap = bitmap.Copy();
-            using var _pixelmap = _bitmap.PeekPixels();
-            using var newPixelmap = _pixelmap.WithAlphaType(SKAlphaType.Opaque);
+            using var newBitmap = new SKBitmap(bitmap.Info);
+            using var newPixelmap = newBitmap.PeekPixels();
+            using var pixelmap = bitmap.PeekPixels();
+            pixelmap.GetPixelSpan<SKColor>().CopyTo(newPixelmap.GetPixelSpan<SKColor>());
 
-            return EncodePng(newPixelmap);
+            return EncodePng(newPixelmap.WithAlphaType(SKAlphaType.Opaque));
         }
 
         if (channel == Channel.RGBA)

--- a/ValveResourceFormat/IO/TextureExtract.cs
+++ b/ValveResourceFormat/IO/TextureExtract.cs
@@ -131,7 +131,7 @@ public sealed class TextureExtract
 
     public static byte[] ToPngImageChannels(SKBitmap bitmap, Channel channel)
     {
-        if (channel < Channel._OneChannel)
+        if (channel < Channel._Single)
         {
             using var newBitmap = new SKBitmap(bitmap.Width, bitmap.Height, SKColorType.Gray8, SKAlphaType.Opaque);
             using var newPixelmap = newBitmap.PeekPixels();
@@ -156,7 +156,7 @@ public sealed class TextureExtract
         }
 
         // Shift a combination of two channels to RG
-        if (channel < Channel._TwoChannels && channel == Channel.GA)
+        if (channel < Channel._Double && channel == Channel.GA)
         {
             using var newBitmap = new SKBitmap(bitmap.Info);
             using var newPixelmap = newBitmap.PeekPixels();
@@ -173,6 +173,7 @@ public sealed class TextureExtract
             return EncodePng(newPixelmap);
         }
 
+        // Wipes out the alpha channel
         if (channel == Channel.RGB)
         {
             using var _bitmap = bitmap.Copy();
@@ -188,6 +189,133 @@ public sealed class TextureExtract
         }
 
         throw new InvalidOperationException($"{channel} is not a valid channel to extract.");
+    }
+
+    public static void CopyChannel(SKPixmap srcPixels, Channel srcChannel, SKPixmap dstPixels, Channel dstChannel, bool invert)
+    {
+        if (srcChannel >= Channel._Single)
+        {
+            throw new ArgumentOutOfRangeException(nameof(srcChannel), "Can only copy individual channels.");
+        }
+
+        if (dstChannel >= Channel._Single)
+        {
+            throw new ArgumentOutOfRangeException(nameof(dstChannel), "Can only copy individual channels.");
+        }
+
+        var srcPixelSpan = srcPixels.GetPixelSpan<SKColor>();
+        var pixelSpan = dstPixels.GetPixelSpan<SKColor>();
+
+        var inv = (byte)(invert ? 0xFF : 0x00);
+
+#pragma warning disable CS8509 // non exhaustive switch
+        for (var i = 0; i < srcPixelSpan.Length; i++)
+        {
+            pixelSpan[i] = dstChannel switch
+            {
+                Channel.R => srcChannel switch
+                {
+                    Channel.R => pixelSpan[i].WithRed((byte)(srcPixelSpan[i].Red ^ inv)),
+                    Channel.G => pixelSpan[i].WithRed((byte)(srcPixelSpan[i].Green ^ inv)),
+                    Channel.B => pixelSpan[i].WithRed((byte)(srcPixelSpan[i].Blue ^ inv)),
+                    Channel.A => pixelSpan[i].WithRed((byte)(srcPixelSpan[i].Alpha ^ inv)),
+                },
+                Channel.G => srcChannel switch
+                {
+                    Channel.R => pixelSpan[i].WithGreen((byte)(srcPixelSpan[i].Red ^ inv)),
+                    Channel.G => pixelSpan[i].WithGreen((byte)(srcPixelSpan[i].Green ^ inv)),
+                    Channel.B => pixelSpan[i].WithGreen((byte)(srcPixelSpan[i].Blue ^ inv)),
+                    Channel.A => pixelSpan[i].WithGreen((byte)(srcPixelSpan[i].Alpha ^ inv)),
+                },
+                Channel.B => srcChannel switch
+                {
+                    Channel.R => pixelSpan[i].WithBlue((byte)(srcPixelSpan[i].Red ^ inv)),
+                    Channel.G => pixelSpan[i].WithBlue((byte)(srcPixelSpan[i].Green ^ inv)),
+                    Channel.B => pixelSpan[i].WithBlue((byte)(srcPixelSpan[i].Blue ^ inv)),
+                    Channel.A => pixelSpan[i].WithBlue((byte)(srcPixelSpan[i].Alpha ^ inv)),
+                },
+                Channel.A => srcChannel switch
+                {
+                    Channel.R => pixelSpan[i].WithAlpha((byte)(srcPixelSpan[i].Red ^ inv)),
+                    Channel.G => pixelSpan[i].WithAlpha((byte)(srcPixelSpan[i].Green ^ inv)),
+                    Channel.B => pixelSpan[i].WithAlpha((byte)(srcPixelSpan[i].Blue ^ inv)),
+                    Channel.A => pixelSpan[i].WithAlpha((byte)(srcPixelSpan[i].Alpha ^ inv)),
+                },
+            };
+        }
+#pragma warning restore CS8509 // non exhaustive switch
+    }
+
+    /// <summary>
+    /// Packs masks to a new texture.
+    /// </summary>
+    public class TexturePacker : IDisposable
+    {
+        public SKColor DefaultColor { get; init; } = SKColors.Black;
+        public SKBitmap Bitmap { get; private set; }
+        public string FileName { get; private set; }
+
+        public void Collect(SKPixmap srcPixels, string fileName, Channel srcChannel, Channel dstChannel, bool invert = false)
+        {
+            FileName ??= fileName;
+            if (Bitmap is null)
+            {
+                Bitmap = new SKBitmap(srcPixels.Width, srcPixels.Height, true);
+                if (DefaultColor != SKColors.Black)
+                {
+                    using var pixels = Bitmap.PeekPixels();
+                    pixels.GetPixelSpan<SKColor>().Fill(DefaultColor);
+                }
+            }
+
+
+            if (Bitmap.Width < srcPixels.Width || Bitmap.Height < srcPixels.Height)
+            {
+                var newBitmap = new SKBitmap(srcPixels.Width, srcPixels.Height, true);
+                using (Bitmap)
+                {
+                    // Scale Bitmap up to srcPixels size
+                    using var oldPixels = Bitmap.PeekPixels();
+                    using var newPixels = newBitmap.PeekPixels();
+                    if (!oldPixels.ScalePixels(newPixels, SKFilterQuality.Low))
+                    {
+                        throw new InvalidOperationException($"Failed to scale up pixels of {FileName}");
+                    }
+                }
+                Bitmap = newBitmap;
+            }
+            else if (Bitmap.Width > srcPixels.Width || Bitmap.Height > srcPixels.Height)
+            {
+                // Scale srcPixels up to Bitmap size
+                using var newSrcBitmap = new SKBitmap(Bitmap.Width, Bitmap.Height, true);
+                using var newSrcPixels = newSrcBitmap.PeekPixels();
+                if (!srcPixels.ScalePixels(newSrcPixels, SKFilterQuality.Low))
+                {
+                    throw new InvalidOperationException($"Failed to scale up incoming pixels for {FileName}");
+                }
+                using var dstPixels2 = Bitmap.PeekPixels();
+                CopyChannel(newSrcPixels, srcChannel, dstPixels2, dstChannel, invert);
+                return;
+            }
+
+            using var dstPixels = Bitmap.PeekPixels();
+            CopyChannel(srcPixels, srcChannel, dstPixels, dstChannel, invert);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Bitmap != null && disposing)
+            {
+                Bitmap.Dispose();
+                Bitmap = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
     }
 
     private static byte[] EncodePng(SKBitmap bitmap)


### PR DESCRIPTION
* Switched some logic in glTF material exporter to use sequences of `Texture*` parameters provided by `MaterialExtract` instead of raw `g_t` textures. This way any channel data that is not expected by the [glTF spec](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_material_pbrmetallicroughness_basecolortexture) can be stripped away or extracted separately (example: g_tColor alpha).

* Added CLI option `--gltf_textures_adapt` enabled by default in GUI. This option lets VRF perform operations on textures to make them match the glTF PBR spec (e.g. generate a metallicRoughness PBR texture & erase any useless channels).
  * Disabled 
![image](https://user-images.githubusercontent.com/26466974/206855891-0cdcc8c4-6c61-40f3-bf0c-be06bf74fa1e.png)
  * Enabled
![image](https://user-images.githubusercontent.com/26466974/206861361-b1c9cbb9-ee57-4ae3-bd8f-727a00e46dd0.png)

    * Disabled
    <img src="https://user-images.githubusercontent.com/26466974/206553848-310b56ba-17c9-49d4-a5d1-3704dd33d5bd.png" width=60%>

    * Enabled
    <img src="https://user-images.githubusercontent.com/26466974/206553991-72b866fa-6e67-416f-95ca-beb96b2e465e.png" width=60%>

    * ^ Dota 2 assets export the inverted specular as roughness. A better way would be to use the specular workflow shader instead of metallic but seems like it's deprecated or something. I can't set it up.
        * By using the `MaterialExtract` shader table, this data was able to be extracted from `g_tMasks1` and `g_tMasks2` without additional hard-code.
    * Assets using the simple/complex shader
    <img src="https://media.discordapp.net/attachments/775429805469597768/1050384600158965760/image.png" width=30%><img src="https://media.discordapp.net/attachments/775429805469597768/1050383485392654476/image.png" width=30%>
    <img src="https://user-images.githubusercontent.com/26466974/206570351-1ea8ca21-10d9-4839-bf18-e9a9c46434cb.png" width=30%><img src="https://user-images.githubusercontent.com/26466974/206570742-eb17e289-ed41-4ca3-97db-9b735c85728a.png" width=30%>

* Textures useless to glTF renderer are ignored for export (e.g. detail, masks1). However channels in these textures may still be collected if the `--gltf_textures_adapt` option is enabled.