### PR TITLE
Fix glTF folder export

### DIFF
--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -844,7 +844,7 @@ namespace Decompiler
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
 
-                            gltfModelExporter.Export(resource, outputFile);
+                            gltfModelExporter.Export(resource, outputFile, null);
 
                             continue;
                         }

--- a/Decompiler/Decompiler.cs
+++ b/Decompiler/Decompiler.cs
@@ -788,6 +788,14 @@ namespace Decompiler
             }
 
             var fileLoader = new BasicVpkFileLoader(package);
+            var gltfModelExporter = new GltfModelExporter
+            {
+                ExportMaterials = GltfExportMaterials,
+                AdaptTextures = GltfExportAdaptTextures,
+                ProgressReporter = new Progress<string>(progress => Console.WriteLine($"--- {progress}")),
+                FileLoader = fileLoader
+            };
+
             var entries = package.Entries[type];
 
             foreach (var file in entries)
@@ -835,14 +843,6 @@ namespace Decompiler
                             var outputFile = Path.Combine(OutputFile, Path.ChangeExtension(filePath, outputExtension));
 
                             Directory.CreateDirectory(Path.GetDirectoryName(outputFile));
-
-                            var gltfModelExporter = new GltfModelExporter
-                            {
-                                ExportMaterials = GltfExportMaterials,
-                                AdaptTextures = GltfExportAdaptTextures,
-                                ProgressReporter = new Progress<string>(progress => Console.WriteLine($"--- {progress}")),
-                                FileLoader = fileLoader
-                            };
 
                             gltfModelExporter.Export(resource, outputFile);
 

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -180,7 +180,8 @@ namespace GUI.Forms
 
                             if (GltfModelExporter.CanExport(resource))
                             {
-                                gltfExporter.Export(resource, Path.ChangeExtension(outFilePath, "glb"));
+                                gltfExporter.Export(resource, Path.ChangeExtension(outFilePath, "glb"),
+                                    cancellationTokenSource.Token);
                                 continue;
                             }
 
@@ -246,6 +247,7 @@ namespace GUI.Forms
         {
             foreach (var contentSubFile in contentFile.SubFiles)
             {
+                cancellationTokenSource.Token.ThrowIfCancellationRequested();
                 contentSubFile.FileName = Path.Combine(contentRelativeFolder, contentSubFile.FileName).Replace(Path.DirectorySeparatorChar, '/');
                 var fullPath = Path.Combine(path, contentSubFile.FileName);
 

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -62,7 +62,7 @@ namespace GUI.Types.Exporter
                         FileLoader = exportData.VrfGuiContext.FileLoader,
                     };
 
-                    exporter.Export(resource, dialog.FileName);
+                    exporter.Export(resource, dialog.FileName, null);
                 }
                 else
                 {

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -287,7 +287,7 @@ namespace ValveResourceFormat.IO
                 // Add animations
                 foreach (var animation in animations)
                 {
-                    var exportedAnimation = exportedModel.CreateAnimation(animation.Name);
+                    var exportedAnimation = exportedModel.UseAnimation(animation.Name);
                     var rotationDict = new Dictionary<string, Dictionary<float, Quaternion>>();
                     var lastRotationDict = new Dictionary<string, Quaternion>();
                     var rotationOmittedSet = new HashSet<string>();

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -521,8 +521,9 @@ namespace ValveResourceFormat.IO
             return exportedModel;
         }
 
-        private static void WriteModelFile(ModelRoot exportedModel, string filePath)
+        private void WriteModelFile(ModelRoot exportedModel, string filePath)
         {
+            ProgressReporter.Report("Writing model to file...");
             var settings = new WriteSettings
             {
                 ImageWriting = ResourceWriteMode.SatelliteFile,

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -51,22 +51,29 @@ namespace ValveResourceFormat.IO
 
         public void Export(Resource resource, string targetPath)
         {
-            switch (resource.ResourceType)
+            try
             {
-                case ResourceType.Mesh:
-                    ExportToFile(resource.FileName, targetPath, new VMesh(resource));
-                    break;
-                case ResourceType.Model:
-                    ExportToFile(resource.FileName, targetPath, (VModel)resource.DataBlock);
-                    break;
-                case ResourceType.WorldNode:
-                    ExportToFile(resource.FileName, targetPath, (VWorldNode)resource.DataBlock);
-                    break;
-                case ResourceType.World:
-                    ExportToFile(resource.FileName, targetPath, (VWorld)resource.DataBlock);
-                    break;
-                default:
-                    throw new ArgumentException($"{resource.ResourceType} not supported for gltf export");
+                switch (resource.ResourceType)
+                {
+                    case ResourceType.Mesh:
+                        ExportToFile(resource.FileName, targetPath, new VMesh(resource));
+                        break;
+                    case ResourceType.Model:
+                        ExportToFile(resource.FileName, targetPath, (VModel)resource.DataBlock);
+                        break;
+                    case ResourceType.WorldNode:
+                        ExportToFile(resource.FileName, targetPath, (VWorldNode)resource.DataBlock);
+                        break;
+                    case ResourceType.World:
+                        ExportToFile(resource.FileName, targetPath, (VWorld)resource.DataBlock);
+                        break;
+                    default:
+                        throw new ArgumentException($"{resource.ResourceType} not supported for gltf export");
+                }
+            }
+            finally
+            {
+                LoadedUnskinnedMeshDictionary.Clear();
             }
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Skeleton.cs
@@ -29,6 +29,11 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 
             var remapTableStarts = modelData.GetIntegerArray("m_remappingTableStarts");
 
+            if (remapTableStarts.Length <= meshIndex)
+            {
+                return null;
+            }
+
             var start = (int)remapTableStarts[meshIndex];
             var end = meshIndex < remapTableStarts.Length - 1
                 ? (int)remapTableStarts[meshIndex + 1]


### PR DESCRIPTION
This PR fixes
- Mesh cache not being cleared after glTF export
- GetSkeleton throwing on invalid meshIndex (to avoid workarounds in other code)
- glTF `NODE_SKINNED_MESH_NON_ROOT` warning by removing behavior introduced in #467 - otherwise mesh reusing is not possible due to LogicalParent check

and allows much better mesh reusing via `LoadedMeshDictionary`, this way export of Dota 2 `maps/dota_728.vpk` `maps/dota/world.vwrld` is now possible within a reasonable time (2m22s300ms on my PC from GUI).
Can't check Dota 2 `maps/dota.vpk` export because it throws because of vphys parsing right now.

Also I don't know whether that's old or new behavior, but exported dota map materials aren't working properly.
![sandbox babylonjs com_](https://user-images.githubusercontent.com/11695747/206873715-24749001-91ff-4267-8ecf-6af8b873d9fb.png)