### PR TITLE
Fix GLTF vertex buffers being duplicated between draw calls

### DIFF
--- a/GUI/Types/Renderer/DrawCall.cs
+++ b/GUI/Types/Renderer/DrawCall.cs
@@ -7,7 +7,7 @@ namespace GUI.Types.Renderer
     {
         public PrimitiveType PrimitiveType { get; set; }
         public Shader Shader { get; set; }
-        //public uint BaseVertex { get; set; }
+        public uint BaseVertex { get; set; }
         //public uint VertexCount { get; set; }
         public uint StartIndex { get; set; }
         public int IndexCount { get; set; }

--- a/GUI/Types/Renderer/GPUMeshBufferCache.cs
+++ b/GUI/Types/Renderer/GPUMeshBufferCache.cs
@@ -17,6 +17,7 @@ namespace GUI.Types.Renderer
             public Shader Shader;
             public uint VertexIndex;
             public uint IndexIndex;
+            public uint BaseVertex;
         }
 
         public GPUMeshBufferCache()
@@ -37,10 +38,17 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public uint GetVertexArrayObject(VBIB vbib, Shader shader, uint vtxIndex, uint idxIndex)
+        public uint GetVertexArrayObject(VBIB vbib, Shader shader, uint vtxIndex, uint idxIndex, uint baseVertex)
         {
             var gpuVbib = GetVertexIndexBuffers(vbib);
-            var vaoKey = new VAOKey { VBIB = gpuVbib, Shader = shader, VertexIndex = vtxIndex, IndexIndex = idxIndex };
+            var vaoKey = new VAOKey
+            {
+                VBIB = gpuVbib,
+                Shader = shader,
+                VertexIndex = vtxIndex,
+                IndexIndex = idxIndex,
+                BaseVertex = baseVertex,
+            };
 
             if (vertexArrayObjects.TryGetValue(vaoKey, out var vaoHandle))
             {
@@ -66,7 +74,7 @@ namespace GUI.Types.Renderer
                         attributeName += texCoordNum;
                     }
 
-                    BindVertexAttrib(attribute, attributeName, shader.Program, (int)curVertexBuffer.ElementSizeInBytes);
+                    BindVertexAttrib(attribute, attributeName, shader.Program, (int)curVertexBuffer.ElementSizeInBytes, baseVertex);
                 }
 
                 GL.BindVertexArray(0);
@@ -76,7 +84,8 @@ namespace GUI.Types.Renderer
             }
         }
 
-        private static void BindVertexAttrib(VBIB.RenderInputLayoutField attribute, string attributeName, int shaderProgram, int stride)
+        private static void BindVertexAttrib(VBIB.RenderInputLayoutField attribute, string attributeName,
+            int shaderProgram, int stride, uint baseVertex)
         {
             var attributeLocation = GL.GetAttribLocation(shaderProgram, attributeName);
 
@@ -91,43 +100,43 @@ namespace GUI.Types.Renderer
             switch (attribute.Format)
             {
                 case DXGI_FORMAT.R32G32B32_FLOAT:
-                    GL.VertexAttribPointer(attributeLocation, 3, VertexAttribPointerType.Float, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 3, VertexAttribPointerType.Float, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R8G8B8A8_UNORM:
-                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.UnsignedByte, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.UnsignedByte, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R32G32_FLOAT:
-                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.Float, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.Float, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R16G16_FLOAT:
-                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.HalfFloat, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.HalfFloat, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R32G32B32A32_FLOAT:
-                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.Float, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.Float, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R8G8B8A8_UINT:
-                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.UnsignedByte, false, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 4, VertexAttribPointerType.UnsignedByte, false, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R16G16_SINT:
-                    GL.VertexAttribIPointer(attributeLocation, 2, VertexAttribIntegerType.Short, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribIPointer(attributeLocation, 2, VertexAttribIntegerType.Short, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R16G16B16A16_SINT:
-                    GL.VertexAttribIPointer(attributeLocation, 4, VertexAttribIntegerType.Short, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribIPointer(attributeLocation, 4, VertexAttribIntegerType.Short, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R16G16_SNORM:
-                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.Short, true, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.Short, true, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 case DXGI_FORMAT.R16G16_UNORM:
-                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.UnsignedShort, true, stride, (IntPtr)attribute.Offset);
+                    GL.VertexAttribPointer(attributeLocation, 2, VertexAttribPointerType.UnsignedShort, true, stride, (IntPtr)(baseVertex + attribute.Offset));
                     break;
 
                 default:

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -66,7 +66,8 @@ namespace GUI.Types.Renderer
                     mesh.VBIB,
                     call.Shader,
                     call.VertexBuffer.Id,
-                    call.IndexBuffer.Id);
+                    call.IndexBuffer.Id,
+                    call.BaseVertex);
             }
         }
 
@@ -182,15 +183,17 @@ namespace GUI.Types.Renderer
             var indexBufferObject = objectDrawCall.GetSubCollection("m_indexBuffer");
 
             var indexBuffer = default(DrawBuffer);
-            indexBuffer.Id = Convert.ToUInt32(indexBufferObject.GetProperty<object>("m_hBuffer"), CultureInfo.InvariantCulture);
-            indexBuffer.Offset = Convert.ToUInt32(indexBufferObject.GetProperty<object>("m_nBindOffsetBytes"), CultureInfo.InvariantCulture);
+            indexBuffer.Id = indexBufferObject.GetUInt32Property("m_hBuffer");
+            indexBuffer.Offset = indexBufferObject.GetUInt32Property("m_nBindOffsetBytes");
             drawCall.IndexBuffer = indexBuffer;
 
+            var vertexElementSize = vbib.VertexBuffers[(int)drawCall.VertexBuffer.Id].ElementSizeInBytes;
+            drawCall.BaseVertex = objectDrawCall.GetUInt32Property("m_nBaseVertex") * vertexElementSize;
+            //drawCall.VertexCount = objectDrawCall.GetUInt32Property("m_nVertexCount");
+
             var indexElementSize = vbib.IndexBuffers[(int)drawCall.IndexBuffer.Id].ElementSizeInBytes;
-            //drawCall.BaseVertex = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nBaseVertex"));
-            //drawCall.VertexCount = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nVertexCount"));
-            drawCall.StartIndex = Convert.ToUInt32(objectDrawCall.GetProperty<object>("m_nStartIndex"), CultureInfo.InvariantCulture) * indexElementSize;
-            drawCall.IndexCount = Convert.ToInt32(objectDrawCall.GetProperty<object>("m_nIndexCount"), CultureInfo.InvariantCulture);
+            drawCall.StartIndex = objectDrawCall.GetUInt32Property("m_nStartIndex") * indexElementSize;
+            drawCall.IndexCount = objectDrawCall.GetInt32Property("m_nIndexCount");
 
             if (objectDrawCall.ContainsKey("m_vTintColor"))
             {
@@ -216,15 +219,16 @@ namespace GUI.Types.Renderer
             var m_vertexBuffer = objectDrawCall.GetArray("m_vertexBuffers")[0]; // TODO: Not just 0
 
             var vertexBuffer = default(DrawBuffer);
-            vertexBuffer.Id = Convert.ToUInt32(m_vertexBuffer.GetProperty<object>("m_hBuffer"), CultureInfo.InvariantCulture);
-            vertexBuffer.Offset = Convert.ToUInt32(m_vertexBuffer.GetProperty<object>("m_nBindOffsetBytes"), CultureInfo.InvariantCulture);
+            vertexBuffer.Id = m_vertexBuffer.GetUInt32Property("m_hBuffer");
+            vertexBuffer.Offset = m_vertexBuffer.GetUInt32Property("m_nBindOffsetBytes");
             drawCall.VertexBuffer = vertexBuffer;
 
             drawCall.VertexArrayObject = guiContext.MeshBufferCache.GetVertexArrayObject(
                 vbib,
                 drawCall.Shader,
                 drawCall.VertexBuffer.Id,
-                drawCall.IndexBuffer.Id);
+                drawCall.IndexBuffer.Id,
+                drawCall.BaseVertex);
 
             return drawCall;
         }

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -756,7 +756,6 @@ namespace ValveResourceFormat.IO
                 return accessors;
             }).ToArray();
 
-            var vertexIndex = 0;
             foreach (var sceneObject in data.GetArray("m_sceneObjects"))
             {
                 foreach (var drawCall in sceneObject.GetArray("m_drawCalls"))
@@ -801,9 +800,9 @@ namespace ValveResourceFormat.IO
 
                     if (vmesh.MorphData != null && vmesh.MorphData.FlexData != null)
                     {
+                        var vertexIndex = drawCall.GetInt32Property("m_nBaseVertex");
                         var vertexCount = drawCall.GetInt32Property("m_nVertexCount");
                         AddMorphTargetsToPrimitive(vmesh.MorphData, primitive, model, vertexIndex, vertexCount);
-                        vertexIndex += vertexCount;
                     }
 
                     // Add material

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -3,9 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Threading;
 using SharpGLTF.IO;
+using SharpGLTF.Memory;
 using SharpGLTF.Schema2;
 using ValveResourceFormat.Blocks;
+using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
 using ValveResourceFormat.Serialization;
 using ValveResourceFormat.Utils;
@@ -18,8 +21,6 @@ using VModel = ValveResourceFormat.ResourceTypes.Model;
 using VWorldNode = ValveResourceFormat.ResourceTypes.WorldNode;
 using VWorld = ValveResourceFormat.ResourceTypes.World;
 using VEntityLump = ValveResourceFormat.ResourceTypes.EntityLump;
-using System.Threading;
-using ValveResourceFormat.ResourceTypes;
 
 namespace ValveResourceFormat.IO
 {
@@ -591,6 +592,170 @@ namespace ValveResourceFormat.IO
 
             vmesh.LoadExternalMorphData(FileLoader);
 
+            var vertexBufferAccessors = vbib.VertexBuffers.Select((vertexBuffer, vertexBufferIndex) =>
+            {
+                var accessors = new Dictionary<string, Accessor>();
+
+                // Avoid duplicate attribute names
+                var attributeCounters = new Dictionary<string, int>();
+
+                // Set vertex attributes
+                foreach (var attribute in vertexBuffer.InputLayoutFields)
+                {
+                    attributeCounters.TryGetValue(attribute.SemanticName, out var attributeCounter);
+                    attributeCounters[attribute.SemanticName] = attributeCounter + 1;
+                    var accessorName = GetAccessorName(attribute.SemanticName, attributeCounter);
+
+                    var buffer = ReadAttributeBuffer(vertexBuffer, attribute);
+                    var numComponents = buffer.Length / vertexBuffer.ElementCount;
+
+                    if (attribute.SemanticName == "BLENDINDICES")
+                    {
+                        if (!includeJoints)
+                        {
+                            continue;
+                        }
+
+                        var byteBuffer = buffer.Select(f => (byte)f).ToArray();
+                        var rawBufferData = new byte[buffer.Length];
+                        System.Buffer.BlockCopy(byteBuffer, 0, rawBufferData, 0, rawBufferData.Length);
+
+                        var bufferView = mesh.LogicalParent.UseBufferView(rawBufferData);
+                        var accessor = mesh.LogicalParent.CreateAccessor();
+                        accessor.SetVertexData(bufferView, 0, buffer.Length / 4, DimensionType.VEC4, EncodingType.UNSIGNED_BYTE);
+
+                        accessors[accessorName] = accessor;
+
+                        continue;
+                    }
+
+                    if (attribute.SemanticName == "NORMAL")
+                    {
+                        var isCompressedNormalTangent = data.GetArray("m_sceneObjects").Any(sceneObject =>
+                        {
+                            return sceneObject.GetArray("m_drawCalls").Any(drawCall =>
+                            {
+                                return drawCall.GetInt32Property("m_hBuffer") == vertexBufferIndex
+                                    && VMesh.IsCompressedNormalTangent(drawCall);
+                            });
+                        });
+                        if (isCompressedNormalTangent)
+                        {
+                            var vectors = ToVector4Array(buffer);
+                            var (normals, tangents) = DecompressNormalTangents(vectors);
+
+                            {
+                                BufferView bufferView = model.CreateBufferView(12 * normals.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new Vector3Array(bufferView.Content).Fill(normals);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, normals.Length, DimensionType.VEC3);
+                                accessors["NORMAL"] = accessor;
+                            }
+
+                            {
+                                BufferView bufferView = model.CreateBufferView(16 * tangents.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new Vector4Array(bufferView.Content).Fill(tangents);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, tangents.Length, DimensionType.VEC4);
+                                accessors["TANGENT"] = accessor;
+                            }
+
+                            continue;
+                        }
+                    }
+
+                    if (attribute.SemanticName == "TEXCOORD" && numComponents != 2)
+                    {
+                        // We are ignoring some data, but non-2-component UVs cause failures in gltf consumers
+                        continue;
+                    }
+
+                    if (attribute.SemanticName == "BLENDWEIGHT" && numComponents != 4)
+                    {
+                        Console.Error.WriteLine($"This model has {attribute.SemanticName} with {numComponents} components, which in unsupported.");
+                        continue;
+                    }
+
+                    switch (numComponents)
+                    {
+                        case 4:
+                            {
+                                var vectors = ToVector4Array(buffer);
+
+                                // dropship.vmdl in HL:A has a tanget with value of <0, -0, 0>
+                                if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
+                                {
+                                    vectors = FixZeroLengthVectors(vectors);
+                                }
+
+                                BufferView bufferView = model.CreateBufferView(16 * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new Vector4Array(bufferView.Content).Fill(vectors);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, vectors.Length, DimensionType.VEC4);
+                                accessors[accessorName] = accessor;
+                                break;
+                            }
+
+                        case 3:
+                            {
+                                var vectors = ToVector3Array(buffer);
+
+                                // dropship.vmdl in HL:A has a normal with value of <0, 0, 0>
+                                if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
+                                {
+                                    vectors = FixZeroLengthVectors(vectors);
+                                }
+
+                                BufferView bufferView = model.CreateBufferView(12 * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new Vector3Array(bufferView.Content).Fill(vectors);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, vectors.Length, DimensionType.VEC3);
+                                accessors[accessorName] = accessor;
+                                break;
+                            }
+
+                        case 2:
+                            {
+                                var vectors = ToVector2Array(buffer);
+                                BufferView bufferView = model.CreateBufferView(8 * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new Vector2Array(bufferView.Content).Fill(vectors);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, vectors.Length, DimensionType.VEC2);
+                                accessors[accessorName] = accessor;
+                                break;
+                            }
+
+                        case 1:
+                            {
+                                BufferView bufferView = model.CreateBufferView(4 * buffer.Length, 0, BufferMode.ARRAY_BUFFER);
+                                new ScalarArray(bufferView.Content).Fill(buffer);
+                                Accessor accessor = model.CreateAccessor();
+                                accessor.SetVertexData(bufferView, 0, buffer.Length, DimensionType.SCALAR);
+                                accessors[accessorName] = accessor;
+                                break;
+                            }
+
+                        default:
+                            throw new NotImplementedException($"Attribute \"{attribute.SemanticName}\" has {numComponents} components");
+                    }
+                }
+
+                // For some reason soruce models can have joints but no weights, check if that is the case
+                if (accessors.TryGetValue("JOINTS_0", out var jointAccessor) && !accessors.ContainsKey("WEIGHTS_0"))
+                {
+                    // If this occurs, give default weights
+                    var defaultWeights = Enumerable.Repeat(Vector4.UnitX, jointAccessor.Count).ToList();
+
+                    BufferView bufferView = model.CreateBufferView(16 * defaultWeights.Count, 0, BufferMode.ARRAY_BUFFER);
+                    new Vector4Array(bufferView.Content).Fill(defaultWeights);
+                    Accessor accessor = model.CreateAccessor();
+                    accessor.SetVertexData(bufferView, 0, defaultWeights.Count, DimensionType.VEC4);
+                    accessors["WEIGHTS_0"] = accessor;
+                }
+
+                return accessors;
+            }).ToArray();
+
             var vertexIndex = 0;
             foreach (var sceneObject in data.GetArray("m_sceneObjects"))
             {
@@ -598,131 +763,23 @@ namespace ValveResourceFormat.IO
                 {
                     CancellationToken?.ThrowIfCancellationRequested();
                     var vertexBufferInfo = drawCall.GetArray("m_vertexBuffers")[0]; // In what situation can we have more than 1 vertex buffer per draw call?
-                    var vertexBufferIndex = (int)vertexBufferInfo.GetIntegerProperty("m_hBuffer");
-                    var vertexBuffer = vbib.VertexBuffers[vertexBufferIndex];
+                    var vertexBufferIndex = vertexBufferInfo.GetInt32Property("m_hBuffer");
 
                     var indexBufferInfo = drawCall.GetSubCollection("m_indexBuffer");
-                    var indexBufferIndex = (int)indexBufferInfo.GetIntegerProperty("m_hBuffer");
+                    var indexBufferIndex = indexBufferInfo.GetInt32Property("m_hBuffer");
                     var indexBuffer = vbib.IndexBuffers[indexBufferIndex];
 
                     // Create one primitive per draw call
                     var primitive = mesh.CreatePrimitive();
 
-                    // Avoid duplicate attribute names
-                    var attributeCounters = new Dictionary<string, int>();
-
-                    // Set vertex attributes
-                    foreach (var attribute in vertexBuffer.InputLayoutFields)
+                    foreach (var (attributeKey, accessor) in vertexBufferAccessors[vertexBufferIndex])
                     {
-                        attributeCounters.TryGetValue(attribute.SemanticName, out var attributeCounter);
-                        attributeCounters[attribute.SemanticName] = attributeCounter + 1;
-                        var accessorName = GetAccessorName(attribute.SemanticName, attributeCounter);
-
-                        var buffer = ReadAttributeBuffer(vertexBuffer, attribute);
-                        var numComponents = buffer.Length / vertexBuffer.ElementCount;
-
-                        if (attribute.SemanticName == "BLENDINDICES")
-                        {
-                            if (!includeJoints)
-                            {
-                                continue;
-                            }
-
-                            var byteBuffer = buffer.Select(f => (byte)f).ToArray();
-                            var rawBufferData = new byte[buffer.Length];
-                            System.Buffer.BlockCopy(byteBuffer, 0, rawBufferData, 0, rawBufferData.Length);
-
-                            var bufferView = mesh.LogicalParent.UseBufferView(rawBufferData);
-                            var accessor = mesh.LogicalParent.CreateAccessor();
-                            accessor.SetVertexData(bufferView, 0, buffer.Length / 4, DimensionType.VEC4, EncodingType.UNSIGNED_BYTE);
-
-                            primitive.SetVertexAccessor(accessorName, accessor);
-
-                            continue;
-                        }
-
-                        if (attribute.SemanticName == "NORMAL" && VMesh.IsCompressedNormalTangent(drawCall))
-                        {
-                            var vectors = ToVector4Array(buffer);
-                            var (normals, tangents) = DecompressNormalTangents(vectors);
-                            primitive.WithVertexAccessor("NORMAL", normals);
-                            primitive.WithVertexAccessor("TANGENT", tangents);
-
-                            continue;
-                        }
-
-                        if (attribute.SemanticName == "TEXCOORD" && numComponents != 2)
-                        {
-                            // We are ignoring some data, but non-2-component UVs cause failures in gltf consumers
-                            continue;
-                        }
-
-                        if (attribute.SemanticName == "BLENDWEIGHT" && numComponents != 4)
-                        {
-                            Console.Error.WriteLine($"This model has {attribute.SemanticName} with {numComponents} components, which in unsupported.");
-                            continue;
-                        }
-
-                        switch (numComponents)
-                        {
-                            case 4:
-                                {
-                                    var vectors = ToVector4Array(buffer);
-
-                                    // dropship.vmdl in HL:A has a tanget with value of <0, -0, 0>
-                                    if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
-                                    {
-                                        vectors = FixZeroLengthVectors(vectors);
-                                    }
-
-                                    primitive.WithVertexAccessor(accessorName, vectors);
-                                    break;
-                                }
-
-                            case 3:
-                                {
-                                    var vectors = ToVector3Array(buffer);
-
-                                    // dropship.vmdl in HL:A has a normal with value of <0, 0, 0>
-                                    if (attribute.SemanticName == "NORMAL" || attribute.SemanticName == "TANGENT")
-                                    {
-                                        vectors = FixZeroLengthVectors(vectors);
-                                    }
-
-                                    primitive.WithVertexAccessor(accessorName, vectors);
-                                    break;
-                                }
-
-                            case 2:
-                                {
-                                    var vectors = ToVector2Array(buffer);
-                                    primitive.WithVertexAccessor(accessorName, vectors);
-                                    break;
-                                }
-
-                            case 1:
-                                {
-                                    primitive.WithVertexAccessor(accessorName, buffer);
-                                    break;
-                                }
-
-                            default:
-                                throw new NotImplementedException($"Attribute \"{attribute.SemanticName}\" has {numComponents} components");
-                        }
-                    }
-
-                    // For some reason soruce models can have joints but no weights, check if that is the case
-                    var jointAccessor = primitive.GetVertexAccessor("JOINTS_0");
-                    if (jointAccessor != null && primitive.GetVertexAccessor("WEIGHTS_0") == null)
-                    {
-                        // If this occurs, give default weights
-                        var defaultWeights = Enumerable.Repeat(Vector4.UnitX, jointAccessor.Count).ToList();
-                        primitive.WithVertexAccessor("WEIGHTS_0", defaultWeights);
+                        primitive.SetVertexAccessor(attributeKey, accessor);
                     }
 
                     // Set index buffer
-                    var startIndex = (int)drawCall.GetIntegerProperty("m_nStartIndex");
-                    var indexCount = (int)drawCall.GetIntegerProperty("m_nIndexCount");
+                    var startIndex = drawCall.GetInt32Property("m_nStartIndex");
+                    var indexCount = drawCall.GetInt32Property("m_nIndexCount");
                     var indices = ReadIndices(indexBuffer, startIndex, indexCount);
 
                     var primitiveType = drawCall.GetProperty<object>("m_nPrimitiveType") switch

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using ValveResourceFormat.Blocks;
@@ -26,12 +27,10 @@ namespace ValveResourceFormat.ResourceTypes
             {
                 var refMesh = refMeshes[meshIndex];
 
-                if (refMesh == null)
+                if (!String.IsNullOrEmpty(refMesh))
                 {
-                    continue;
+                    result.Add((meshIndex, refMesh, refLODGroupMasks[meshIndex]));
                 }
-
-                result.Add((meshIndex, refMesh, refLODGroupMasks[meshIndex]));
             }
 
             return result;


### PR DESCRIPTION
Fixes export of `Aperture Desk Job\game\steampal\maps\aperture_desk_job.vpk
File: maps/aperture_desk_job/worldnodes/node000_model_lr0_agg9_243_tube_paint_under.vmdl_c`