### PR TITLE
Factor in `g_flEdgeColorThickness` in glass shader

### DIFF
--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -131,6 +131,8 @@ namespace GUI.Types.Renderer
             Scene.MainCamera = e.Camera;
             Scene.Update(e.FrameTime);
 
+            GL.Enable(EnableCap.CullFace);
+
             if (ShowBaseGrid)
             {
                 baseGrid.Render(e.Camera, RenderPass.Both);

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -45,9 +45,10 @@ uniform vec4 g_vColorTint;
 
 // glass specific params
 #if param_F_GLASS == 1
+uniform bool g_bFresnel = true;
 uniform float g_flEdgeColorFalloff = 3.0;
-uniform float g_flEdgeColorMaxOpacity = 1.0;
-uniform float g_flEdgeColorThickness = 1.0;
+uniform float g_flEdgeColorMaxOpacity = 0.5;
+uniform float g_flEdgeColorThickness = 0.1;
 uniform vec4 g_vEdgeColor;
 uniform float g_flRefractScale = 0.1;
 uniform float g_flOpacityScale = 1.0;
@@ -132,8 +133,9 @@ void main()
 #if param_F_GLASS == 1
     vec4 glassColor = vec4(illumination * color.rgb * g_vColorTint.rgb, color.a);
 
-    float fresnel = pow(1.0 - abs(dot(worldNormal, viewDirection)), g_flEdgeColorFalloff);
-    vec4 fresnelColor = vec4(g_vEdgeColor.xyz, g_flEdgeColorMaxOpacity * fresnel);
+    float viewDotNormalInv = clamp(1.0 - (dot(viewDirection, worldNormal) - g_flEdgeColorThickness), 0.0, 1.0);
+    float fresnel = clamp(pow(viewDotNormalInv, g_flEdgeColorFalloff), 0.0, 1.0) * g_flEdgeColorMaxOpacity * (g_bFresnel ? 1.0 : 0.0);
+    vec4 fresnelColor = vec4(g_vEdgeColor.xyz, fresnel);
 
     outputColor = mix(glassColor, fresnelColor, g_flOpacityScale);
 #else


### PR DESCRIPTION
And fix backface culling being enabled on startup.

resource:
Aperture Desk Job/models/tileset/pipe/pipe01_str_128a_glass.vmdl_c
master:
![image](https://user-images.githubusercontent.com/26466974/210149644-31cd1ab4-35af-44a6-b343-6944a49b4da6.png)
this pr:
![image](https://media.discordapp.net/attachments/775429805469597768/1058407532588183552/image.png?width=908&height=593)
