### PR TITLE
glTF improvements

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -713,7 +713,8 @@ namespace ValveResourceFormat.IO
         private IEnumerable<(Node Node, List<int> Indices)> CreateBonesRecursive(Bone bone, Node parent)
         {
             var node = parent.CreateNode(bone.Name)
-                .WithLocalTransform(bone.BindPose);
+                .WithLocalTranslation(bone.Position)
+                .WithLocalRotation(bone.Angle);
 
             // Recurse into children
             return bone.Children

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -444,18 +444,17 @@ namespace ValveResourceFormat.IO
             {
                 ImageWriting = ResourceWriteMode.SatelliteFile,
                 ImageWriteCallback = ImageWriteCallback,
-                JsonIndented = true
+                JsonIndented = true,
+                MergeBuffers = true
             };
 
             // See https://github.com/KhronosGroup/glTF/blob/0bc36d536946b13c4807098f9cf62ddff738e7a5/specification/2.0/README.md#buffers-and-buffer-views
-            // Disable merging buffers if the buffer size is over 1GiB, otherwise this will
+            // Disable merging buffers if the buffer size is >=2GiB, otherwise this will
             // cause SharpGLTF to run past the int32 limitation and crash.
             var totalSize = exportedModel.LogicalBuffers.Sum(buffer => (long)buffer.Content.Length);
-            settings.MergeBuffers = totalSize <= 1_074_000_000;
-
-            if (!settings.MergeBuffers)
+            if (totalSize > int.MaxValue)
             {
-                throw new NotSupportedException("VRF does not properly support big model (>1GiB) exports yet due to glTF limitations. See https://github.com/SteamDatabase/ValveResourceFormat/issues/379");
+                throw new NotSupportedException("VRF does not properly support big model (>=2GiB) exports yet due to glTF limitations. See https://github.com/SteamDatabase/ValveResourceFormat/issues/379");
             }
 
             exportedModel.Save(filePath, settings);


### PR DESCRIPTION
This PR fixes
- Animations being duplicated in resulting glTF which resulted in huge glTF size - by reusing the same skeleton
- Animations related errors in resulting glTF caused by mixing `WithLocalTransform` and `WithLocalTranslation`/`WithLocalRotation`
- Int32 overflow check in WriteModelFile

and adds animation channel data deduplication.

Fixes most, if not all cases of #379.
Dota 2 `models/items/spectre/spectre_arcana/spectre_arcana_base.vmdl` mentioned in the issue gets perfectly exported with a more or less reasonable size of 75.5MB (instead of 1GB+).
![sandbox babylonjs com_](https://user-images.githubusercontent.com/11695747/206851569-89d31a5a-e193-47c9-9fb9-d57cd4a7872f.png)
