### PR TITLE
Implement deferred animations decoding

### DIFF
--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -46,6 +46,8 @@ namespace GUI.Types.Renderer
         private ICollection<string> activeMeshGroups = new HashSet<string>();
         private ICollection<RenderableMesh> activeMeshRenderers = new HashSet<RenderableMesh>();
 
+        private AnimationFrameCache animationFrameCache = new AnimationFrameCache();
+
         public ModelSceneNode(Scene scene, Model model, string skin = null, bool loadAnimations = true)
             : base(scene)
         {
@@ -92,7 +94,7 @@ namespace GUI.Types.Renderer
                     animationMatrices[(j * 16) + 15] = 1.0f;
                 }
 
-                animationMatrices = activeAnimation.GetAnimationMatricesAsArray(AnimationController.Time, skeleton);
+                animationMatrices = activeAnimation.GetAnimationMatricesAsArray(animationFrameCache, AnimationController.Time, skeleton);
 
                 // Update animation texture
                 GL.BindTexture(TextureTarget.Texture2D, animationTexture);
@@ -258,6 +260,7 @@ namespace GUI.Types.Renderer
         public void SetAnimation(string animationName)
         {
             activeAnimation = animations.FirstOrDefault(a => a.Name == animationName);
+            animationFrameCache.Clear();
             AnimationController.SetAnimation(activeAnimation);
 
             if (activeAnimation != default)

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -61,6 +61,10 @@ namespace GUI.Types.Renderer
             LoadMeshes();
             UpdateBoundingBox();
 
+            AnimationController.RegisterUpdateHandler((animation, frame) =>
+            {
+            });
+
             // Load required resources
             if (loadAnimations)
             {

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -273,7 +273,7 @@ namespace GUI.Types.Renderer
 
                 if (animation != default)
                 {
-                    modelNode.LoadAnimation(animation); // Load only this animation
+                    modelNode.LoadAnimations();
                     modelNode.SetAnimation(animation);
                 }
 

--- a/GUI/Types/Renderer/WorldLoader.cs
+++ b/GUI/Types/Renderer/WorldLoader.cs
@@ -152,8 +152,7 @@ namespace GUI.Types.Renderer
                 var model = entity.GetProperty<string>("model");
                 var skin = entity.GetProperty<string>("skin");
                 var particle = entity.GetProperty<string>("effect_name");
-                //var animation = entity.GetProperty<string>("defaultanim");
-                string animation = null;
+                var animation = entity.GetProperty<string>("defaultanim");
 
                 if (scale == null || position == null || angles == null)
                 {

--- a/Tests/AnimationTest.cs
+++ b/Tests/AnimationTest.cs
@@ -32,17 +32,14 @@ namespace Tests
             Assert.That(animations[0].Name, Is.EqualTo("ref_pose"));
             Assert.That(animations[0].Fps, Is.EqualTo(30));
             Assert.That(animations[0].FrameCount, Is.EqualTo(1));
-            Assert.That(animations[0].Frames.Count, Is.EqualTo(animations[0].FrameCount));
 
             Assert.That(animations[1].Name, Is.EqualTo("box_creature_leggy_idle"));
             Assert.That(animations[1].Fps, Is.EqualTo(30));
             Assert.That(animations[1].FrameCount, Is.EqualTo(49));
-            Assert.That(animations[1].Frames.Count, Is.EqualTo(animations[1].FrameCount));
 
             Assert.That(animations[2].Name, Is.EqualTo("box_creature_leggy_walk"));
             Assert.That(animations[2].Fps, Is.EqualTo(30));
             Assert.That(animations[2].FrameCount, Is.EqualTo(25));
-            Assert.That(animations[2].Frames.Count, Is.EqualTo(animations[2].FrameCount));
         }
     }
 }

--- a/ValveResourceFormat/IO/AnimationGroupLoader.cs
+++ b/ValveResourceFormat/IO/AnimationGroupLoader.cs
@@ -9,24 +9,6 @@ namespace ValveResourceFormat.IO
 {
     public static class AnimationGroupLoader
     {
-        public static List<Animation> GetAllAnimations(Model model, IFileLoader fileLoader)
-        {
-            var animGroupPaths = model.GetReferencedAnimationGroupNames();
-            var animations = model.GetEmbeddedAnimations().ToList();
-
-            // Load animations from referenced animation groups
-            foreach (var animGroupPath in animGroupPaths)
-            {
-                var animGroup = fileLoader.LoadFile(animGroupPath + "_c");
-                if (animGroup != default)
-                {
-                    animations.AddRange(LoadAnimationGroup(animGroup, fileLoader));
-                }
-            }
-
-            return animations.ToList();
-        }
-
         public static IEnumerable<Animation> LoadAnimationGroup(Resource resource, IFileLoader fileLoader)
         {
             var data = resource.DataBlock.AsKeyValueCollection();
@@ -53,28 +35,6 @@ namespace ValveResourceFormat.IO
             }
 
             return animationList;
-        }
-
-        public static IEnumerable<Animation> TryLoadSingleAnimationFileFromGroup(Resource resource, string animationName, IFileLoader fileLoader)
-        {
-            var data = resource.DataBlock.AsKeyValueCollection();
-
-            // Get the list of animation files
-            var animArray = data.GetArray<string>("m_localHAnimArray").Where(a => a != null);
-            // Get the key to decode the animations
-            var decodeKey = data.GetSubCollection("m_decodeKey");
-
-            // TODO: This needs to support embedded ANIM somehow
-            var animation = animArray.FirstOrDefault(a => a != null && a.EndsWith($"{animationName}.vanim", StringComparison.InvariantCulture));
-
-            if (animation != default)
-            {
-                return LoadAnimationFile(animation, decodeKey, fileLoader);
-            }
-            else
-            {
-                return null;
-            }
         }
 
         private static IEnumerable<Animation> LoadAnimationFile(string animationFile, IKeyValueCollection decodeKey, IFileLoader fileLoader)

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -298,8 +298,10 @@ namespace ValveResourceFormat.IO
             {
                 var animations = AnimationGroupLoader.GetAllAnimations(model, FileLoader);
                 // Add animations
+                var frame = new Frame();
                 foreach (var animation in animations)
                 {
+                    frame.Bones.Clear();
                     var exportedAnimation = exportedModel.UseAnimation(animation.Name);
                     var rotationDict = new Dictionary<string, Dictionary<float, Quaternion>>();
                     var lastRotationDict = new Dictionary<string, Quaternion>();
@@ -313,9 +315,10 @@ namespace ValveResourceFormat.IO
 
                     for (var frameIndex = 0; frameIndex < animation.FrameCount; frameIndex++)
                     {
+                        animation.DecodeFrame(frameIndex, frame);
                         var time = frameIndex / (float)animation.Fps;
                         var prevFrameTime = (frameIndex - 1) / (float)animation.Fps;
-                        foreach (var boneFrame in animation.Frames[frameIndex].Bones)
+                        foreach (var boneFrame in frame.Bones)
                         {
                             var bone = boneFrame.Key;
                             if (!rotationDict.ContainsKey(bone))

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -296,7 +296,7 @@ namespace ValveResourceFormat.IO
 
             if (skeletonNode != null)
             {
-                var animations = AnimationGroupLoader.GetAllAnimations(model, FileLoader);
+                var animations = model.GetAllAnimations(FileLoader);
                 // Add animations
                 var frame = new Frame();
                 foreach (var animation in animations)

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Numerics;
+
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation
+{
+    public class AnimationFrameCache
+    {
+        private (int FrameIndex, Frame Frame) PreviousFrame { get; set; } = (-1, new Frame());
+        private (int FrameIndex, Frame Frame) NextFrame { get; set; } = (-1, new Frame());
+        private Frame InterpolatedFrame { get; } = new Frame();
+
+        /// <summary>
+        /// Get the animation frame at a time.
+        /// </summary>
+        /// <param name="time">The time to get the frame for.</param>
+        public Frame GetFrame(Animation anim, float time)
+        {
+            // Calculate the index of the current frame
+            var frameIndex = (int)(time * anim.Fps) % anim.FrameCount;
+            var t = ((time * anim.Fps) - frameIndex) % 1;
+
+            // Get current and next frame
+            var frame1 = GetFrame(anim, frameIndex);
+            var frame2 = GetFrame(anim, (frameIndex + 1) % anim.FrameCount);
+
+            // Interpolate bone positions, angles and scale
+            foreach (var bonePair in frame1.Bones)
+            {
+                var frame1Bone = frame1.Bones[bonePair.Key];
+                var frame2Bone = frame2.Bones[bonePair.Key];
+                var position = Vector3.Lerp(frame1Bone.Position, frame2Bone.Position, t);
+                var angle = Quaternion.Slerp(frame1Bone.Angle, frame2Bone.Angle, t);
+                var scale = frame1Bone.Scale + (frame2Bone.Scale - frame1Bone.Scale) * t;
+
+                if (InterpolatedFrame.Bones.TryGetValue(bonePair.Key, out var interpolatedBone))
+                {
+                    interpolatedBone.Position = position;
+                    interpolatedBone.Angle = angle;
+                    interpolatedBone.Scale = scale;
+                }
+                else
+                {
+                    InterpolatedFrame.Bones.Add(bonePair.Key, new FrameBone(position, angle, scale));
+                }
+            }
+
+            return InterpolatedFrame;
+        }
+
+        /// <summary>
+        /// Clears interpolated frame bones and frame cache.
+        /// Should be used on animation change.
+        /// </summary>
+        public void Clear()
+        {
+            PreviousFrame.Frame.Bones.Clear();
+            PreviousFrame = (-1, PreviousFrame.Frame);
+
+            NextFrame.Frame.Bones.Clear();
+            NextFrame = (-1, NextFrame.Frame);
+
+            InterpolatedFrame.Bones.Clear();
+        }
+
+        private Frame GetFrame(Animation anim, int frameIndex)
+        {
+            // Try to lookup cached (precomputed) frame - happens when GUI Autoplay runs faster than animation FPS
+            if (frameIndex == PreviousFrame.FrameIndex)
+            {
+                return PreviousFrame.Frame;
+            }
+            if (frameIndex == NextFrame.FrameIndex)
+            {
+                return NextFrame.Frame;
+            }
+
+            // Only two frames are cached at a time to minimize memory usage, especially with Autoplay enabled
+            Frame frame;
+            if (frameIndex > PreviousFrame.FrameIndex)
+            {
+                frame = PreviousFrame.Frame;
+                PreviousFrame = NextFrame;
+                NextFrame = (frameIndex, frame);
+            }
+            else
+            {
+                frame = NextFrame.Frame;
+                NextFrame = PreviousFrame;
+                PreviousFrame = (frameIndex, frame);
+            }
+            // We make an assumption that frames contain identical bone sets in GetFrame,
+            // so we don't clear bones here and reuse their objects
+
+            anim.DecodeFrame(frameIndex, frame);
+
+            return frame;
+        }
+    }
+}


### PR DESCRIPTION
Should greatly reduce memory usage by both GUI and decompiler

`GetFrame` (previously `GetTransformsAtTime`) inclusive CPU time spent on `models/items/spectre/spectre_arcana/spectre_arcana_base.vmdl_c` on `spct_arc_flail` animation in GUI in Release mode at ~120FPS:
without previous/next frame cache: ~29.43%
with previous/next frame cache: ~5.63%
with frame cache, but without reusing `FrameBone`s: ~6.17%

For comparison on master (48a28406a84c137b5bb914e3cefff856ddb83be9) - frames are always cached, but interpolated frame/bones aren't reused: ~5.58%

It also uses ~350-400MB less RAM than on master in GUI in Release mode on given model and animation.