### PR TITLE
Gltf memory and image overwriting fixes

### DIFF
--- a/ValveResourceFormat/ValveResourceFormat.csproj
+++ b/ValveResourceFormat/ValveResourceFormat.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0027" />
+    <PackageReference Include="SharpGLTF.Toolkit" Version="1.0.0-alpha0028" />
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.3" />
     <PackageReference Include="ValveKeyValue" Version="0.8.2.162" />


### PR DESCRIPTION
In satellite images mode, [SharpGLTF](https://github.com/vpenades/SharpGLTF)'s `model.UseImage` will read the file from disk and hold data in memory so it can do the writing itself. This operation is totally unnecessary when VRF has just written the image to disk.

Due to API limitations I had to write a 44 byte png, send that image to SharpGLTF for linking like before, and then replace the 44 byte png on disk with the full image. Then through the provided callback, SharpGLTF's image writing is canceled the URI is fixed up. This should reduce memory consumption.
**Edit:** After an API update on SharpGLTF' side, writing the empty image on disk is not needed.

The sum of images will be kept in memory only when using embedded image mode.