### PR TITLE
Auto-add folders with "addoninfo.txt" or ".addon" to path

### DIFF
--- a/GUI/Utils/AdvancedGuiFileLoader.cs
+++ b/GUI/Utils/AdvancedGuiFileLoader.cs
@@ -200,6 +200,16 @@ namespace GUI.Utils
             }
             else
             {
+                var addonsSuffix = "_addons";
+                if (assumedGameRoot.EndsWith(addonsSuffix, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var mainGameDir = assumedGameRoot[..^addonsSuffix.Length];
+                    if (Directory.Exists(mainGameDir))
+                    {
+                        folders.Add(mainGameDir);
+                    }
+                }
+
                 folders.Add(rootFolder);
             }
 
@@ -244,8 +254,6 @@ namespace GUI.Utils
                     Console.WriteLine($"Added folder \"{folder}\" to game search paths");
 
                     CurrentGameSearchPaths.Add(folder);
-
-                    continue;
                 }
             }
         }


### PR DESCRIPTION
Supports dota/hla/steamvr and s&box addons.

Dota/hla/steamvr addons will also mount their base-mod. This is a guess based on the `<base-mod>_addons` rule.