### PR TITLE
Fix animations that skip bones

### DIFF
--- a/GUI/Types/Renderer/AnimationController.cs
+++ b/GUI/Types/Renderer/AnimationController.cs
@@ -10,6 +10,7 @@ namespace GUI.Types.Renderer
         private Action<Animation, int> updateHandler = (_, __) => { };
         private Animation activeAnimation;
         private float Time;
+        private bool shouldUpdate;
 
         public bool IsPaused { get; set; }
         public int Frame
@@ -29,6 +30,7 @@ namespace GUI.Types.Renderer
                     Time = activeAnimation.Fps != 0
                         ? value / activeAnimation.Fps
                         : 0f;
+                    shouldUpdate = true;
                 }
             }
         }
@@ -45,12 +47,16 @@ namespace GUI.Types.Renderer
                 return false;
             }
 
-            if (!IsPaused)
+            if (IsPaused)
             {
-                Time += timeStep;
-                updateHandler(activeAnimation, Frame);
+                var res = shouldUpdate;
+                shouldUpdate = false;
+                return res;
             }
 
+            Time += timeStep;
+            updateHandler(activeAnimation, Frame);
+            shouldUpdate = false;
             return true;
         }
 

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/AnimationFrameCache.cs
@@ -36,9 +36,14 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 var frame1Bone = frame1.Bones[i];
                 var frame2Bone = frame2.Bones[i];
-                InterpolatedFrame.Bones[i].Position = Vector3.Lerp(frame1Bone.Position, frame2Bone.Position, t);
-                InterpolatedFrame.Bones[i].Angle = Quaternion.Slerp(frame1Bone.Angle, frame2Bone.Angle, t);
-                InterpolatedFrame.Bones[i].Scale = frame1Bone.Scale + (frame2Bone.Scale - frame1Bone.Scale) * t;
+                var present = frame1Bone.Present && frame2Bone.Present;
+                InterpolatedFrame.Bones[i].Present = present;
+                if (present)
+                {
+                    InterpolatedFrame.Bones[i].Position = Vector3.Lerp(frame1Bone.Position, frame2Bone.Position, t);
+                    InterpolatedFrame.Bones[i].Angle = Quaternion.Slerp(frame1Bone.Angle, frame2Bone.Angle, t);
+                    InterpolatedFrame.Bones[i].Scale = frame1Bone.Scale + (frame2Bone.Scale - frame1Bone.Scale) * t;
+                }
             }
 
             return InterpolatedFrame;

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
@@ -19,6 +19,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Position:
                     Bones[bone].Position = data;
+                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -35,6 +36,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Angle:
                     Bones[bone].Angle = data;
+                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -51,6 +53,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Scale:
                     Bones[bone].Scale = data;
+                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -66,8 +69,9 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             for (var i = 0; i < Bones.Length; i++)
             {
                 Bones[i].Position = Vector3.Zero;
-                Bones[i].Angle = new Quaternion(0, 0, 0, 1);
+                Bones[i].Angle = Quaternion.Identity;
                 Bones[i].Scale = 1;
+                Bones[i].Present = false;
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
@@ -7,5 +7,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public Vector3 Position { get; set; }
         public Quaternion Angle { get; set; }
         public float Scale { get; set; }
+        public bool Present { get; set; }
     }
 }


### PR DESCRIPTION
Fixes SteamVR `Team Fortress 2 Supervillain Lair` `models/props_animated/doomsday_button001.vmdl_c`.

Also fixes unnecessary animations processing in the GUI.