### PR TITLE
Properly handle animations with no Fps/FrameCount

### DIFF
--- a/GUI/Types/Renderer/AnimationController.cs
+++ b/GUI/Types/Renderer/AnimationController.cs
@@ -16,7 +16,7 @@ namespace GUI.Types.Renderer
         {
             get
             {
-                if (activeAnimation != null)
+                if (activeAnimation != null && activeAnimation.FrameCount != 0)
                 {
                     return (int)Math.Round(Time * activeAnimation.Fps) % activeAnimation.FrameCount;
                 }
@@ -26,7 +26,9 @@ namespace GUI.Types.Renderer
             {
                 if (activeAnimation != null)
                 {
-                    Time = value / activeAnimation.Fps;
+                    Time = activeAnimation.Fps != 0
+                        ? value / activeAnimation.Fps
+                        : 0f;
                 }
             }
         }

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -143,6 +143,10 @@ namespace GUI.Types.Renderer
                     if (frame == -1)
                     {
                         var maximum = animation == null ? 1 : animation.FrameCount - 1;
+                        if (maximum < 0)
+                        {
+                            maximum = 0;
+                        }
                         if (animationTrackBar.TrackBar.Maximum != maximum)
                         {
                             animationTrackBar.TrackBar.Maximum = maximum;

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -466,6 +466,13 @@ namespace ValveResourceFormat.IO
 
                     for (var boneID = 0; boneID < boneCount; boneID++)
                     {
+                        if (animation.FrameCount == 0)
+                        {
+                            rotationDicts[boneID].Add(0f, model.Skeleton.Bones[boneID].Angle);
+                            translationDicts[boneID].Add(0f, model.Skeleton.Bones[boneID].Position);
+                            scaleDicts[boneID].Add(0f, Vector3.One);
+                        }
+
                         var jointNode = joints[boneID];
                         exportedAnimation.CreateRotationChannel(jointNode, rotationDicts[boneID], true);
                         exportedAnimation.CreateTranslationChannel(jointNode, translationDicts[boneID], true);

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -183,6 +183,15 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             // Create output array
             var matrices = new Matrix4x4[skeleton.Bones.Length];
 
+            if (FrameCount == 0)
+            {
+                for (var i = 0; i < matrices.Length; i++)
+                {
+                    matrices[i] = Matrix4x4.Identity;
+                }
+                return matrices;
+            }
+
             // Get bone transformations
             var frame = frameCache.GetFrame(this, time);
 


### PR DESCRIPTION
Fixes glTF export and GUI handling of Dota 2 `models/heroes/snapfire/debut/assets/basket/basket.vmdl_c` and its `hammer_placeholder` animation.