### PR TITLE
Filter out children in glTF folder exports to avoid duplicates

### DIFF
--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -26,7 +26,15 @@ namespace GUI.Forms
 
         private static readonly List<ResourceType> ExtractOrder = new()
         {
-            // Materials before textures
+            ResourceType.World,
+            ResourceType.WorldNode,
+            ResourceType.Model,
+            ResourceType.Mesh,
+            ResourceType.AnimationGroup,
+            ResourceType.Animation,
+            ResourceType.Sequence,
+            ResourceType.Morph,
+
             ResourceType.Material,
             ResourceType.Texture,
         };
@@ -56,7 +64,7 @@ namespace GUI.Forms
             {
                 gltfExporter = new GltfModelExporter()
                 {
-                    FileLoader = exportData.VrfGuiContext.FileLoader,
+                    FileLoader = new TrackingFileLoader(exportData.VrfGuiContext.FileLoader),
                     ProgressReporter = new Progress<string>(SetProgress),
                 };
             }
@@ -194,6 +202,11 @@ namespace GUI.Forms
             if (GltfModelExporter.CanExport(resource) && Path.GetExtension(outFilePath) is ".glb" or ".gltf")
             {
                 gltfExporter.Export(resource, outFilePath, cancellationTokenSource.Token);
+                if (gltfExporter.FileLoader is TrackingFileLoader trackingFileLoader)
+                {
+                    extractedFiles.UnionWith(trackingFileLoader.LoadedFilePaths);
+                }
+
                 return;
             }
 

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -57,6 +57,31 @@ namespace ValveResourceFormat.IO
         public virtual Func<byte[]> Extract { get; set; }
     }
 
+    /// <summary>
+    /// Wrapper around IFileLoader that keeps track of successfully loaded resource paths.
+    /// </summary>
+    public class TrackingFileLoader : IFileLoader
+    {
+        public HashSet<string> LoadedFilePaths { get; } = new HashSet<string>();
+        private readonly IFileLoader fileLoader;
+
+        public Resource LoadFile(string file)
+        {
+            var resource = fileLoader.LoadFile(file);
+            if (resource is not null)
+            {
+                LoadedFilePaths.Add(file.Replace('\\', '/'));
+            }
+
+            return resource;
+        }
+
+        public TrackingFileLoader(IFileLoader fileLoader)
+        {
+            this.fileLoader = fileLoader;
+        }
+    }
+
     public static class FileExtract
     {
         /// <summary>

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -104,6 +104,7 @@ namespace ValveResourceFormat.IO
                 {
                     continue;
                 }
+
                 var worldResource = FileLoader.LoadFile(worldNodeName + ".vwnod_c");
                 if (worldResource == null)
                 {


### PR DESCRIPTION
The order of exports for gltf-exportables is now
```py
ResourceType.World
ResourceType.WorldNode
ResourceType.Model
ResourceType.Mesh
ResourceType.AnimationGroup
ResourceType.Animation
ResourceType.Sequence
ResourceType.Morph
```

This means that when exporting folders in GUI, WorldNodes referenced by World, Meshes referenced by Models and so on will be skipped.

![image](https://user-images.githubusercontent.com/26466974/207982316-ae6fe423-9c4c-4557-99da-ddb9545d5903.png)
* This folder now exports 3 GLB files, previously it did 6.
* Some cases had the vmesh_c with same name as vmdl_c, which would result in an overwrite with potential loss of data since vmesh_c is a subset of vmdl_c.

Closes #481