### PR TITLE
Optimize animations

### DIFF
--- a/GUI/Types/Renderer/AnimationController.cs
+++ b/GUI/Types/Renderer/AnimationController.cs
@@ -6,9 +6,9 @@ namespace GUI.Types.Renderer
 {
     public class AnimationController
     {
+        private readonly AnimationFrameCache animationFrameCache;
         private Action<Animation, int> updateHandler = (_, __) => { };
         private Animation activeAnimation;
-        private AnimationFrameCache animationFrameCache = new();
         private float Time;
 
         public bool IsPaused { get; set; }
@@ -29,6 +29,11 @@ namespace GUI.Types.Renderer
                     Time = value / activeAnimation.Fps;
                 }
             }
+        }
+
+        public AnimationController(Skeleton skeleton)
+        {
+            animationFrameCache = new(skeleton);
         }
 
         public bool Update(float timeStep)

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -32,7 +32,7 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public AnimationController AnimationController { get; } = new();
+        public readonly AnimationController AnimationController;
         public IEnumerable<RenderableMesh> RenderableMeshes => activeMeshRenderers;
 
         private readonly List<RenderableMesh> meshRenderers = new();
@@ -50,6 +50,7 @@ namespace GUI.Types.Renderer
             : base(scene)
         {
             Model = model;
+            AnimationController = new(model.Skeleton);
 
             if (skin != null)
             {

--- a/ValveResourceFormat/IO/AnimationGroupLoader.cs
+++ b/ValveResourceFormat/IO/AnimationGroupLoader.cs
@@ -9,7 +9,7 @@ namespace ValveResourceFormat.IO
 {
     public static class AnimationGroupLoader
     {
-        public static IEnumerable<Animation> LoadAnimationGroup(Resource resource, IFileLoader fileLoader)
+        public static IEnumerable<Animation> LoadAnimationGroup(Resource resource, IFileLoader fileLoader, Skeleton skeleton)
         {
             var data = resource.DataBlock.AsKeyValueCollection();
 
@@ -21,7 +21,7 @@ namespace ValveResourceFormat.IO
             if (resource.ContainsBlockType(BlockType.ANIM))
             {
                 var animBlock = (KeyValuesOrNTRO)resource.GetBlockByType(BlockType.ANIM);
-                animationList.AddRange(Animation.FromData(animBlock.Data, decodeKey));
+                animationList.AddRange(Animation.FromData(animBlock.Data, decodeKey, skeleton));
                 return animationList;
             }
 
@@ -31,23 +31,16 @@ namespace ValveResourceFormat.IO
             // Load animation files
             foreach (var animationFile in animArray)
             {
-                animationList.AddRange(LoadAnimationFile(animationFile, decodeKey, fileLoader));
+                var animResource = fileLoader.LoadFile(animationFile + "_c");
+
+                if (animResource != null)
+                {
+                    // Build animation classes
+                    animationList.AddRange(Animation.FromResource(animResource, decodeKey, skeleton));
+                }
             }
 
             return animationList;
-        }
-
-        private static IEnumerable<Animation> LoadAnimationFile(string animationFile, IKeyValueCollection decodeKey, IFileLoader fileLoader)
-        {
-            var animResource = fileLoader.LoadFile(animationFile + "_c");
-
-            if (animResource == null)
-            {
-                return Enumerable.Empty<Animation>();
-            }
-
-            // Build animation classes
-            return Animation.FromResource(animResource, decodeKey);
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/Model.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Model.cs
@@ -171,7 +171,7 @@ namespace ValveResourceFormat.ResourceTypes
 
             var animationDataBlock = Resource.GetBlockByIndex(animDataBlockIndex) as KeyValuesOrNTRO;
 
-            return Animation.FromData(animationDataBlock.Data, decodeKey);
+            return Animation.FromData(animationDataBlock.Data, decodeKey, Skeleton);
         }
 
         public IEnumerable<Animation> GetAllAnimations(IFileLoader fileLoader)
@@ -190,7 +190,7 @@ namespace ValveResourceFormat.ResourceTypes
                 var animGroup = fileLoader.LoadFile(animGroupPath + "_c");
                 if (animGroup != default)
                 {
-                    animations.AddRange(AnimationGroupLoader.LoadAnimationGroup(animGroup, fileLoader));
+                    animations.AddRange(AnimationGroupLoader.LoadAnimationGroup(animGroup, fileLoader, Skeleton));
                 }
             }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -38,7 +38,8 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
-        public static IEnumerable<Animation> FromData(IKeyValueCollection animationData, IKeyValueCollection decodeKey)
+        public static IEnumerable<Animation> FromData(IKeyValueCollection animationData, IKeyValueCollection decodeKey,
+            Skeleton skeleton)
         {
             var animArray = animationData.GetArray<IKeyValueCollection>("m_animArray");
 
@@ -60,7 +61,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             var dataChannelArray = new AnimationDataChannel[dataChannelArrayKV.Length];
             for (var i = 0; i < dataChannelArrayKV.Length; i++)
             {
-                dataChannelArray[i] = new AnimationDataChannel(dataChannelArrayKV[i], channelElements);
+                dataChannelArray[i] = new AnimationDataChannel(skeleton, dataChannelArrayKV[i], channelElements);
             }
 
             var segmentArrayKV = animationData.GetArray("m_segmentArray");
@@ -74,12 +75,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 // Read header
                 var decoder = decoderArray[containerReader.ReadInt16()];
                 var cardinality = containerReader.ReadInt16();
-                var numBones = containerReader.ReadInt16();
+                var numElements = containerReader.ReadInt16();
                 var totalLength = containerReader.ReadInt16();
 
                 // Read bone list
-                var elements = new int[numBones];
-                for (var j = 0; j < numBones; j++)
+                var elements = new int[numElements];
+                for (var j = 0; j < numElements; j++)
                 {
                     elements[j] = containerReader.ReadInt16();
                 }
@@ -90,38 +91,62 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                     container.Length - (int)containerReader.BaseStream.Position
                 );
 
+                var remapTable = localChannel.RemapTable
+                    .Select(i => Array.IndexOf(elements, i))
+                    .ToArray();
+                var wantedElements = remapTable.Where(boneID => boneID != -1).ToArray();
+                remapTable = remapTable
+                    .Select((boneID, i) => (boneID, i))
+                    .Where(t => t.boneID != -1)
+                    .Select(t => t.i)
+                    .ToArray();
+                var channelAttribute = localChannel.ChannelAttribute switch
+                {
+                    "Position" => AnimationChannelAttribute.Position,
+                    "Angle" => AnimationChannelAttribute.Angle,
+                    "Scale" => AnimationChannelAttribute.Scale,
+                    _ => AnimationChannelAttribute.Unknown,
+                };
+
+                if (channelAttribute == AnimationChannelAttribute.Unknown)
+                {
+                    Console.WriteLine($"Unknown channel attribute '{localChannel.ChannelAttribute}' encountered with '{decoder}' decoder");
+                    continue;
+                }
+
                 // Look at the decoder to see what to read
                 switch (decoder)
                 {
                     case "CCompressedStaticFullVector3":
-                        segmentArray[i] = new CCompressedStaticFullVector3(containerSegment, elements, localChannel);
-                        break;
-                    case "CCompressedFullVector3":
-                        segmentArray[i] = new CCompressedFullVector3(containerSegment, elements, localChannel);
-                        break;
-                    case "CCompressedDeltaVector3":
-                        segmentArray[i] = new CCompressedDeltaVector3(containerSegment, elements, localChannel);
-                        break;
-                    case "CCompressedAnimVector3":
-                        segmentArray[i] = new CCompressedAnimVector3(containerSegment, elements, localChannel);
+                        segmentArray[i] = new CCompressedStaticFullVector3(containerSegment, wantedElements, remapTable, channelAttribute);
                         break;
                     case "CCompressedStaticVector3":
-                        segmentArray[i] = new CCompressedStaticVector3(containerSegment, elements, localChannel);
-                        break;
-                    case "CCompressedAnimQuaternion":
-                        segmentArray[i] = new CCompressedAnimQuaternion(containerSegment, elements, localChannel);
+                        segmentArray[i] = new CCompressedStaticVector3(containerSegment, wantedElements, remapTable, channelAttribute);
                         break;
                     case "CCompressedStaticQuaternion":
-                        segmentArray[i] = new CCompressedStaticQuaternion(containerSegment, elements, localChannel);
-                        break;
-                    case "CCompressedFullQuaternion":
-                        segmentArray[i] = new CCompressedFullQuaternion(containerSegment, elements, localChannel);
+                        segmentArray[i] = new CCompressedStaticQuaternion(containerSegment, wantedElements, remapTable, channelAttribute);
                         break;
                     case "CCompressedStaticFloat":
-                        segmentArray[i] = new CCompressedStaticFloat(containerSegment, elements, localChannel);
+                        segmentArray[i] = new CCompressedStaticFloat(containerSegment, wantedElements, remapTable, channelAttribute);
+                        break;
+
+                    case "CCompressedFullVector3":
+                        segmentArray[i] = new CCompressedFullVector3(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
+                        break;
+                    case "CCompressedDeltaVector3":
+                        segmentArray[i] = new CCompressedDeltaVector3(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
+                        break;
+                    case "CCompressedAnimVector3":
+                        segmentArray[i] = new CCompressedAnimVector3(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
+                        break;
+                    case "CCompressedAnimQuaternion":
+                        segmentArray[i] = new CCompressedAnimQuaternion(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
+                        break;
+                    case "CCompressedFullQuaternion":
+                        segmentArray[i] = new CCompressedFullQuaternion(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
                         break;
                     case "CCompressedFullFloat":
-                        segmentArray[i] = new CCompressedFullFloat(containerSegment, elements, localChannel);
+                        segmentArray[i] = new CCompressedFullFloat(containerSegment, wantedElements, remapTable, numElements, channelAttribute);
                         break;
 #if DEBUG
                     default:
@@ -140,8 +165,8 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
                 .ToArray();
         }
 
-        public static IEnumerable<Animation> FromResource(Resource resource, IKeyValueCollection decodeKey)
-            => FromData(GetAnimationData(resource), decodeKey);
+        public static IEnumerable<Animation> FromResource(Resource resource, IKeyValueCollection decodeKey, Skeleton skeleton)
+            => FromData(GetAnimationData(resource), decodeKey, skeleton);
 
         private static IKeyValueCollection GetAnimationData(Resource resource)
             => resource.DataBlock.AsKeyValueCollection();
@@ -189,20 +214,17 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         /// <summary>
         /// Get animation matrix recursively.
         /// </summary>
-        private void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 parentBindPose, Matrix4x4 parentInvBindPose, Frame frame, ref Matrix4x4[] matrices)
+        private void GetAnimationMatrixRecursive(Bone bone, Matrix4x4 bindPose, Matrix4x4 invBindPose, Frame frame, ref Matrix4x4[] matrices)
         {
-            // Calculate world space bind and inverse bind pose
-            var bindPose = parentBindPose;
-            var invBindPose = parentInvBindPose * bone.InverseBindPose;
+            // Calculate world space inverse bind pose
+            invBindPose *= bone.InverseBindPose;
 
-            if (frame.Bones.TryGetValue(bone.Name, out var transform))
-            {
-                // Calculate and apply tranformation matrix
-                bindPose = Matrix4x4.CreateScale(transform.Scale)
-                    * Matrix4x4.CreateFromQuaternion(transform.Angle)
-                    * Matrix4x4.CreateTranslation(transform.Position)
-                    * bindPose;
-            }
+            // Calculate and apply tranformation matrix
+            var transform = frame.Bones[bone.Index];
+            bindPose = Matrix4x4.CreateScale(transform.Scale)
+                * Matrix4x4.CreateFromQuaternion(transform.Angle)
+                * Matrix4x4.CreateTranslation(transform.Position)
+                * bindPose;
 
             // Store result
             var skinMatrix = invBindPose * bindPose;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationChannelAttribute.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationChannelAttribute.cs
@@ -1,0 +1,10 @@
+namespace ValveResourceFormat.ResourceTypes.ModelAnimation
+{
+    public enum AnimationChannelAttribute
+    {
+        Position,
+        Angle,
+        Scale,
+        Unknown,
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentDecoder.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationSegmentDecoder.cs
@@ -4,13 +4,13 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
     public abstract class AnimationSegmentDecoder
     {
-        public int[] Elements { get; }
-        public AnimationDataChannel LocalChannel { get; }
+        public int[] RemapTable { get; }
+        public AnimationChannelAttribute ChannelAttribute { get; }
 
-        protected AnimationSegmentDecoder(int[] elements, AnimationDataChannel localChannel)
+        protected AnimationSegmentDecoder(int[] remapTable, AnimationChannelAttribute channelAttribute)
         {
-            Elements = elements;
-            LocalChannel = localChannel;
+            RemapTable = remapTable;
+            ChannelAttribute = channelAttribute;
         }
 
         public abstract void Read(int frameIndex, Frame outFrame);

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
@@ -1,28 +1,24 @@
 using System;
-using System.Collections.Generic;
 using System.Numerics;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
     public class Frame
     {
-        public Dictionary<string, FrameBone> Bones { get; }
+        public FrameBone[] Bones { get; }
 
-        public Frame()
+        public Frame(Skeleton skeleton)
         {
-            Bones = new Dictionary<string, FrameBone>();
+            Bones = new FrameBone[skeleton.Bones.Length];
+            Clear();
         }
 
-        public void SetAttribute(string bone, string attribute, Vector3 data)
+        public void SetAttribute(int bone, AnimationChannelAttribute attribute, Vector3 data)
         {
             switch (attribute)
             {
-                case "Position":
-                    GetBone(bone).Position = data;
-                    break;
-
-                case "data":
-                    //ignore
+                case AnimationChannelAttribute.Position:
+                    Bones[bone].Position = data;
                     break;
 
 #if DEBUG
@@ -33,16 +29,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
-        public void SetAttribute(string bone, string attribute, Quaternion data)
+        public void SetAttribute(int bone, AnimationChannelAttribute attribute, Quaternion data)
         {
             switch (attribute)
             {
-                case "Angle":
-                    GetBone(bone).Angle = data;
-                    break;
-
-                case "data":
-                    //ignore
+                case AnimationChannelAttribute.Angle:
+                    Bones[bone].Angle = data;
                     break;
 
 #if DEBUG
@@ -53,16 +45,12 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
-        public void SetAttribute(string bone, string attribute, float data)
+        public void SetAttribute(int bone, AnimationChannelAttribute attribute, float data)
         {
             switch (attribute)
             {
-                case "Scale":
-                    GetBone(bone).Scale = data;
-                    break;
-
-                case "data":
-                    //ignore
+                case AnimationChannelAttribute.Scale:
+                    Bones[bone].Scale = data;
                     break;
 
 #if DEBUG
@@ -73,16 +61,14 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
-        private FrameBone GetBone(string name)
+        public void Clear()
         {
-            if (!Bones.TryGetValue(name, out var bone))
+            for (var i = 0; i < Bones.Length; i++)
             {
-                bone = new FrameBone(new Vector3(0, 0, 0), new Quaternion(0, 0, 0, 1), 1);
-
-                Bones[name] = bone;
+                Bones[i].Position  = new Vector3(0, 0, 0);
+                Bones[i].Angle = new Quaternion(0, 0, 0, 1);
+                Bones[i].Scale = 1;
             }
-
-            return bone;
         }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
@@ -2,17 +2,10 @@ using System.Numerics;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation
 {
-    public class FrameBone
+    public struct FrameBone
     {
         public Vector3 Position { get; set; }
         public Quaternion Angle { get; set; }
         public float Scale { get; set; }
-
-        public FrameBone(Vector3 pos, Quaternion a, float scale)
-        {
-            Position = pos;
-            Angle = a;
-            Scale = scale;
-        }
     }
 }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimQuaternion.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedAnimQuaternion.cs
@@ -1,28 +1,40 @@
 using System;
+using System.Linq;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
 {
     public class CCompressedAnimQuaternion : AnimationSegmentDecoder
     {
-        public ArraySegment<byte> Data { get; }
+        public byte[] Data { get; }
 
-        public CCompressedAnimQuaternion(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        public CCompressedAnimQuaternion(ArraySegment<byte> data, int[] wantedElements, int[] remapTable,
+            int elementCount, AnimationChannelAttribute channelAttribute) : base(remapTable, channelAttribute)
         {
-            Data = data;
+            const int elementSize = 6;
+            var stride = elementCount * elementSize;
+            Data = Enumerable.Range(0, data.Count / stride)
+                .SelectMany(i => wantedElements.SelectMany(j =>
+                {
+                    return data.Slice(i * stride + j * elementSize, elementSize);
+                }).ToArray())
+                .ToArray();
         }
 
         public override void Read(int frameIndex, Frame outFrame)
         {
-            var offset = 6 * Elements.Length * frameIndex;
-
-            for (var element = 0; element < Elements.Length; element++)
+            const int elementSize = 6;
+            var offset = frameIndex * RemapTable.Length * elementSize;
+            for (var i = 0; i < RemapTable.Length; i++)
             {
                 outFrame.SetAttribute(
-                    LocalChannel.BoneNames[Elements[element]],
-                    LocalChannel.ChannelAttribute,
-                    SegmentHelpers.ReadQuaternion(Data.Slice(offset))
+                    RemapTable[i],
+                    ChannelAttribute,
+                    SegmentHelpers.ReadQuaternion(new ReadOnlySpan<byte>(
+                        Data,
+                        offset + i * elementSize,
+                        elementSize
+                    ))
                 );
-                offset += 6;
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFloat.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
 {
@@ -6,25 +7,20 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
     {
         public float[] Data { get; }
 
-        public CCompressedStaticFloat(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        public CCompressedStaticFloat(ArraySegment<byte> data, int[] wantedElements, int[] remapTable,
+            AnimationChannelAttribute channelAttribute) : base(remapTable, channelAttribute)
         {
-            Data = new float[elements.Length];
-            // Static data has only one frame of data, so prefetch all data to avoid unnecessary GC
-            for (var i = 0; i < elements.Length; i++)
+            Data = wantedElements.Select(i =>
             {
-                Data[i] = BitConverter.ToSingle(data.Slice(i * 4));
-            }
+                return BitConverter.ToSingle(data.Slice(i * 4));
+            }).ToArray();
         }
 
         public override void Read(int frameIndex, Frame outFrame)
         {
-            for (var element = 0; element < Elements.Length; element++)
+            for (var i = 0; i < RemapTable.Length; i++)
             {
-                outFrame.SetAttribute(
-                    LocalChannel.BoneNames[Elements[element]],
-                    LocalChannel.ChannelAttribute,
-                    Data[element]
-                );
+                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, Data[i]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticFullVector3.cs
@@ -8,31 +8,25 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
     {
         public Vector3[] Data { get; }
 
-        public CCompressedStaticFullVector3(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        public CCompressedStaticFullVector3(ArraySegment<byte> data, int[] wantedElements, int[] remapTable,
+            AnimationChannelAttribute channelAttribute) : base(remapTable, channelAttribute)
         {
-            // Static data has only one frame of data, so prefetch all data to avoid unnecessary GC
-            Data = Enumerable.Range(0, data.Count / (3 * 4))
-                .Select(i =>
-                {
-                    var offset = i * 3 * 4;
-                    return new Vector3(
-                        BitConverter.ToSingle(data.Slice(offset + (0 * 4))),
-                        BitConverter.ToSingle(data.Slice(offset + (1 * 4))),
-                        BitConverter.ToSingle(data.Slice(offset + (2 * 4)))
-                    );
-                })
-                .ToArray();
+            Data = wantedElements.Select(i =>
+            {
+                var offset = i * (3 * 4);
+                return new Vector3(
+                    BitConverter.ToSingle(data.Slice(offset + (0 * 4))),
+                    BitConverter.ToSingle(data.Slice(offset + (1 * 4))),
+                    BitConverter.ToSingle(data.Slice(offset + (2 * 4)))
+                );
+            }).ToArray();
         }
 
         public override void Read(int frameIndex, Frame outFrame)
         {
-            for (var element = 0; element < Elements.Length; element++)
+            for (var i = 0; i < RemapTable.Length; i++)
             {
-                outFrame.SetAttribute(
-                    LocalChannel.BoneNames[Elements[element]],
-                    LocalChannel.ChannelAttribute,
-                    Data[element]
-                );
+                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, Data[i]);
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/SegmentDecoders/CCompressedStaticVector3.cs
@@ -8,31 +8,25 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation.SegmentDecoders
     {
         public Vector3[] Data { get; }
 
-        public CCompressedStaticVector3(ArraySegment<byte> data, int[] elements, AnimationDataChannel localChannel) : base(elements, localChannel)
+        public CCompressedStaticVector3(ArraySegment<byte> data, int[] wantedElements, int[] remapTable,
+            AnimationChannelAttribute channelAttribute) : base(remapTable, channelAttribute)
         {
-            // Static data has only one frame of data, so prefetch all data to avoid unnecessary GC
-            Data = Enumerable.Range(0, data.Count / (3 * 2))
-                .Select(i =>
-                {
-                    var offset = i * (3 * 2);
-                    return new Vector3(
-                        (float)BitConverter.ToHalf(data.Slice(offset + (0 * 2))),
-                        (float)BitConverter.ToHalf(data.Slice(offset + (1 * 2))),
-                        (float)BitConverter.ToHalf(data.Slice(offset + (2 * 2)))
-                    );
-                })
-                .ToArray();
+            Data = wantedElements.Select(i =>
+            {
+                var offset = i * (3 * 2);
+                return new Vector3(
+                    (float)BitConverter.ToHalf(data.Slice(offset + (0 * 2))),
+                    (float)BitConverter.ToHalf(data.Slice(offset + (1 * 2))),
+                    (float)BitConverter.ToHalf(data.Slice(offset + (2 * 2)))
+                );
+            }).ToArray();
         }
 
         public override void Read(int frameIndex, Frame outFrame)
         {
-            for (var element = 0; element < Elements.Length; element++)
+            for (var i = 0; i < RemapTable.Length; i++)
             {
-                outFrame.SetAttribute(
-                    LocalChannel.BoneNames[Elements[element]],
-                    LocalChannel.ChannelAttribute,
-                    Data[element]
-                );
+                outFrame.SetAttribute(RemapTable[i], ChannelAttribute, Data[i]);
             }
         }
     }


### PR DESCRIPTION
Gives ~25% FPS boost on Aperture Desk Job map at `point_devshot_camera` camera by avoiding Dictionary usage in animations code.

Should decrease both CPU and RAM usage, but it's hard to measure actual RAM usage because of the GC.