### PR TITLE
Remove FrameBone#Parent

### DIFF
--- a/GUI/Types/Renderer/ShaderLoader.cs
+++ b/GUI/Types/Renderer/ShaderLoader.cs
@@ -254,7 +254,7 @@ namespace GUI.Types.Renderer
                         return "vr_glass";
                     }
 
-                    return "vr_standard";
+                    return "simple";
                 case "water_dota.vfx":
                     return "water";
                 case "hero.vfx":

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -371,7 +371,7 @@ namespace ValveResourceFormat.IO
                 foreach (var animation in animations)
                 {
                     // Cleanup state
-                    frame.Clear();
+                    frame.Clear(model.Skeleton);
                     for (var i = 0; i < boneCount; i++)
                     {
                         rotationDicts[i].Clear();

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Animation.cs
@@ -226,7 +226,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             invBindPose *= bone.InverseBindPose;
 
             // Calculate and apply tranformation matrix
-            if (frame != null && frame.Bones[bone.Index].Present)
+            if (frame != null)
             {
                 var transform = frame.Bones[bone.Index];
                 bindPose = Matrix4x4.CreateScale(transform.Scale)

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/Frame.cs
@@ -10,7 +10,7 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public Frame(Skeleton skeleton)
         {
             Bones = new FrameBone[skeleton.Bones.Length];
-            Clear();
+            Clear(skeleton);
         }
 
         public void SetAttribute(int bone, AnimationChannelAttribute attribute, Vector3 data)
@@ -19,7 +19,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Position:
                     Bones[bone].Position = data;
-                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -36,7 +35,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Angle:
                     Bones[bone].Angle = data;
-                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -53,7 +51,6 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             {
                 case AnimationChannelAttribute.Scale:
                     Bones[bone].Scale = data;
-                    Bones[bone].Present = true;
                     break;
 
 #if DEBUG
@@ -64,14 +61,18 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
             }
         }
 
-        public void Clear()
+        /// <summary>
+        /// Resets frame bones to their bind pose.
+        /// Should be used on animation change.
+        /// </summary>
+        /// <param name="skeleton">The same skeleton that was passed to the constructor.</param>
+        public void Clear(Skeleton skeleton)
         {
             for (var i = 0; i < Bones.Length; i++)
             {
-                Bones[i].Position = Vector3.Zero;
-                Bones[i].Angle = Quaternion.Identity;
+                Bones[i].Position = skeleton.Bones[i].Position;
+                Bones[i].Angle = skeleton.Bones[i].Angle;
                 Bones[i].Scale = 1;
-                Bones[i].Present = false;
             }
         }
     }

--- a/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/ModelAnimation/FrameBone.cs
@@ -7,6 +7,5 @@ namespace ValveResourceFormat.ResourceTypes.ModelAnimation
         public Vector3 Position { get; set; }
         public Quaternion Angle { get; set; }
         public float Scale { get; set; }
-        public bool Present { get; set; }
     }
 }


### PR DESCRIPTION
I didn't pay attention to Bone Position and Angles in #499, and I believe this change should use a bit less memory and code.

Also fixes leftover reference to deleted `vr_standard` from c921650 and updates comment in Frame that should've been changed in #497.