### PR TITLE
Implement FrameBone#Scale

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -140,6 +140,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                     case "CCompressedFullQuaternion":
                         segmentArray[i] = new CCompressedFullQuaternion(containerSegment, elements, localChannel);
                         break;
+                    case "CCompressedStaticFloat":
+                        segmentArray[i] = new CCompressedStaticFloat(containerSegment, elements, localChannel);
+                        break;
+                    case "CCompressedFullFloat":
+                        segmentArray[i] = new CCompressedFullFloat(containerSegment, elements, localChannel);
+                        break;
 #if DEBUG
                     default:
                         if (localChannel.ChannelAttribute != "data")
@@ -205,7 +211,9 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             if (transforms.Bones.ContainsKey(bone.Name))
             {
                 var transform = transforms.Bones[bone.Name];
-                transformMatrix = Matrix4x4.CreateFromQuaternion(transform.Angle) * Matrix4x4.CreateTranslation(transform.Position);
+                transformMatrix = Matrix4x4.CreateScale(transform.Scale)
+                    * Matrix4x4.CreateFromQuaternion(transform.Angle)
+                    * Matrix4x4.CreateTranslation(transform.Position);
             }
 
             // Apply tranformation
@@ -250,9 +258,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             // Interpolate bone positions and angles
             foreach (var bonePair in frame1.Bones)
             {
-                var position = Vector3.Lerp(frame1.Bones[bonePair.Key].Position, frame2.Bones[bonePair.Key].Position, t);
-                var angle = Quaternion.Slerp(frame1.Bones[bonePair.Key].Angle, frame2.Bones[bonePair.Key].Angle, t);
-                frame.Bones[bonePair.Key] = new FrameBone(position, angle);
+                var frame1Bone = frame1.Bones[bonePair.Key];
+                var frame2Bone = frame1.Bones[bonePair.Key];
+                var position = Vector3.Lerp(frame1Bone.Position, frame2Bone.Position, t);
+                var angle = Quaternion.Slerp(frame1Bone.Angle, frame2Bone.Angle, t);
+                var scale = frame1Bone.Scale + (frame2Bone.Scale - frame1Bone.Scale) * t;
+                frame.Bones[bonePair.Key] = new FrameBone(position, angle, scale);
             }
 
             return frame;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
@@ -53,11 +53,31 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
+        public void SetAttribute(string bone, string attribute, float data)
+        {
+            switch (attribute)
+            {
+                case "Scale":
+                    GetBone(bone).Scale = data;
+                    break;
+
+                case "data":
+                    //ignore
+                    break;
+
+#if DEBUG
+                default:
+                    Console.WriteLine($"Unknown frame attribute '{attribute}' encountered with float data");
+                    break;
+#endif
+            }
+        }
+
         private FrameBone GetBone(string name)
         {
             if (!Bones.TryGetValue(name, out var bone))
             {
-                bone = new FrameBone(new Vector3(0, 0, 0), new Quaternion(0, 0, 0, 1));
+                bone = new FrameBone(new Vector3(0, 0, 0), new Quaternion(0, 0, 0, 1), 1);
 
                 Bones[name] = bone;
             }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
@@ -6,11 +6,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
     {
         public Vector3 Position { get; set; }
         public Quaternion Angle { get; set; }
+        public float Scale { get; set; }
 
-        public FrameBone(Vector3 pos, Quaternion a)
+        public FrameBone(Vector3 pos, Quaternion a, float scale)
         {
             Position = pos;
             Angle = a;
+            Scale = scale;
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullFloat.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedFullFloat.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Linq;
+
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
+{
+    public class CCompressedFullFloat : AnimationSegmentDecoder
+    {
+        public float[] Data { get; }
+
+        public CCompressedFullFloat(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        {
+            Data = Enumerable.Range(0, data.Count / 4)
+                .Select(i => BitConverter.ToSingle(data.Slice(i * 4)))
+                .ToArray();
+        }
+
+        public override void Read(int frameIndex, Frame outFrame)
+        {
+            var offset = Elements.Length * frameIndex;
+
+            for (var element = 0; element < Elements.Length; element++)
+            {
+                outFrame.SetAttribute(
+                    LocalChannel.BoneNames[Elements[element]],
+                    LocalChannel.ChannelAttribute,
+                    Data[offset + element]
+                );
+            }
+        }
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
@@ -1,19 +1,18 @@
 using System;
-using System.Numerics;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
 {
-    public class CCompressedStaticQuaternion : AnimationSegmentDecoder
+    public class CCompressedStaticFloat : AnimationSegmentDecoder
     {
-        public Quaternion[] Data { get; }
+        public float[] Data { get; }
 
-        public CCompressedStaticQuaternion(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        public CCompressedStaticFloat(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
         {
-            Data = new Quaternion[elements.Length];
+            Data = new float[elements.Length];
             // Static data has only one frame of data, so prefetch all data to avoid unnecessary GC
             for (var i = 0; i < elements.Length; i++)
             {
-                Data[i] = SegmentHelpers.ReadQuaternion(data.Slice(i * 6));
+                Data[i] = BitConverter.ToSingle(data.Slice(i * 4));
             }
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
@@ -28,7 +28,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         {
             for (var element = 0; element < Elements.Length; element++)
             {
-                // Get the bone we are reading for
                 outFrame.SetAttribute(
                     LocalChannel.BoneNames[Elements[element]],
                     LocalChannel.ChannelAttribute,

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
@@ -28,7 +28,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
         {
             for (var element = 0; element < Elements.Length; element++)
             {
-                // Get the bone we are reading for
                 outFrame.SetAttribute(
                     LocalChannel.BoneNames[Elements[element]],
                     LocalChannel.ChannelAttribute,


### PR DESCRIPTION
Fixes #464 and cleans up inconsistent comments from previous animations PR.

I'm unsure how correct it is, as `models/items/elder_titan/taunt_motorcycle_alt_back_weapon/elder_titan_taunt_motorcycle_alt_back_weapon.vmdl_c` is not used in-game, but it looks about correct.

Scale of `models/heroes/abyssal_underlord/abyssal_underlord_portal_model.vmdl_c` is always 1.

`models/items/chen/chen_infernal_psychic_mount/chen_infernal_psychic_mount.vmdl_c` doesn't have a `Scale` channel.

`models/heroes/abaddon/abaddon.vmdl_c` has only one difference in scale - `1` => `1.00000072`, so it's impossible to tell without debugging the game.