### PR TITLE
Scene model picker

### DIFF
--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -22,6 +22,7 @@ namespace GUI.Controls
         private static readonly float TickFrequency = TicksPerSecond / Stopwatch.Frequency;
 
         public GLControl GLControl { get; }
+        public IGLViewer GLViewer { get; }
 
         private int currentControlsHeight = 35;
 
@@ -44,11 +45,12 @@ namespace GUI.Controls
 
         Vector2 initialMousePosition;
 
-        public GLViewerControl()
+        public GLViewerControl(IGLViewer glViewer)
         {
             InitializeComponent();
             Dock = DockStyle.Fill;
 
+            GLViewer = glViewer;
             Camera = new Camera();
 
             // Initialize GL control
@@ -110,7 +112,7 @@ namespace GUI.Controls
 
             SetControlLocation(selectionControl);
 
-            selectionControl.ComboBox.SelectionChangeCommitted += (_, __) =>
+            selectionControl.ComboBox.SelectedIndexChanged += (_, __) =>
             {
                 selectionControl.Refresh();
                 changeCallback(selectionControl.ComboBox.SelectedItem as string, selectionControl.ComboBox.SelectedIndex);
@@ -121,9 +123,14 @@ namespace GUI.Controls
             return selectionControl.ComboBox;
         }
 
-        public CheckedListBox AddMultiSelection(string name, Action<IEnumerable<string>> changeCallback)
+        public CheckedListBox AddMultiSelection(string name, Action<CheckedListBox> initializeCallback, Action<IEnumerable<string>> changeCallback)
         {
             var selectionControl = new GLViewerMultiSelectionControl(name);
+
+            if (initializeCallback != null)
+            {
+                initializeCallback(selectionControl.CheckedListBox);
+            }
 
             controlsPanel.Controls.Add(selectionControl);
 
@@ -218,7 +225,6 @@ namespace GUI.Controls
             }
 
             Camera.Picker?.Request.NextFrame(e.X, e.Y, PickingIntent.Select);
-
         }
 
         private void OnLoad(object sender, EventArgs e)

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -11,7 +11,8 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Input;
-using FormsMouseEventArgs = System.Windows.Forms.MouseEventArgs;
+using WinFormsMouseEventArgs = System.Windows.Forms.MouseEventArgs;
+using static GUI.Types.Renderer.PickingTexture;
 
 namespace GUI.Controls
 {
@@ -41,6 +42,8 @@ namespace GUI.Controls
         long lastUpdate;
         int frames;
 
+        Vector2 initialMousePosition;
+
         public GLViewerControl()
         {
             InitializeComponent();
@@ -61,6 +64,7 @@ namespace GUI.Controls
             GLControl.Resize += OnResize;
             GLControl.MouseEnter += OnMouseEnter;
             GLControl.MouseLeave += OnMouseLeave;
+            GLControl.MouseUp += OnMouseUp;
             GLControl.MouseDown += OnMouseDown;
             GLControl.GotFocus += OnGotFocus;
             GLControl.VisibleChanged += OnVisibleChanged;
@@ -168,6 +172,7 @@ namespace GUI.Controls
             GLControl.Resize -= OnResize;
             GLControl.MouseEnter -= OnMouseEnter;
             GLControl.MouseLeave -= OnMouseLeave;
+            GLControl.MouseUp -= OnMouseUp;
             GLControl.MouseDown -= OnMouseDown;
             GLControl.GotFocus -= OnGotFocus;
             GLControl.VisibleChanged -= OnVisibleChanged;
@@ -193,14 +198,27 @@ namespace GUI.Controls
             Camera.MouseOverRenderArea = true;
         }
 
-        private void OnMouseDown(object sender, FormsMouseEventArgs e)
+        private void OnMouseDown(object sender, WinFormsMouseEventArgs e)
         {
-            if (e.Button != MouseButtons.Left)
+            if (e.Button == MouseButtons.Left)
+            {
+                initialMousePosition = new Vector2(e.X, e.Y);
+                if (e.Clicks == 2)
+                {
+                    Camera.Picker?.Request.NextFrame(e.X, e.Y, PickingIntent.Open);
+                }
+            }
+        }
+
+        private void OnMouseUp(object sender, WinFormsMouseEventArgs e)
+        {
+            if (e.Button != MouseButtons.Left || initialMousePosition != new Vector2(e.X, e.Y))
             {
                 return;
             }
 
-            Camera.Picker?.Request.NextFrame(e.X, e.Y, e.Clicks);
+            Camera.Picker?.Request.NextFrame(e.X, e.Y, PickingIntent.Select);
+
         }
 
         private void OnLoad(object sender, EventArgs e)

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -34,7 +34,6 @@ namespace GUI.Controls
 
         public event EventHandler<RenderEventArgs> GLPaint;
         public event EventHandler GLLoad;
-        public event EventHandler<uint> SceneNodeDoubleClick;
 
         private static bool hasCheckedOpenGL;
 
@@ -197,7 +196,7 @@ namespace GUI.Controls
         {
             if (e.Clicks == 2)
             {
-                Camera.Picker.Pick(e.X, e.Y, SceneNodeDoubleClick);
+                Camera.Picker.Request.NextFrame(e.X, e.Y);
             }
         }
 

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -196,7 +196,7 @@ namespace GUI.Controls
         {
             if (e.Clicks == 2)
             {
-                Camera.Picker.Request.NextFrame(e.X, e.Y);
+                Camera.Picker?.Request.NextFrame(e.X, e.Y);
             }
         }
 

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -11,6 +11,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Graphics.OpenGL;
 using OpenTK.Input;
+using FormsMouseEventArgs = System.Windows.Forms.MouseEventArgs;
 
 namespace GUI.Controls
 {
@@ -60,6 +61,7 @@ namespace GUI.Controls
             GLControl.Resize += OnResize;
             GLControl.MouseEnter += OnMouseEnter;
             GLControl.MouseLeave += OnMouseLeave;
+            GLControl.MouseDown += OnMouseDown;
             GLControl.GotFocus += OnGotFocus;
             GLControl.VisibleChanged += OnVisibleChanged;
             GLControl.Disposed += OnDisposed;
@@ -188,6 +190,15 @@ namespace GUI.Controls
         private void OnMouseEnter(object sender, EventArgs e)
         {
             Camera.MouseOverRenderArea = true;
+        }
+
+        private void OnMouseDown(object sender, FormsMouseEventArgs e)
+        {
+            if (e.Clicks == 2)
+            {
+                var objectID = Camera.Picking?.ReadPixel(e.X, e.Y) ?? 0;
+                Console.WriteLine($"Picked ID: {objectID}");
+            }
         }
 
         private void OnLoad(object sender, EventArgs e)

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -195,10 +195,12 @@ namespace GUI.Controls
 
         private void OnMouseDown(object sender, FormsMouseEventArgs e)
         {
-            if (e.Clicks == 2)
+            if (e.Button != MouseButtons.Left)
             {
-                Camera.Picker?.Request.NextFrame(e.X, e.Y);
+                return;
             }
+
+            Camera.Picker?.Request.NextFrame(e.X, e.Y, e.Clicks);
         }
 
         private void OnLoad(object sender, EventArgs e)

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -34,6 +34,7 @@ namespace GUI.Controls
 
         public event EventHandler<RenderEventArgs> GLPaint;
         public event EventHandler GLLoad;
+        public event EventHandler<uint> SceneNodeDoubleClick;
 
         private static bool hasCheckedOpenGL;
 
@@ -196,8 +197,7 @@ namespace GUI.Controls
         {
             if (e.Clicks == 2)
             {
-                var objectID = Camera.Picking?.ReadPixel(e.X, e.Y) ?? 0;
-                Console.WriteLine($"Picked ID: {objectID}");
+                Camera.Picker.Pick(e.X, e.Y, SceneNodeDoubleClick);
             }
         }
 

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -168,6 +168,7 @@ namespace GUI.Controls
             GLControl.Resize -= OnResize;
             GLControl.MouseEnter -= OnMouseEnter;
             GLControl.MouseLeave -= OnMouseLeave;
+            GLControl.MouseDown -= OnMouseDown;
             GLControl.GotFocus -= OnGotFocus;
             GLControl.VisibleChanged -= OnVisibleChanged;
             GLControl.Disposed -= OnDisposed;

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -34,7 +34,7 @@ namespace GUI.Controls
 
         public event EventHandler<RenderEventArgs> GLPaint;
         public event EventHandler GLLoad;
-
+        public Action<GLViewerControl> GLPostLoad { get; set; }
         private static bool hasCheckedOpenGL;
 
         long lastFpsUpdate;
@@ -225,6 +225,8 @@ namespace GUI.Controls
             }
 
             HandleResize();
+            GLPostLoad?.Invoke(this);
+            GLPostLoad = null;
             Draw();
         }
 

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -428,7 +428,7 @@ namespace GUI
             OpenFile(vrfGuiContext, null);
         }
 
-        public void OpenFile(VrfGuiContext vrfGuiContext, PackageEntry file)
+        public Task<TabPage> OpenFile(VrfGuiContext vrfGuiContext, PackageEntry file)
         {
             var tab = new TabPage(Path.GetFileName(vrfGuiContext.FileName))
             {
@@ -500,6 +500,8 @@ namespace GUI
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnRanToCompletion,
                 TaskScheduler.FromCurrentSynchronizationContext());
+
+            return task;
         }
 
         private TabPage ProcessFile(VrfGuiContext vrfGuiContext, PackageEntry file)

--- a/GUI/Types/Renderer/AnimationController.cs
+++ b/GUI/Types/Renderer/AnimationController.cs
@@ -12,6 +12,7 @@ namespace GUI.Types.Renderer
         private float Time;
         private bool shouldUpdate;
 
+        public Animation ActiveAnimation => activeAnimation;
         public bool IsPaused { get; set; }
         public int Frame
         {

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -153,7 +153,7 @@ namespace GUI.Types.Renderer
         {
             KeyboardState = keyboardState;
 
-            if (MouseOverRenderArea && mouseState.LeftButton == ButtonState.Pressed)
+            if (MouseOverRenderArea && (mouseState.LeftButton == ButtonState.Pressed || mouseState.RightButton == ButtonState.Pressed))
             {
                 if (!MouseDragging)
                 {
@@ -169,7 +169,7 @@ namespace GUI.Types.Renderer
                 MousePreviousPosition = mouseNewCoords;
             }
 
-            if (!MouseOverRenderArea || mouseState.LeftButton == ButtonState.Released)
+            if (!MouseOverRenderArea || !mouseState.IsConnected || (mouseState.LeftButton == ButtonState.Released && mouseState.RightButton == ButtonState.Released))
             {
                 MouseDragging = false;
                 MouseDelta = default;

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -19,7 +19,7 @@ namespace GUI.Types.Renderer
         public Matrix4x4 CameraViewMatrix { get; private set; }
         public Matrix4x4 ViewProjectionMatrix { get; private set; }
         public Frustum ViewFrustum { get; } = new Frustum();
-        public PickingTexture Picking { get; set; }
+        public PickingTexture Picker { get; set; }
         public bool RenderToPicker { get; set; }
 
         // Set from outside this class by forms code
@@ -73,7 +73,7 @@ namespace GUI.Types.Renderer
             // setup viewport
             GL.Viewport(0, 0, viewportWidth, viewportHeight);
 
-            Picking?.Resize(viewportWidth, viewportHeight);
+            Picker?.Resize(viewportWidth, viewportHeight);
         }
 
         public void CopyFrom(Camera fromOther)

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -20,8 +20,6 @@ namespace GUI.Types.Renderer
         public Matrix4x4 ViewProjectionMatrix { get; private set; }
         public Frustum ViewFrustum { get; } = new Frustum();
         public PickingTexture Picker { get; set; }
-        public bool RenderToPicker { get; set; }
-        public bool PickerDebug { get; set; }
 
         // Set from outside this class by forms code
         public bool MouseOverRenderArea { get; set; }

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -19,6 +19,8 @@ namespace GUI.Types.Renderer
         public Matrix4x4 CameraViewMatrix { get; private set; }
         public Matrix4x4 ViewProjectionMatrix { get; private set; }
         public Frustum ViewFrustum { get; } = new Frustum();
+        public PickingTexture Picking { get; set; }
+        public bool RenderToPicker { get; set; }
 
         // Set from outside this class by forms code
         public bool MouseOverRenderArea { get; set; }
@@ -70,6 +72,8 @@ namespace GUI.Types.Renderer
 
             // setup viewport
             GL.Viewport(0, 0, viewportWidth, viewportHeight);
+
+            Picking?.Resize(viewportWidth, viewportHeight);
         }
 
         public void CopyFrom(Camera fromOther)

--- a/GUI/Types/Renderer/Camera.cs
+++ b/GUI/Types/Renderer/Camera.cs
@@ -21,6 +21,7 @@ namespace GUI.Types.Renderer
         public Frustum ViewFrustum { get; } = new Frustum();
         public PickingTexture Picker { get; set; }
         public bool RenderToPicker { get; set; }
+        public bool PickerDebug { get; set; }
 
         // Set from outside this class by forms code
         public bool MouseOverRenderArea { get; set; }

--- a/GUI/Types/Renderer/GLMaterialViewer.cs
+++ b/GUI/Types/Renderer/GLMaterialViewer.cs
@@ -11,7 +11,7 @@ namespace GUI.Types.Renderer
     /// Renders a list of MatarialRenderers.
     /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    internal class GLMaterialViewer
+    internal class GLMaterialViewer : IGLViewer
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
         private ICollection<MaterialRenderer> Renderers { get; } = new HashSet<MaterialRenderer>();
@@ -24,7 +24,7 @@ namespace GUI.Types.Renderer
 
         public GLMaterialViewer()
         {
-            viewerControl = new GLViewerControl();
+            viewerControl = new GLViewerControl(this);
 
             viewerControl.GLLoad += OnLoad;
         }

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -187,9 +187,9 @@ namespace GUI.Types.Renderer
             }
         }
 
-        protected override void OnPickerDoubleClick(object sender, PickingTexture.PixelInfo pixelInfo)
+        protected override void OnPickerDoubleClick(object sender, PickingTexture.PickingResponse pickingResponse)
         {
-            Console.WriteLine("Selected mesh with index " + pixelInfo.MeshId);
+            Console.WriteLine("Selected mesh with index " + pickingResponse.PixelInfo.MeshId);
         }
 
         private void SetAvailableAnimations(IEnumerable<string> animations)

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -16,11 +16,11 @@ namespace GUI.Types.Renderer
         private readonly Model model;
         private readonly Mesh mesh;
         private PhysAggregateData phys;
-        private ComboBox animationComboBox;
+        public ComboBox animationComboBox { get; private set; }
         private CheckBox animationPlayPause;
         private GLViewerTrackBarControl animationTrackBar;
-        private CheckedListBox meshGroupListBox;
-        private ComboBox materialGroupListBox;
+        public CheckedListBox meshGroupListBox { get; private set; }
+        public ComboBox materialGroupListBox { get; private set; }
         private ModelSceneNode modelSceneNode;
         private MeshSceneNode meshSceneNode;
         private PhysSceneNode physSceneNode;
@@ -113,16 +113,17 @@ namespace GUI.Types.Renderer
 
                 if (meshGroups.Count() > 1)
                 {
-                    meshGroupListBox = ViewerControl.AddMultiSelection("Mesh Group", selectedGroups =>
+                    meshGroupListBox = ViewerControl.AddMultiSelection("Mesh Group", listBox =>
+                    {
+                        listBox.Items.AddRange(modelSceneNode.GetMeshGroups().ToArray<object>());
+                        foreach (var group in modelSceneNode.GetActiveMeshGroups())
+                        {
+                            listBox.SetItemChecked(listBox.FindStringExact(group), true);
+                        }
+                    }, selectedGroups =>
                     {
                         modelSceneNode.SetActiveMeshGroups(selectedGroups);
                     });
-
-                    meshGroupListBox.Items.AddRange(modelSceneNode.GetMeshGroups().ToArray<object>());
-                    foreach (var group in modelSceneNode.GetActiveMeshGroups())
-                    {
-                        meshGroupListBox.SetItemChecked(meshGroupListBox.FindStringExact(group), true);
-                    }
                 }
 
                 var materialGroups = model.GetMaterialGroups();

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -166,6 +166,7 @@ namespace GUI.Types.Renderer
             else
             {
                 SetAvailableAnimations(Enumerable.Empty<string>());
+                ViewerControl.Camera.Picker.OnPicked -= OnPickerDoubleClick;
             }
 
             if (mesh != null)
@@ -184,6 +185,11 @@ namespace GUI.Types.Renderer
 
                 ViewerControl.AddCheckBox("Show Physics", physSceneNode.Enabled, (v) => { physSceneNode.Enabled = v; });
             }
+        }
+
+        protected override void OnPickerDoubleClick(object sender, PickingTexture.PixelInfo pixelInfo)
+        {
+            Console.WriteLine("Selected mesh with index " + pixelInfo.MeshId);
         }
 
         private void SetAvailableAnimations(IEnumerable<string> animations)

--- a/GUI/Types/Renderer/GLParticleViewer.cs
+++ b/GUI/Types/Renderer/GLParticleViewer.cs
@@ -15,7 +15,7 @@ namespace GUI.Types.Renderer
     /// Renders a list of ParticleRenderers.
     /// </summary>
 #pragma warning disable CA1001 // Types that own disposable fields should be disposable
-    internal class GLParticleViewer
+    internal class GLParticleViewer : IGLViewer
 #pragma warning restore CA1001 // Types that own disposable fields should be disposable
     {
         private ICollection<ParticleRenderer.ParticleRenderer> Renderers { get; } = new HashSet<ParticleRenderer.ParticleRenderer>();
@@ -34,7 +34,7 @@ namespace GUI.Types.Renderer
         {
             vrfGuiContext = guiContext;
 
-            viewerControl = new GLViewerControl();
+            viewerControl = new GLViewerControl(this);
 
             renderModeComboBox = viewerControl.AddSelection("Render Mode", (renderMode, _) => SetRenderMode(renderMode));
 

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -261,7 +261,7 @@ namespace GUI.Types.Renderer
                     Console.WriteLine($"Selected {modelNode.GetModelFileName()} (Id: {nodeID})");
                     if (entry != null)
                     {
-                        var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext);
+                        var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext.ParentGuiContext);
                         Program.MainForm.OpenFile(newVrfGuiContext, entry);
                     }
                 }

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -35,6 +35,7 @@ namespace GUI.Types.Renderer
         private readonly Camera skyboxCamera = new();
         private OctreeDebugRenderer<SceneNode> staticOctreeRenderer;
         private OctreeDebugRenderer<SceneNode> dynamicOctreeRenderer;
+        private PickingTexture pickingTexture;
 
         protected GLSceneViewer(VrfGuiContext guiContext, Frustum cullFrustum)
         {
@@ -120,6 +121,8 @@ namespace GUI.Types.Renderer
             staticOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.StaticOctree, Scene.GuiContext, false);
             dynamicOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.DynamicOctree, Scene.GuiContext, true);
 
+            pickingTexture = new PickingTexture(1024, 1024, Scene.GuiContext);
+
             if (renderModeComboBox != null)
             {
                 var supportedRenderModes = Scene.AllNodes
@@ -159,7 +162,7 @@ namespace GUI.Types.Renderer
                 GL.Clear(ClearBufferMask.DepthBufferBit);
             }
 
-            Scene.RenderWithCamera(e.Camera, lockedCullFrustum);
+            Scene.RenderWithCamera(e.Camera, lockedCullFrustum, pickingTexture);
 
             if (showStaticOctree)
             {

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -12,7 +12,7 @@ using static GUI.Controls.GLViewerControl;
 
 namespace GUI.Types.Renderer
 {
-    internal abstract class GLSceneViewer
+    internal abstract class GLSceneViewer : IGLViewer
     {
         public Scene Scene { get; }
         public Scene SkyboxScene { get; protected set; }
@@ -40,7 +40,7 @@ namespace GUI.Types.Renderer
         protected GLSceneViewer(VrfGuiContext guiContext, Frustum cullFrustum)
         {
             Scene = new Scene(guiContext);
-            ViewerControl = new GLViewerControl();
+            ViewerControl = new GLViewerControl(this);
             lockedCullFrustum = cullFrustum;
 
             InitializeControl();
@@ -53,7 +53,7 @@ namespace GUI.Types.Renderer
         protected GLSceneViewer(VrfGuiContext guiContext)
         {
             Scene = new Scene(guiContext);
-            ViewerControl = new GLViewerControl();
+            ViewerControl = new GLViewerControl(this);
 
             InitializeControl();
             ViewerControl.AddCheckBox("Show Static Octree", showStaticOctree, (v) =>

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -28,6 +28,7 @@ namespace GUI.Types.Renderer
         private bool showStaticOctree;
         private bool showDynamicOctree;
         private bool showToolsMaterials = true;
+        private bool renderToPicker = true;
         private Frustum lockedCullFrustum;
 
         private ComboBox renderModeComboBox;
@@ -35,7 +36,6 @@ namespace GUI.Types.Renderer
         private readonly Camera skyboxCamera = new();
         private OctreeDebugRenderer<SceneNode> staticOctreeRenderer;
         private OctreeDebugRenderer<SceneNode> dynamicOctreeRenderer;
-        private PickingTexture pickingTexture;
 
         protected GLSceneViewer(VrfGuiContext guiContext, Frustum cullFrustum)
         {
@@ -75,6 +75,7 @@ namespace GUI.Types.Renderer
                     SkyboxScene.ShowToolsMaterials = v;
                 }
             });
+            ViewerControl.AddCheckBox("Render To Picker", renderToPicker, (v) => renderToPicker = v);
             ViewerControl.AddCheckBox("Lock Cull Frustum", false, (v) =>
             {
                 if (v)
@@ -121,7 +122,7 @@ namespace GUI.Types.Renderer
             staticOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.StaticOctree, Scene.GuiContext, false);
             dynamicOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.DynamicOctree, Scene.GuiContext, true);
 
-            pickingTexture = new PickingTexture(1024, 1024, Scene.GuiContext);
+            ViewerControl.Camera.Picking = new PickingTexture(Scene.GuiContext);
 
             if (renderModeComboBox != null)
             {
@@ -162,7 +163,8 @@ namespace GUI.Types.Renderer
                 GL.Clear(ClearBufferMask.DepthBufferBit);
             }
 
-            Scene.RenderWithCamera(e.Camera, lockedCullFrustum, pickingTexture);
+            e.Camera.RenderToPicker = renderToPicker;
+            Scene.RenderWithCamera(e.Camera, lockedCullFrustum);
 
             if (showStaticOctree)
             {

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -103,8 +103,7 @@ namespace GUI.Types.Renderer
             ViewerControl.Camera.SetLocation(new Vector3(256));
             ViewerControl.Camera.LookAt(new Vector3(0));
 
-            ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext);
-            ViewerControl.Camera.Picker.OnPicked += OnSceneNodeDoubleClick;
+            ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext, OnSceneNodeDoubleClick);
 
             var timer = new Stopwatch();
             timer.Start();
@@ -193,6 +192,8 @@ namespace GUI.Types.Renderer
             button.Click += (s, e) =>
             {
                 SetRenderMode(renderModeComboBox?.SelectedItem as string);
+                ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext, OnSceneNodeDoubleClick);
+                ViewerControl.Camera.Picker.Resize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
             };
             ViewerControl.AddControl(button);
 #endif

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -35,6 +35,7 @@ namespace GUI.Types.Renderer
         private readonly Camera skyboxCamera = new();
         private OctreeDebugRenderer<SceneNode> staticOctreeRenderer;
         private OctreeDebugRenderer<SceneNode> dynamicOctreeRenderer;
+        protected SelectedNodeRenderer selectedNodeRenderer;
 
         protected GLSceneViewer(VrfGuiContext guiContext, Frustum cullFrustum)
         {
@@ -93,11 +94,12 @@ namespace GUI.Types.Renderer
 
         protected abstract void LoadScene();
 
-        protected abstract void OnPickerDoubleClick(object sender, PickingTexture.PixelInfo pixelInfo);
+        protected abstract void OnPickerDoubleClick(object sender, PickingTexture.PickingResponse pixelInfo);
 
         private void OnLoad(object sender, EventArgs e)
         {
             baseGrid = new ParticleGrid(20, 5, GuiContext);
+            selectedNodeRenderer = new(GuiContext);
 
             ViewerControl.Camera.SetViewportSize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
             ViewerControl.Camera.SetLocation(new Vector3(256));
@@ -164,6 +166,8 @@ namespace GUI.Types.Renderer
             }
 
             Scene.RenderWithCamera(e.Camera, lockedCullFrustum);
+
+            selectedNodeRenderer.Render(e.Camera, RenderPass.Both);
 
             if (showStaticOctree)
             {

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -29,6 +29,7 @@ namespace GUI.Types.Renderer
         private bool showDynamicOctree;
         private bool showToolsMaterials = true;
         private bool renderToPicker;
+        private bool pickerDebug;
         private Frustum lockedCullFrustum;
 
         private ComboBox renderModeComboBox;
@@ -76,6 +77,7 @@ namespace GUI.Types.Renderer
                 }
             });
             ViewerControl.AddCheckBox("Render To Picker", renderToPicker, (v) => renderToPicker = v);
+            ViewerControl.AddCheckBox("Picker Debug", pickerDebug, (v) => pickerDebug = v);
             ViewerControl.AddCheckBox("Lock Cull Frustum", false, (v) =>
             {
                 if (v)
@@ -165,6 +167,8 @@ namespace GUI.Types.Renderer
             }
 
             e.Camera.RenderToPicker = renderToPicker;
+            e.Camera.PickerDebug = pickerDebug;
+
             Scene.RenderWithCamera(e.Camera, lockedCullFrustum);
 
             if (showStaticOctree)

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -28,7 +28,7 @@ namespace GUI.Types.Renderer
         private bool showStaticOctree;
         private bool showDynamicOctree;
         private bool showToolsMaterials = true;
-        private bool renderToPicker = true;
+        private bool renderToPicker;
         private Frustum lockedCullFrustum;
 
         private ComboBox renderModeComboBox;
@@ -89,6 +89,7 @@ namespace GUI.Types.Renderer
             });
 
             ViewerControl.GLLoad += OnLoad;
+            ViewerControl.SceneNodeDoubleClick += OnSceneNodeDoubleClick;
         }
 
         protected abstract void InitializeControl();
@@ -122,7 +123,7 @@ namespace GUI.Types.Renderer
             staticOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.StaticOctree, Scene.GuiContext, false);
             dynamicOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.DynamicOctree, Scene.GuiContext, true);
 
-            ViewerControl.Camera.Picking = new PickingTexture(Scene.GuiContext);
+            ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext);
 
             if (renderModeComboBox != null)
             {
@@ -231,6 +232,34 @@ namespace GUI.Types.Renderer
                 foreach (var node in SkyboxScene.AllNodes)
                 {
                     node.SetRenderMode(renderMode);
+                }
+            }
+        }
+
+        private void OnSceneNodeDoubleClick(object sender, uint nodeID)
+        {
+            if (nodeID == 0)
+            {
+                return;
+            }
+
+            foreach (var node in Scene.AllNodes)
+            {
+                if (node.Id != nodeID)
+                {
+                    continue;
+                }
+
+                if (node is ModelSceneNode modelNode)
+                {
+                    // TODO: Use FileLoader
+                    var entry = GuiContext.CurrentPackage?.FindEntry(modelNode.GetModelFileName() + "_c");
+                    Console.WriteLine($"Selected {modelNode.GetModelFileName()} (Id: {nodeID})");
+                    if (entry != null)
+                    {
+                        var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext);
+                        Program.MainForm.OpenFile(newVrfGuiContext, entry);
+                    }
                 }
             }
         }

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -228,6 +228,14 @@ namespace GUI.Types.Renderer
 
         private void SetRenderMode(string renderMode)
         {
+            if (ViewerControl.Camera is not null && renderMode == "Object Id")
+            {
+                ViewerControl.Camera.Picker.Debug = true;
+                return;
+            }
+
+            ViewerControl.Camera.Picker.Debug = false;
+
             foreach (var node in Scene.AllNodes)
             {
                 node.SetRenderMode(renderMode);
@@ -239,11 +247,6 @@ namespace GUI.Types.Renderer
                 {
                     node.SetRenderMode(renderMode);
                 }
-            }
-
-            if (ViewerControl.Camera is not null)
-            {
-                ViewerControl.Camera.Picker.Debug = renderMode == "Object Id";
             }
         }
     }

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -228,13 +228,16 @@ namespace GUI.Types.Renderer
 
         private void SetRenderMode(string renderMode)
         {
-            if (ViewerControl.Camera is not null && renderMode == "Object Id")
+            if (ViewerControl.Camera is not null)
             {
-                ViewerControl.Camera.Picker.Debug = true;
-                return;
-            }
+                if (renderMode == "Object Id")
+                {
+                    ViewerControl.Camera.Picker.Debug = true;
+                    return;
+                }
 
-            ViewerControl.Camera.Picker.Debug = false;
+                ViewerControl.Camera.Picker.Debug = false;
+            }
 
             foreach (var node in Scene.AllNodes)
             {

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -186,9 +186,14 @@ namespace GUI.Types.Renderer
             };
             button.Click += (s, e) =>
             {
+                if (ViewerControl.Camera.Picker is not null)
+                {
+                    ViewerControl.Camera.Picker.Dispose();
+                    ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext, OnPickerDoubleClick);
+                    ViewerControl.Camera.Picker.Resize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
+                }
+
                 SetRenderMode(renderModeComboBox?.SelectedItem as string);
-                ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext, OnPickerDoubleClick);
-                ViewerControl.Camera.Picker.Resize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
             };
             ViewerControl.AddControl(button);
 #endif
@@ -236,9 +241,9 @@ namespace GUI.Types.Renderer
                 }
             }
 
-            if (Scene.MainCamera.Picker is not null)
+            if (ViewerControl.Camera is not null)
             {
-                Scene.MainCamera.Picker.Debug = renderMode == "Object Id";
+                ViewerControl.Camera.Picker.Debug = renderMode == "Object Id";
             }
         }
     }

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -28,7 +28,6 @@ namespace GUI.Types.Renderer
         private bool showStaticOctree;
         private bool showDynamicOctree;
         private bool showToolsMaterials = true;
-        private bool renderToPicker;
         private bool pickerDebug;
         private Frustum lockedCullFrustum;
 
@@ -76,7 +75,6 @@ namespace GUI.Types.Renderer
                     SkyboxScene.ShowToolsMaterials = v;
                 }
             });
-            ViewerControl.AddCheckBox("Render To Picker", renderToPicker, (v) => renderToPicker = v);
             ViewerControl.AddCheckBox("Picker Debug", pickerDebug, (v) => pickerDebug = v);
             ViewerControl.AddCheckBox("Lock Cull Frustum", false, (v) =>
             {
@@ -91,7 +89,6 @@ namespace GUI.Types.Renderer
             });
 
             ViewerControl.GLLoad += OnLoad;
-            ViewerControl.SceneNodeDoubleClick += OnSceneNodeDoubleClick;
         }
 
         protected abstract void InitializeControl();
@@ -105,6 +102,9 @@ namespace GUI.Types.Renderer
             ViewerControl.Camera.SetViewportSize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
             ViewerControl.Camera.SetLocation(new Vector3(256));
             ViewerControl.Camera.LookAt(new Vector3(0));
+
+            ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext);
+            ViewerControl.Camera.Picker.OnPicked += OnSceneNodeDoubleClick;
 
             var timer = new Stopwatch();
             timer.Start();
@@ -124,8 +124,6 @@ namespace GUI.Types.Renderer
 
             staticOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.StaticOctree, Scene.GuiContext, false);
             dynamicOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.DynamicOctree, Scene.GuiContext, true);
-
-            ViewerControl.Camera.Picker = new PickingTexture(Scene.GuiContext);
 
             if (renderModeComboBox != null)
             {
@@ -166,8 +164,10 @@ namespace GUI.Types.Renderer
                 GL.Clear(ClearBufferMask.DepthBufferBit);
             }
 
-            e.Camera.RenderToPicker = renderToPicker;
-            e.Camera.PickerDebug = pickerDebug;
+            if (e.Camera.Picker is not null)
+            {
+                e.Camera.Picker.Debug = pickerDebug;
+            }
 
             Scene.RenderWithCamera(e.Camera, lockedCullFrustum);
 

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -210,11 +210,6 @@ namespace GUI.Types.Renderer
 
             var task = Program.MainForm.OpenFile(foundFile.Context, foundFile.PackageEntry);
 
-            if (!worldModel.Transform.IsIdentity)
-            {
-                return;
-            }
-
             task.ContinueWith(
                 t =>
                 {
@@ -223,7 +218,15 @@ namespace GUI.Types.Renderer
                         .Controls.OfType<GLViewerControl>().First();
                     if (glViewer is not null)
                     {
-                        glViewer.GLPostLoad = (viewerControl) => viewerControl.Camera.CopyFrom(Scene.MainCamera);
+                        glViewer.GLPostLoad = (viewerControl) =>
+                        {
+                            Matrix4x4.Invert(worldModel.Transform * Scene.MainCamera.CameraViewMatrix, out var transform);
+
+                            var yaw = (float)Math.Atan2(-transform.M32, -transform.M31);
+                            var pitch = (float)Math.Asin(-transform.M33);
+
+                            viewerControl.Camera.SetLocationPitchYaw(transform.Translation, pitch, yaw);
+                        };
                     }
                 },
                 CancellationToken.None,

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -195,14 +195,7 @@ namespace GUI.Types.Renderer
                 return;
             }
 
-            // 3D Sky
-            if (pixelInfo.ObjectId == 1)
-            {
-                return;
-            }
-
-            var worldModel = Scene.Find(pixelInfo.ObjectId) as ModelSceneNode;
-            if (worldModel is null)
+            if (Scene.Find(pixelInfo.ObjectId) is not ModelSceneNode worldModel)
             {
                 return;
             }

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -223,7 +223,10 @@ namespace GUI.Types.Renderer
                             Matrix4x4.Invert(worldModel.Transform * Scene.MainCamera.CameraViewMatrix, out var transform);
 
                             var yaw = (float)Math.Atan2(-transform.M32, -transform.M31);
-                            var pitch = (float)Math.Asin(-transform.M33);
+
+                            var scaleZ = Math.Sqrt(transform.M31 * transform.M31 + transform.M32 * transform.M32 + transform.M33 * transform.M33);
+                            var unscaledZ = transform.M33 / scaleZ;
+                            var pitch = (float)Math.Asin(-unscaledZ);
 
                             viewerControl.Camera.SetLocationPitchYaw(transform.Translation, pitch, yaw);
                         };

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -201,7 +201,7 @@ namespace GUI.Types.Renderer
 
             var foundNode = Scene.Find(pixelInfo.ObjectId);
 
-            if (pickingResponse.Clicks != 2)
+            if (pickingResponse.Intent == PickingIntent.Select)
             {
                 selectedNodeRenderer.SelectNode(foundNode);
                 return;

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -199,32 +199,26 @@ namespace GUI.Types.Renderer
                 return;
             }
 
-            var foundNode = Scene.Find(pixelInfo.ObjectId);
+            var sceneNode = Scene.Find(pixelInfo.ObjectId);
 
             if (pickingResponse.Intent == PickingIntent.Select)
             {
-                selectedNodeRenderer.SelectNode(foundNode);
+                selectedNodeRenderer.SelectNode(sceneNode);
                 return;
             }
 
-            if (foundNode is not ModelSceneNode worldModel)
-            {
-                return;
-            }
+            Console.WriteLine($"Selected {sceneNode.Name} (Id: {pixelInfo.ObjectId})");
 
-            var foundFile = GuiContext.FileLoader.FindFileWithContext(worldModel.GetModelFileName() + "_c");
-            Console.WriteLine($"Selected {worldModel.GetModelFileName()} (Id: {pixelInfo.ObjectId})");
+            var foundFile = GuiContext.FileLoader.FindFileWithContext(sceneNode.Name + "_c");
 
             if (foundFile.Context == null)
             {
                 return;
             }
 
-            Matrix4x4.Invert(worldModel.Transform * Scene.MainCamera.CameraViewMatrix, out var transform);
+            Matrix4x4.Invert(sceneNode.Transform * Scene.MainCamera.CameraViewMatrix, out var transform);
 
-            var task = Program.MainForm.OpenFile(foundFile.Context, foundFile.PackageEntry);
-
-            task.ContinueWith(
+            Program.MainForm.OpenFile(foundFile.Context, foundFile.PackageEntry).ContinueWith(
                 t =>
                 {
                     var glViewer = t.Result.Controls.OfType<TabControl>().FirstOrDefault()?
@@ -242,7 +236,11 @@ namespace GUI.Types.Renderer
 
                             viewerControl.Camera.SetLocationPitchYaw(transform.Translation, pitch, yaw);
 
-                            //if (foundNode is ModelSceneNode worldModel) // TODO: Enable this check when other node types are supported
+                            if (sceneNode is not ModelSceneNode worldModel)
+                            {
+                                return;
+                            }
+
                             if (glViewer.GLViewer is GLModelViewer glModelViewer)
                             {
                                 // Set same mesh groups

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -44,7 +44,7 @@ namespace GUI.Types.Renderer
         {
             AddRenderModeSelectionControl();
 
-            worldLayersComboBox = ViewerControl.AddMultiSelection("World Layers", (worldLayers) =>
+            worldLayersComboBox = ViewerControl.AddMultiSelection("World Layers", null, (worldLayers) =>
             {
                 SetEnabledLayers(new HashSet<string>(worldLayers));
             });
@@ -241,6 +241,51 @@ namespace GUI.Types.Renderer
                             var pitch = (float)Math.Asin(-unscaledZ);
 
                             viewerControl.Camera.SetLocationPitchYaw(transform.Translation, pitch, yaw);
+
+                            //if (foundNode is ModelSceneNode worldModel) // TODO: Enable this check when other node types are supported
+                            if (glViewer.GLViewer is GLModelViewer glModelViewer)
+                            {
+                                // Set same mesh groups
+                                if (glModelViewer.meshGroupListBox != null)
+                                {
+                                    foreach (int checkedItemIndex in glModelViewer.meshGroupListBox.CheckedIndices)
+                                    {
+                                        glModelViewer.meshGroupListBox.SetItemChecked(checkedItemIndex, false);
+                                    }
+
+                                    foreach (var group in worldModel.GetActiveMeshGroups())
+                                    {
+                                        var item = glModelViewer.meshGroupListBox.FindStringExact(group);
+
+                                        if (item != ListBox.NoMatches)
+                                        {
+                                            glModelViewer.meshGroupListBox.SetItemChecked(item, true);
+                                        }
+                                    }
+                                }
+
+                                // Set same material group
+                                if (glModelViewer.materialGroupListBox != null && worldModel.ActiveSkin != null)
+                                {
+                                    var skinId = glModelViewer.materialGroupListBox.FindStringExact(worldModel.ActiveSkin);
+
+                                    if (skinId != -1)
+                                    {
+                                        glModelViewer.materialGroupListBox.SelectedIndex = skinId;
+                                    }
+                                }
+
+                                // Set animation
+                                if (glModelViewer.animationComboBox != null && worldModel.AnimationController.ActiveAnimation != null)
+                                {
+                                    var animationId = glModelViewer.animationComboBox.FindStringExact(worldModel.AnimationController.ActiveAnimation.Name);
+
+                                    if (animationId != -1)
+                                    {
+                                        glModelViewer.animationComboBox.SelectedIndex = animationId;
+                                    }
+                                }
+                            }
                         };
                     }
                 },

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -187,29 +187,31 @@ namespace GUI.Types.Renderer
 
         protected override void OnPickerDoubleClick(object sender, PickingTexture.PixelInfo pixelInfo)
         {
+            // Void
             if (pixelInfo.ObjectId == 0)
             {
                 return;
             }
 
-            foreach (var node in Scene.AllNodes)
+            // 3D Sky
+            if (pixelInfo.ObjectId == 1)
             {
-                if (node.Id != pixelInfo.ObjectId)
-                {
-                    continue;
-                }
+                return;
+            }
 
-                if (node is ModelSceneNode modelNode)
-                {
-                    // TODO: Use FileLoader
-                    var entry = GuiContext.CurrentPackage?.FindEntry(modelNode.GetModelFileName() + "_c");
-                    Console.WriteLine($"Selected {modelNode.GetModelFileName()} (Id: {pixelInfo.ObjectId})");
-                    if (entry != null)
-                    {
-                        var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext.ParentGuiContext);
-                        Program.MainForm.OpenFile(newVrfGuiContext, entry);
-                    }
-                }
+            var worldModel = Scene.Find(pixelInfo.ObjectId) as ModelSceneNode;
+            if (worldModel is null)
+            {
+                return;
+            }
+
+            // TODO: Use FileLoader
+            var entry = GuiContext.CurrentPackage?.FindEntry(worldModel.GetModelFileName() + "_c");
+            Console.WriteLine($"Selected {worldModel.GetModelFileName()} (Id: {pixelInfo.ObjectId})");
+            if (entry != null)
+            {
+                var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext.ParentGuiContext);
+                Program.MainForm.OpenFile(newVrfGuiContext, entry);
             }
         }
 

--- a/GUI/Types/Renderer/GLWorldViewer.cs
+++ b/GUI/Types/Renderer/GLWorldViewer.cs
@@ -185,6 +185,34 @@ namespace GUI.Types.Renderer
             ViewerControl.Invoke((Action)savedCameraPositionsControl.RefreshSavedPositions);
         }
 
+        protected override void OnPickerDoubleClick(object sender, PickingTexture.PixelInfo pixelInfo)
+        {
+            if (pixelInfo.ObjectId == 0)
+            {
+                return;
+            }
+
+            foreach (var node in Scene.AllNodes)
+            {
+                if (node.Id != pixelInfo.ObjectId)
+                {
+                    continue;
+                }
+
+                if (node is ModelSceneNode modelNode)
+                {
+                    // TODO: Use FileLoader
+                    var entry = GuiContext.CurrentPackage?.FindEntry(modelNode.GetModelFileName() + "_c");
+                    Console.WriteLine($"Selected {modelNode.GetModelFileName()} (Id: {pixelInfo.ObjectId})");
+                    if (entry != null)
+                    {
+                        var newVrfGuiContext = new VrfGuiContext(entry.GetFileName(), GuiContext.ParentGuiContext);
+                        Program.MainForm.OpenFile(newVrfGuiContext, entry);
+                    }
+                }
+            }
+        }
+
         private void SetAvailableLayers(IEnumerable<string> worldLayers)
         {
             worldLayersComboBox.Items.Clear();

--- a/GUI/Types/Renderer/IGLViewer.cs
+++ b/GUI/Types/Renderer/IGLViewer.cs
@@ -1,0 +1,6 @@
+namespace GUI.Types.Renderer
+{
+    internal interface IGLViewer
+    {
+    }
+}

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -15,8 +15,8 @@ namespace GUI.Types.Renderer
             public RenderableMesh Mesh;
             public DrawCall Call;
             public float DistanceFromCamera;
-            public int NodeId;
-            public int MeshId;
+            public uint NodeId;
+            public uint MeshId;
         }
 
         public static void Render(List<Request> requests, Scene.RenderContext context)
@@ -94,12 +94,12 @@ namespace GUI.Types.Renderer
 
                         if (uniformLocationScId != -1)
                         {
-                            GL.Uniform1(uniformLocationScId, (uint)request.NodeId);
+                            GL.Uniform1(uniformLocationScId, request.NodeId);
                         }
 
                         if (uniformLocationMeshId != -1)
                         {
-                            GL.Uniform1(uniformLocationMeshId, (uint)request.MeshId);
+                            GL.Uniform1(uniformLocationMeshId, request.MeshId);
                         }
 
                         if (uniformLocationTime != 1)

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -65,6 +65,7 @@ namespace GUI.Types.Renderer
                 var uniformLocationTint = shader.GetUniformLocation("m_vTintColorSceneObject");
                 var uniformLocationTintDrawCall = shader.GetUniformLocation("m_vTintColorDrawCall");
                 var uniformLocationTime = shader.GetUniformLocation("g_flTime");
+                var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
 
                 GL.UseProgram(shader.Program);
 
@@ -88,9 +89,7 @@ namespace GUI.Types.Renderer
                         var transformTk = request.Transform.ToOpenTK();
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
 
-                        var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
-
-                        if (uniformLocationTime != 1)
+                        if (uniformLocationScId != 1)
                         {
                             GL.Uniform1(uniformLocationScId, (uint)request.NodeId);
                         }

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -71,6 +71,7 @@ namespace GUI.Types.Renderer
                 GL.Uniform3(shader.GetUniformLocation("vLightPosition"), lightPosition);
                 GL.Uniform3(shader.GetUniformLocation("vEyePosition"), cameraPosition);
                 GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref viewProjectionMatrix);
+
                 foreach (var materialGroup in shaderGroup.GroupBy(a => a.Call.Material))
                 {
                     var material = materialGroup.Key;

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -16,6 +16,7 @@ namespace GUI.Types.Renderer
             public DrawCall Call;
             public float DistanceFromCamera;
             public int NodeId;
+            public int MeshId;
         }
 
         public static void Render(List<Request> requests, Scene.RenderContext context)
@@ -67,6 +68,7 @@ namespace GUI.Types.Renderer
                 var uniformLocationTintDrawCall = shader.GetUniformLocation("m_vTintColorDrawCall");
                 var uniformLocationTime = shader.GetUniformLocation("g_flTime");
                 var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
+                var uniformLocationMeshId = shader.GetUniformLocation("meshId");
 
                 GL.UseProgram(shader.Program);
 
@@ -90,9 +92,14 @@ namespace GUI.Types.Renderer
                         var transformTk = request.Transform.ToOpenTK();
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
 
-                        if (uniformLocationScId != 1)
+                        if (uniformLocationScId != -1)
                         {
                             GL.Uniform1(uniformLocationScId, (uint)request.NodeId);
+                        }
+
+                        if (uniformLocationMeshId != -1)
+                        {
+                            GL.Uniform1(uniformLocationMeshId, (uint)request.MeshId);
                         }
 
                         if (uniformLocationTime != 1)

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -50,11 +50,9 @@ namespace GUI.Types.Renderer
             var cameraPosition = context.Camera.Location.ToOpenTK();
             var lightPosition = cameraPosition; // (context.LightPosition ?? context.Camera.Location).ToOpenTK();
 
-            var groupedDrawCalls = context.ReplacementShader switch
-            {
-                null => drawCalls.GroupBy(a => a.Call.Shader),
-                _ => drawCalls.GroupBy(a => context.ReplacementShader)
-            };
+            var groupedDrawCalls = context.ReplacementShader == null
+                ? drawCalls.GroupBy(a => a.Call.Shader)
+                : drawCalls.GroupBy(a => context.ReplacementShader);
 
             foreach (var shaderGroup in groupedDrawCalls)
             {

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -65,7 +65,7 @@ namespace GUI.Types.Renderer
                 var uniformLocationTint = shader.GetUniformLocation("m_vTintColorSceneObject");
                 var uniformLocationTintDrawCall = shader.GetUniformLocation("m_vTintColorDrawCall");
                 var uniformLocationTime = shader.GetUniformLocation("g_flTime");
-                var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
+                var uniformLocationObjectId = shader.GetUniformLocation("sceneObjectId");
                 var uniformLocationMeshId = shader.GetUniformLocation("meshId");
 
                 GL.UseProgram(shader.Program);
@@ -90,9 +90,9 @@ namespace GUI.Types.Renderer
                         var transformTk = request.Transform.ToOpenTK();
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
 
-                        if (uniformLocationScId != -1)
+                        if (uniformLocationObjectId != -1)
                         {
-                            GL.Uniform1(uniformLocationScId, request.NodeId);
+                            GL.Uniform1(uniformLocationObjectId, request.NodeId);
                         }
 
                         if (uniformLocationMeshId != -1)

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -89,7 +89,11 @@ namespace GUI.Types.Renderer
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
 
                         var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
-                        GL.Uniform1(uniformLocationScId, (uint)(request.NodeId + 1));
+
+                        if (uniformLocationTime != 1)
+                        {
+                            GL.Uniform1(uniformLocationScId, (uint)request.NodeId);
+                        }
 
                         if (uniformLocationTime != 1)
                         {

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -49,14 +49,15 @@ namespace GUI.Types.Renderer
             var cameraPosition = context.Camera.Location.ToOpenTK();
             var lightPosition = cameraPosition; // (context.LightPosition ?? context.Camera.Location).ToOpenTK();
 
-            foreach (var shaderGroup in drawCalls.GroupBy(a => a.Call.Shader))
+            var groupedDrawCalls = context.ReplacementShader switch
+            {
+                null => drawCalls.GroupBy(a => a.Call.Shader),
+                _ => drawCalls.GroupBy(a => context.ReplacementShader)
+            };
+
+            foreach (var shaderGroup in groupedDrawCalls)
             {
                 var shader = shaderGroup.Key;
-
-                if (context.ReplacementShader != null)
-                {
-                    shader = context.ReplacementShader;
-                }
 
                 var uniformLocationAnimated = shader.GetUniformLocation("bAnimated");
                 var uniformLocationAnimationTexture = shader.GetUniformLocation("animationTexture");

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -15,6 +15,7 @@ namespace GUI.Types.Renderer
             public RenderableMesh Mesh;
             public DrawCall Call;
             public float DistanceFromCamera;
+            public int NodeId;
         }
 
         public static void Render(List<Request> requests, Scene.RenderContext context)
@@ -70,7 +71,6 @@ namespace GUI.Types.Renderer
                 GL.Uniform3(shader.GetUniformLocation("vLightPosition"), lightPosition);
                 GL.Uniform3(shader.GetUniformLocation("vEyePosition"), cameraPosition);
                 GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref viewProjectionMatrix);
-
                 foreach (var materialGroup in shaderGroup.GroupBy(a => a.Call.Material))
                 {
                     var material = materialGroup.Key;
@@ -87,7 +87,8 @@ namespace GUI.Types.Renderer
                         var transformTk = request.Transform.ToOpenTK();
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
 
-                        GL.Uniform1(shader.GetUniformLocation("sceneObjectId"), request.DistanceFromCamera);
+                        var uniformLocationScId = shader.GetUniformLocation("sceneObjectId");
+                        GL.Uniform1(uniformLocationScId, (uint)(request.NodeId + 1));
 
                         if (uniformLocationTime != 1)
                         {

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -52,6 +52,11 @@ namespace GUI.Types.Renderer
             {
                 var shader = shaderGroup.Key;
 
+                if (context.ReplacementShader != null)
+                {
+                    shader = context.ReplacementShader;
+                }
+
                 var uniformLocationAnimated = shader.GetUniformLocation("bAnimated");
                 var uniformLocationAnimationTexture = shader.GetUniformLocation("animationTexture");
                 var uniformLocationNumBones = shader.GetUniformLocation("fNumBones");
@@ -81,6 +86,8 @@ namespace GUI.Types.Renderer
                     {
                         var transformTk = request.Transform.ToOpenTK();
                         GL.UniformMatrix4(uniformLocationTransform, false, ref transformTk);
+
+                        GL.Uniform1(shader.GetUniformLocation("sceneObjectId"), request.DistanceFromCamera);
 
                         if (uniformLocationTime != 1)
                         {

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -233,6 +233,9 @@ namespace GUI.Types.Renderer
             }
         }
 
+        public string GetModelFileName()
+            => Model.Data.GetStringProperty("m_name");
+
         public IEnumerable<string> GetMeshGroups()
             => Model.GetMeshGroups();
 

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -176,8 +176,7 @@ namespace GUI.Types.Renderer
             }
 
             // Load referred meshes from file (only load meshes with LoD 1)
-            var referredMeshesAndLoDs = Model.GetReferenceMeshNamesAndLoD();
-            foreach (var refMesh in referredMeshesAndLoDs.Where(m => (m.LoDMask & 1) != 0))
+            foreach (var refMesh in GetLod1RefMeshes())
             {
                 var newResource = Scene.GuiContext.LoadFileByAnyMeansNecessary(refMesh.MeshName + "_c");
                 if (newResource == null)
@@ -238,6 +237,9 @@ namespace GUI.Types.Renderer
 
         public string GetModelFileName()
             => Model.Data.GetStringProperty("m_name");
+
+        public IEnumerable<(int MeshIndex, string MeshName, long LoDMask)> GetLod1RefMeshes()
+            => Model.GetReferenceMeshNamesAndLoD().Where(m => (m.LoDMask & 1) != 0);
 
         public IEnumerable<string> GetMeshGroups()
             => Model.GetMeshGroups();

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -34,6 +34,7 @@ namespace GUI.Types.Renderer
 
         public readonly AnimationController AnimationController;
         public IEnumerable<RenderableMesh> RenderableMeshes => activeMeshRenderers;
+        public string ActiveSkin { get; private set; }
 
         private readonly List<RenderableMesh> meshRenderers = new();
         private readonly List<Animation> animations = new();
@@ -118,6 +119,8 @@ namespace GUI.Types.Renderer
 
         public void SetSkin(string skin)
         {
+            ActiveSkin = skin;
+
             var materialGroups = Model.Data.GetArray<IKeyValueCollection>("m_materialGroups");
             string[] defaultMaterials = null;
 

--- a/GUI/Types/Renderer/ModelSceneNode.cs
+++ b/GUI/Types/Renderer/ModelSceneNode.cs
@@ -235,9 +235,6 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public string GetModelFileName()
-            => Model.Data.GetStringProperty("m_name");
-
         public IEnumerable<(int MeshIndex, string MeshName, long LoDMask)> GetLod1RefMeshes()
             => Model.GetReferenceMeshNamesAndLoD().Where(m => (m.LoDMask & 1) != 0);
 

--- a/GUI/Types/Renderer/OctreeDebugRenderer.cs
+++ b/GUI/Types/Renderer/OctreeDebugRenderer.cs
@@ -61,7 +61,7 @@ namespace GUI.Types.Renderer
             vertices.Add(a);
         }
 
-        private static void AddBox(List<float> vertices, AABB box, float r, float g, float b, float a)
+        public static void AddBox(List<float> vertices, AABB box, float r, float g, float b, float a)
         {
             // Adding a box will add many vertices, so ensure the required capacity for it up front
             vertices.EnsureCapacity(vertices.Count + 14 * 12);

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -12,20 +12,26 @@ internal class PickingTexture : IDisposable
         public bool ActiveNextFrame;
         public int CursorPositionX;
         public int CursorPositionY;
-        public int Clicks;
+        public PickingIntent Intent;
 
-        public void NextFrame(int x, int y, int clicks)
+        public void NextFrame(int x, int y, PickingIntent intent)
         {
             ActiveNextFrame = true;
             CursorPositionX = x;
             CursorPositionY = y;
-            Clicks = clicks;
+            Intent = intent;
         }
+    }
+
+    internal enum PickingIntent
+    {
+        Select,
+        Open
     }
 
     internal struct PickingResponse
     {
-        public int Clicks;
+        public PickingIntent Intent;
         public PixelInfo PixelInfo;
     }
 
@@ -105,7 +111,7 @@ internal class PickingTexture : IDisposable
             var pixelInfo = ReadPixelInfo(Request.CursorPositionX, Request.CursorPositionY);
             OnPicked?.Invoke(this, new PickingResponse
             {
-                Clicks = Request.Clicks,
+                Intent = Request.Intent,
                 PixelInfo = pixelInfo,
             });
         }

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -12,13 +12,21 @@ internal class PickingTexture : IDisposable
         public bool ActiveNextFrame;
         public int CursorPositionX;
         public int CursorPositionY;
+        public int Clicks;
 
-        public void NextFrame(int x, int y)
+        public void NextFrame(int x, int y, int clicks)
         {
             ActiveNextFrame = true;
             CursorPositionX = x;
             CursorPositionY = y;
+            Clicks = clicks;
         }
+    }
+
+    internal struct PickingResponse
+    {
+        public int Clicks;
+        public PixelInfo PixelInfo;
     }
 
     internal struct PixelInfo
@@ -30,7 +38,7 @@ internal class PickingTexture : IDisposable
 #pragma warning restore CS0649  // Field is never assigned to, and will always have its default value
     }
 
-    public event EventHandler<PixelInfo> OnPicked;
+    public event EventHandler<PickingResponse> OnPicked;
     public readonly PickingRequest Request = new();
 
     public readonly Shader shader;
@@ -45,7 +53,7 @@ internal class PickingTexture : IDisposable
     private int colorHandle;
     private int depthHandle;
 
-    public PickingTexture(VrfGuiContext vrfGuiContext, EventHandler<PixelInfo> onPicked)
+    public PickingTexture(VrfGuiContext vrfGuiContext, EventHandler<PickingResponse> onPicked)
     {
         shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
         debugShader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>() { { "F_DEBUG_PICKER", true } });
@@ -95,7 +103,11 @@ internal class PickingTexture : IDisposable
         {
             Request.ActiveNextFrame = false;
             var pixelInfo = ReadPixelInfo(Request.CursorPositionX, Request.CursorPositionY);
-            OnPicked?.Invoke(this, pixelInfo);
+            OnPicked?.Invoke(this, new PickingResponse
+            {
+                Clicks = Request.Clicks,
+                PixelInfo = pixelInfo,
+            });
         }
     }
 

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using OpenTK.Graphics.OpenGL4;
-using System.Numerics;
 using GUI.Utils;
 
 namespace GUI.Types.Renderer;
@@ -46,10 +45,11 @@ internal class PickingTexture : IDisposable
 #pragma warning restore CS0649  // Field is never assigned to, and will always have its default value
     }
 
-    public PickingTexture(VrfGuiContext vrfGuiContext)
+    public PickingTexture(VrfGuiContext vrfGuiContext, EventHandler<uint> onPicked)
     {
         shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
         debugShader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>() { { "F_DEBUG_PICKER", true } });
+        OnPicked += onPicked;
         Setup();
     }
 

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -73,7 +73,7 @@ internal class PickingTexture
         int pixel = default;
 
         GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
-        GL.ReadPixels(width, height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
+        GL.ReadPixels(width, this.height - height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
         GL.ReadBuffer(ReadBufferMode.None);
 
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
@@ -85,13 +85,11 @@ internal class PickingTexture
         this.width = width;
         this.height = height;
 
-        //GL.BindTexture(TextureTarget.Texture2D, colorHandle);
-        //GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
-        //
-        //GL.BindTexture(TextureTarget.Texture2D, depthHandle);
-        //GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
+        GL.BindTexture(TextureTarget.Texture2D, colorHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
 
-        Setup();
+        GL.BindTexture(TextureTarget.Texture2D, depthHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
     }
 
     public void Update(float deltaTime)

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -6,35 +6,28 @@ using GUI.Utils;
 
 namespace GUI.Types.Renderer;
 
-internal class PickingRequest
-{
-    public bool ActiveNextFrame;
-    public int CursorPositionX;
-    public int CursorPositionY;
-
-    public void NextFrame(int x, int y)
-    {
-        ActiveNextFrame = true;
-        CursorPositionX = x;
-        CursorPositionY = y;
-    }
-}
-
-internal struct PixelInfo
-{
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-    public uint Id;
-    public uint Unused;
-    public uint Unused2;
-#pragma warning restore CS0649  // Field is never assigned to, and will always have its default value
-}
-
 internal class PickingTexture : IDisposable
 {
+    internal class PickingRequest
+    {
+        public bool ActiveNextFrame;
+        public int CursorPositionX;
+        public int CursorPositionY;
+
+        public void NextFrame(int x, int y)
+        {
+            ActiveNextFrame = true;
+            CursorPositionX = x;
+            CursorPositionY = y;
+        }
+    }
+
     public event EventHandler<uint> OnPicked;
     public readonly PickingRequest Request = new();
+
     public readonly Shader shader;
     public readonly Shader debugShader;
+
     public bool IsActive => Request.ActiveNextFrame;
     public bool Debug { get; set; }
 
@@ -43,6 +36,15 @@ internal class PickingTexture : IDisposable
     private int fboHandle;
     private int colorHandle;
     private int depthHandle;
+
+    internal struct PixelInfo
+    {
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+        public uint Id;
+        public uint Unused;
+        public uint Unused2;
+#pragma warning restore CS0649  // Field is never assigned to, and will always have its default value
+    }
 
     public PickingTexture(VrfGuiContext vrfGuiContext)
     {
@@ -53,11 +55,6 @@ internal class PickingTexture : IDisposable
 
     public void Setup()
     {
-        if (width == 0 || height == 0)
-        {
-            return;
-        }
-
         fboHandle = GL.GenFramebuffer();
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
 

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -20,30 +20,17 @@ internal class PickingTexture : IDisposable
     private int width = 4;
     private int height = 4;
 
-    public Shader shader;
-    private VrfGuiContext ctx;
+    public readonly Shader shader;
+    public readonly Shader debugShader;
     private int fboHandle;
     private int colorHandle;
     private int depthHandle;
 
     public PickingTexture(VrfGuiContext vrfGuiContext)
     {
-        ctx = vrfGuiContext;
-        SetDebug(false);
+        shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
+        debugShader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>() { { "F_DEBUG_PICKER", true } });
         Setup();
-    }
-
-    public void SetDebug(bool debug)
-    {
-        if (debug)
-        {
-            shader = ctx.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>(){
-                { "F_DEBUG_PICKER", true }
-            });
-            return;
-        }
-
-        shader = ctx.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
     }
 
     public void Setup()
@@ -126,7 +113,6 @@ internal class PickingTexture : IDisposable
 
     public void Dispose()
     {
-        ctx.Dispose();
         GL.DeleteTexture(colorHandle);
         GL.DeleteTexture(depthHandle);
         GL.DeleteFramebuffer(fboHandle);

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -11,15 +11,30 @@ internal class PickingTexture
     private int width = 4;
     private int height = 4;
 
-    public readonly Shader shader;
+    public Shader shader;
+    private VrfGuiContext ctx;
     private int fboHandle;
     private int colorHandle;
     private int depthHandle;
 
     public PickingTexture(VrfGuiContext vrfGuiContext)
     {
-        shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
+        ctx = vrfGuiContext;
+        SetDebug(false);
         Setup();
+    }
+
+    public void SetDebug(bool debug)
+    {
+        if (debug)
+        {
+            shader = ctx.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>(){
+                { "F_DEBUG_PICKER", true }
+            });
+            return;
+        }
+
+        shader = ctx.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
     }
 
     public void Setup()

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -6,16 +6,16 @@ using GUI.Utils;
 
 namespace GUI.Types.Renderer;
 
-#pragma warning disable CS0649
 internal struct PixelInfo
 {
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
     public uint Id;
     public uint Unused;
     public uint Unused2;
+#pragma warning restore CS0649  // Field is never assigned to, and will always have its default value
 }
-#pragma warning restore CS0649
 
-internal class PickingTexture
+internal class PickingTexture : IDisposable
 {
     private int width = 4;
     private int height = 4;
@@ -109,6 +109,9 @@ internal class PickingTexture
 
     public uint ReadIdFromPixel(int width, int height)
     {
+        GL.Flush();
+        GL.Finish();
+
         GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, fboHandle);
         GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
 
@@ -119,5 +122,13 @@ internal class PickingTexture
         GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, 0);
 
         return pixelInfo.Id;
+    }
+
+    public void Dispose()
+    {
+        ctx.Dispose();
+        GL.DeleteTexture(colorHandle);
+        GL.DeleteTexture(depthHandle);
+        GL.DeleteFramebuffer(fboHandle);
     }
 }

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -6,10 +6,10 @@ using GUI.Utils;
 
 namespace GUI.Types.Renderer;
 
-internal class PickingTexture// : IRenderer
+internal class PickingTexture
 {
-    private int width;
-    private int height;
+    private int width = 4;
+    private int height = 4;
 
     public readonly Shader shader;
     private int fboHandle;
@@ -18,17 +18,19 @@ internal class PickingTexture// : IRenderer
 
     public AABB BoundingBox => throw new NotImplementedException();
 
-    public PickingTexture(int width, int height, VrfGuiContext vrfGuiContext)
+    public PickingTexture(VrfGuiContext vrfGuiContext)
     {
-        this.width = width;
-        this.height = height;
-
         shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
         Setup();
     }
 
     public void Setup()
     {
+        if (width == 0 || height == 0)
+        {
+            return;
+        }
+
         fboHandle = GL.GenFramebuffer();
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
 
@@ -71,23 +73,25 @@ internal class PickingTexture// : IRenderer
         int pixel = default;
 
         GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
-        GL.ReadPixels(width, height - this.height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
+        GL.ReadPixels(width, height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
         GL.ReadBuffer(ReadBufferMode.None);
 
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
         return pixel;
     }
 
-    public void WindowResized(int width, int height)
+    public void Resize(int width, int height)
     {
         this.width = width;
         this.height = height;
 
-        GL.BindTexture(TextureTarget.Texture2D, colorHandle);
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
+        //GL.BindTexture(TextureTarget.Texture2D, colorHandle);
+        //GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
+        //
+        //GL.BindTexture(TextureTarget.Texture2D, depthHandle);
+        //GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
 
-        GL.BindTexture(TextureTarget.Texture2D, depthHandle);
-        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
+        Setup();
     }
 
     public void Update(float deltaTime)

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using OpenTK.Graphics.OpenGL4;
+using System.Numerics;
+using GUI.Utils;
+
+namespace GUI.Types.Renderer;
+
+internal class PickingTexture// : IRenderer
+{
+    private int width;
+    private int height;
+
+    public readonly Shader shader;
+    private int fboHandle;
+    private int colorHandle;
+    private int depthHandle;
+
+    public AABB BoundingBox => throw new NotImplementedException();
+
+    public PickingTexture(int width, int height, VrfGuiContext vrfGuiContext)
+    {
+        this.width = width;
+        this.height = height;
+
+        shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
+        Setup();
+    }
+
+    public void Setup()
+    {
+        fboHandle = GL.GenFramebuffer();
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+
+        colorHandle = GL.GenTexture();
+        GL.BindTexture(TextureTarget.Texture2D, colorHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)TextureMinFilter.Nearest);
+        GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)TextureMinFilter.Nearest);
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, colorHandle, 0);
+
+        depthHandle = GL.GenTexture();
+        GL.BindTexture(TextureTarget.Texture2D, depthHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
+        GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, TextureTarget.Texture2D, depthHandle, 0);
+
+        var status = GL.CheckFramebufferStatus(FramebufferTarget.Framebuffer);
+        if (status != FramebufferErrorCode.FramebufferComplete)
+        {
+            throw new InvalidOperationException($"Framebuffer failed to bind with error: {status}");
+        }
+
+        GL.BindTexture(TextureTarget.Texture2D, 0);
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+    }
+
+    public void Render()
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+        GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+    }
+
+    public static void Finish()
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+    }
+
+    public int ReadPixel(int width, int height)
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+        int pixel = default;
+
+        GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
+        GL.ReadPixels(width, height - this.height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
+        GL.ReadBuffer(ReadBufferMode.None);
+
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        return pixel;
+    }
+
+    public void WindowResized(int width, int height)
+    {
+        this.width = width;
+        this.height = height;
+
+        GL.BindTexture(TextureTarget.Texture2D, colorHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.Rgba32ui, width, height, 0, PixelFormat.RgbaInteger, PixelType.UnsignedInt, IntPtr.Zero);
+
+        GL.BindTexture(TextureTarget.Texture2D, depthHandle);
+        GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
+    }
+
+    public void Update(float deltaTime)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -130,6 +130,7 @@ internal class PickingTexture : IDisposable
 
     public void Dispose()
     {
+        OnPicked = null;
         GL.DeleteTexture(colorHandle);
         GL.DeleteTexture(depthHandle);
         GL.DeleteFramebuffer(fboHandle);

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -6,6 +6,15 @@ using GUI.Utils;
 
 namespace GUI.Types.Renderer;
 
+#pragma warning disable CS0649
+internal struct PixelInfo
+{
+    public uint Id;
+    public uint Unused;
+    public uint Unused2;
+}
+#pragma warning restore CS0649
+
 internal class PickingTexture
 {
     private int width = 4;
@@ -71,13 +80,13 @@ internal class PickingTexture
 
     public void Render()
     {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+        GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, fboHandle);
         GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
     }
 
     public static void Finish()
     {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        GL.BindFramebuffer(FramebufferTarget.DrawFramebuffer, 0);
     }
 
     public void Resize(int width, int height)
@@ -100,15 +109,15 @@ internal class PickingTexture
 
     public uint ReadIdFromPixel(int width, int height)
     {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+        GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, fboHandle);
         GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
 
-        uint pixel = 0;
-        GL.ReadPixels(width, this.height - height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
+        var pixelInfo = new PixelInfo();
+        GL.ReadPixels(width, this.height - height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixelInfo);
 
         GL.ReadBuffer(ReadBufferMode.None);
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+        GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, 0);
 
-        return pixel;
+        return pixelInfo.Id;
     }
 }

--- a/GUI/Types/Renderer/PickingTexture.cs
+++ b/GUI/Types/Renderer/PickingTexture.cs
@@ -16,8 +16,6 @@ internal class PickingTexture
     private int colorHandle;
     private int depthHandle;
 
-    public AABB BoundingBox => throw new NotImplementedException();
-
     public PickingTexture(VrfGuiContext vrfGuiContext)
     {
         shader = vrfGuiContext.ShaderLoader.LoadShader("vrf.picking", new Dictionary<string, bool>());
@@ -67,19 +65,6 @@ internal class PickingTexture
         GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
     }
 
-    public int ReadPixel(int width, int height)
-    {
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
-        int pixel = default;
-
-        GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
-        GL.ReadPixels(width, this.height - height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
-        GL.ReadBuffer(ReadBufferMode.None);
-
-        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
-        return pixel;
-    }
-
     public void Resize(int width, int height)
     {
         this.width = width;
@@ -92,8 +77,23 @@ internal class PickingTexture
         GL.TexImage2D(TextureTarget.Texture2D, 0, PixelInternalFormat.DepthComponent, width, height, 0, PixelFormat.DepthComponent, PixelType.Float, IntPtr.Zero);
     }
 
-    public void Update(float deltaTime)
+    public void Pick(int x, int y, EventHandler<uint> callback)
     {
-        throw new NotImplementedException();
+        var id = ReadIdFromPixel(x, y);
+        callback.Invoke(this, id);
+    }
+
+    public uint ReadIdFromPixel(int width, int height)
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fboHandle);
+        GL.ReadBuffer(ReadBufferMode.ColorAttachment0);
+
+        uint pixel = 0;
+        GL.ReadPixels(width, this.height - height, 1, 1, PixelFormat.RgbaInteger, PixelType.UnsignedInt, ref pixel);
+
+        GL.ReadBuffer(ReadBufferMode.None);
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, 0);
+
+        return pixel;
     }
 }

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -145,8 +145,8 @@ namespace GUI.Types.Renderer
 
             if (camera.RenderToPicker)
             {
-                renderContext.ReplacementShader = camera.Picking.shader;
-                camera.Picking.Render();
+                renderContext.ReplacementShader = camera.Picker.shader;
+                camera.Picker.Render();
             }
 
             MeshBatchRenderer.Render(opaqueDrawCalls, renderContext);

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -36,7 +36,6 @@ namespace GUI.Types.Renderer
         public bool ShowToolsMaterials { get; set; } = true;
 
         public IEnumerable<SceneNode> AllNodes => staticNodes.Concat(dynamicNodes);
-        public int NodeCount => staticNodes.Count + dynamicNodes.Count;
 
         private readonly List<SceneNode> staticNodes = new();
         private readonly List<SceneNode> dynamicNodes = new();
@@ -50,18 +49,33 @@ namespace GUI.Types.Renderer
 
         public void Add(SceneNode node, bool dynamic)
         {
-
-            node.Id = NodeCount + 1;
             if (dynamic)
             {
                 dynamicNodes.Add(node);
                 DynamicOctree.Insert(node, node.BoundingBox);
+                node.Id = (uint)dynamicNodes.Count * 2 - 1;
             }
             else
             {
                 staticNodes.Add(node);
                 StaticOctree.Insert(node, node.BoundingBox);
+                node.Id = (uint)staticNodes.Count * 2;
             }
+        }
+
+        public SceneNode Find(uint id)
+        {
+            if (id == 0)
+            {
+                return null;
+            }
+
+            if (id % 2 == 1)
+            {
+                return dynamicNodes[((int)id + 1) / 2 - 1];
+            }
+
+            return staticNodes[(int)id / 2 - 1];
         }
 
         public void Update(float timestep)
@@ -104,7 +118,7 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
-                                MeshId = mesh.MeshIndex,
+                                MeshId = (uint)mesh.MeshIndex,
                             });
                         }
 
@@ -117,7 +131,7 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
-                                MeshId = mesh.MeshIndex,
+                                MeshId = (uint)mesh.MeshIndex,
                             });
                         }
                     }

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -149,11 +149,10 @@ namespace GUI.Types.Renderer
                 if (!camera.PickerDebug)
                 {
                     camera.Picker.Render();
-                    camera.Picker.SetDebug(false);
                 }
                 else
                 {
-                    camera.Picker.SetDebug(true);
+                    renderContext.ReplacementShader = camera.Picker.debugShader;
                 }
             }
 

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -166,13 +166,7 @@ namespace GUI.Types.Renderer
 
             if (camera.RenderToPicker)
             {
-                if (camera.Picking.ReadPixel(256, 256) != 0)
-                {
-                    Console.WriteLine("Picking hit!");
-                    Console.WriteLine($"{camera.Picking.ReadPixel(256, 256)}");
-                }
                 PickingTexture.Finish();
-                // Render normally
                 camera.RenderToPicker = false;
                 RenderWithCamera(camera, cullFrustum);
             }

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -104,6 +104,7 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
+                                MeshId = mesh.MeshIndex,
                             });
                         }
 
@@ -116,6 +117,7 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
+                                MeshId = mesh.MeshIndex,
                             });
                         }
                     }

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -143,14 +143,14 @@ namespace GUI.Types.Renderer
                 RenderToolsMaterials = ShowToolsMaterials,
             };
 
-            if (camera.RenderToPicker)
+            if (camera.Picker is not null)
             {
-                renderContext.ReplacementShader = camera.Picker.shader;
-                if (!camera.PickerDebug)
+                if (camera.Picker.IsActive)
                 {
                     camera.Picker.Render();
+                    renderContext.ReplacementShader = camera.Picker.shader;
                 }
-                else
+                else if (camera.Picker.Debug)
                 {
                     renderContext.ReplacementShader = camera.Picker.debugShader;
                 }
@@ -171,14 +171,10 @@ namespace GUI.Types.Renderer
                 node.Render(renderContext);
             }
 
-            if (camera.RenderToPicker)
+            if (camera.Picker is not null && camera.Picker.IsActive)
             {
-                PickingTexture.Finish();
-                camera.RenderToPicker = false;
-                if (!camera.PickerDebug)
-                {
-                    RenderWithCamera(camera, cullFrustum);
-                }
+                camera.Picker.Finish();
+                RenderWithCamera(camera, cullFrustum);
             }
         }
 

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -71,10 +71,26 @@ namespace GUI.Types.Renderer
 
             if (id % 2 == 1)
             {
-                return dynamicNodes[((int)id + 1) / 2 - 1];
-            }
+                var index = ((int)id + 1) / 2 - 1;
 
-            return staticNodes[(int)id / 2 - 1];
+                if (index >= dynamicNodes.Count)
+                {
+                    return null;
+                }
+
+                return dynamicNodes[index];
+            }
+            else
+            {
+                var index = (int)id / 2 - 1;
+
+                if (index >= staticNodes.Count)
+                {
+                    return null;
+                }
+
+                return staticNodes[index];
+            }
         }
 
         public void Update(float timestep)

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -146,7 +146,15 @@ namespace GUI.Types.Renderer
             if (camera.RenderToPicker)
             {
                 renderContext.ReplacementShader = camera.Picker.shader;
-                camera.Picker.Render();
+                if (!camera.PickerDebug)
+                {
+                    camera.Picker.Render();
+                    camera.Picker.SetDebug(false);
+                }
+                else
+                {
+                    camera.Picker.SetDebug(true);
+                }
             }
 
             MeshBatchRenderer.Render(opaqueDrawCalls, renderContext);
@@ -168,7 +176,10 @@ namespace GUI.Types.Renderer
             {
                 PickingTexture.Finish();
                 camera.RenderToPicker = false;
-                RenderWithCamera(camera, cullFrustum);
+                if (!camera.PickerDebug)
+                {
+                    RenderWithCamera(camera, cullFrustum);
+                }
             }
         }
 

--- a/GUI/Types/Renderer/SceneNode.cs
+++ b/GUI/Types/Renderer/SceneNode.cs
@@ -29,6 +29,7 @@ namespace GUI.Types.Renderer
             }
         }
 
+        public string Name { get; set; }
         public uint Id { get; set; }
 
         public Scene Scene { get; }

--- a/GUI/Types/Renderer/SceneNode.cs
+++ b/GUI/Types/Renderer/SceneNode.cs
@@ -29,7 +29,7 @@ namespace GUI.Types.Renderer
             }
         }
 
-        public int Id { get; set; }
+        public uint Id { get; set; }
 
         public Scene Scene { get; }
 

--- a/GUI/Types/Renderer/SceneNode.cs
+++ b/GUI/Types/Renderer/SceneNode.cs
@@ -29,6 +29,8 @@ namespace GUI.Types.Renderer
             }
         }
 
+        public int Id { get; set; }
+
         public Scene Scene { get; }
 
         private AABB localBoundingBox;

--- a/GUI/Types/Renderer/SelectedNodeRenderer.cs
+++ b/GUI/Types/Renderer/SelectedNodeRenderer.cs
@@ -58,7 +58,7 @@ namespace GUI.Types.Renderer
             }
 
             GL.Enable(EnableCap.Blend);
-            //GL.Enable(EnableCap.DepthTest);
+            GL.Enable(EnableCap.DepthTest);
             GL.DepthMask(false);
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             GL.UseProgram(shader.Program);
@@ -72,7 +72,7 @@ namespace GUI.Types.Renderer
             GL.UseProgram(0);
             GL.DepthMask(true);
             GL.Disable(EnableCap.Blend);
-            //GL.Disable(EnableCap.DepthTest);
+            GL.Disable(EnableCap.DepthTest);
         }
     }
 }

--- a/GUI/Types/Renderer/SelectedNodeRenderer.cs
+++ b/GUI/Types/Renderer/SelectedNodeRenderer.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using GUI.Utils;
+using OpenTK.Graphics.OpenGL;
+
+namespace GUI.Types.Renderer
+{
+    internal class SelectedNodeRenderer
+    {
+        private readonly Shader shader;
+        private readonly int vaoHandle;
+        private readonly int vboHandle;
+        private int vertexCount;
+
+        public SelectedNodeRenderer(VrfGuiContext guiContext)
+        {
+            shader = shader = guiContext.ShaderLoader.LoadShader("vrf.grid", new Dictionary<string, bool>());
+            GL.UseProgram(shader.Program);
+
+            vboHandle = GL.GenBuffer();
+
+            vaoHandle = GL.GenVertexArray();
+            GL.BindVertexArray(vaoHandle);
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vboHandle);
+
+            const int stride = sizeof(float) * 7;
+            var positionAttributeLocation = GL.GetAttribLocation(shader.Program, "aVertexPosition");
+            GL.EnableVertexAttribArray(positionAttributeLocation);
+            GL.VertexAttribPointer(positionAttributeLocation, 3, VertexAttribPointerType.Float, false, stride, 0);
+
+            var colorAttributeLocation = GL.GetAttribLocation(shader.Program, "aVertexColor");
+            GL.EnableVertexAttribArray(colorAttributeLocation);
+            GL.VertexAttribPointer(colorAttributeLocation, 4, VertexAttribPointerType.Float, false, stride, sizeof(float) * 3);
+
+            GL.BindVertexArray(0);
+        }
+
+        public void SelectNode(SceneNode node)
+        {
+            if (node == null)
+            {
+                vertexCount = 0;
+                return;
+            }
+
+            var vertices = new List<float>();
+            OctreeDebugRenderer<SceneNode>.AddBox(vertices, node.BoundingBox, 1.0f, 1.0f, 0.0f, 1.0f);
+            vertexCount = vertices.Count / 7;
+
+            GL.BindBuffer(BufferTarget.ArrayBuffer, vboHandle);
+            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Count * sizeof(float), vertices.ToArray(), BufferUsageHint.StaticDraw);
+        }
+
+        public void Render(Camera camera, RenderPass renderPass)
+        {
+            if (vertexCount == 0 || renderPass != RenderPass.Both)
+            {
+                return;
+            }
+
+            GL.Enable(EnableCap.Blend);
+            //GL.Enable(EnableCap.DepthTest);
+            GL.DepthMask(false);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+            GL.UseProgram(shader.Program);
+
+            var projectionViewMatrix = camera.ViewProjectionMatrix.ToOpenTK();
+            GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref projectionViewMatrix);
+
+            GL.BindVertexArray(vaoHandle);
+            GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);
+            GL.BindVertexArray(0);
+            GL.UseProgram(0);
+            GL.DepthMask(true);
+            GL.Disable(EnableCap.Blend);
+            //GL.Disable(EnableCap.DepthTest);
+        }
+    }
+}

--- a/GUI/Types/Renderer/ShaderLoader.cs
+++ b/GUI/Types/Renderer/ShaderLoader.cs
@@ -236,6 +236,8 @@ namespace GUI.Types.Renderer
                     return "error";
                 case "vrf.grid":
                     return "debug_grid";
+                case "vrf.picking":
+                    return "picking";
                 case "vrf.particle.sprite":
                     return "particle_sprite";
                 case "vrf.particle.trail":

--- a/GUI/Types/Renderer/Shaders/dota_hero.vert
+++ b/GUI/Types/Renderer/Shaders/dota_hero.vert
@@ -9,7 +9,7 @@
 #define param_fulltangent 1
 //End of parameter defines
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 in vec4 vTANGENT;

--- a/GUI/Types/Renderer/Shaders/error.vert
+++ b/GUI/Types/Renderer/Shaders/error.vert
@@ -4,7 +4,7 @@
 #include "animation.incl"
 //End of includes
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec2 vTEXCOORD;
 
 out vec2 vTexCoordOut;

--- a/GUI/Types/Renderer/Shaders/multiblend.vert
+++ b/GUI/Types/Renderer/Shaders/multiblend.vert
@@ -8,7 +8,7 @@
 #define param_fulltangent 1
 //End of parameter defines
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 in vec4 vTEXCOORD1;

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -1,10 +1,10 @@
 #version 330
 
-uniform float sceneObjectId = 0.0;
+uniform uint sceneObjectId = uint(1);
 
-out vec4 outputColor;
+out uint outputColor;
 
 void main()
 {
-    outputColor = vec4(sceneObjectId, .6, sceneObjectId, 1);
+    outputColor = uint(sceneObjectId);
 }

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -1,10 +1,20 @@
 #version 330
 
+#define param_F_DEBUG_PICKER 0
+
 uniform uint sceneObjectId = uint(1);
 
-out uint outputColor;
+#if param_F_DEBUG_PICKER == 1
+    out vec4 outputColor;
+#else
+    out uint outputColor;
+#endif
 
 void main()
 {
+#if param_F_DEBUG_PICKER == 1
+    outputColor = vec4(fract(float(sceneObjectId) / 7.0), fract(float(sceneObjectId) / 11.0), fract(float(sceneObjectId) / 13.0), 1.0);
+#else
     outputColor = uint(sceneObjectId);
+#endif
 }

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -15,7 +15,6 @@ void main()
 {
 #if param_F_DEBUG_PICKER == 1
     outputColor = vec4(fract(float(sceneObjectId) / 7.0), fract(float(sceneObjectId) / 11.0), fract(float(sceneObjectId) / 13.0), 1.0);
-    //outputColor = vec4(fract(float(meshId) / 7.0), fract(float(meshId) / 11.0), fract(float(meshId) / 13.0), 1.0);
 #else
     outputColor = uvec2(sceneObjectId, meshId);
 #endif

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -3,18 +3,20 @@
 #define param_F_DEBUG_PICKER 0
 
 uniform uint sceneObjectId;
+uniform uint meshId;
 
 #if param_F_DEBUG_PICKER == 1
     out vec4 outputColor;
 #else
-    out uint outputColor;
+    out uvec2 outputColor;
 #endif
 
 void main()
 {
 #if param_F_DEBUG_PICKER == 1
     outputColor = vec4(fract(float(sceneObjectId) / 7.0), fract(float(sceneObjectId) / 11.0), fract(float(sceneObjectId) / 13.0), 1.0);
+    //outputColor = vec4(fract(float(meshId) / 7.0), fract(float(meshId) / 11.0), fract(float(meshId) / 13.0), 1.0);
 #else
-    outputColor = sceneObjectId;
+    outputColor = uvec2(sceneObjectId, meshId);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -1,0 +1,10 @@
+#version 330
+
+uniform float sceneObjectId = 0.0;
+
+out vec4 outputColor;
+
+void main()
+{
+    outputColor = vec4(sceneObjectId, .6, sceneObjectId, 1);
+}

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -2,7 +2,7 @@
 
 #define param_F_DEBUG_PICKER 0
 
-uniform uint sceneObjectId = uint(1);
+uniform uint sceneObjectId;
 
 #if param_F_DEBUG_PICKER == 1
     out vec4 outputColor;
@@ -15,6 +15,6 @@ void main()
 #if param_F_DEBUG_PICKER == 1
     outputColor = vec4(fract(float(sceneObjectId) / 7.0), fract(float(sceneObjectId) / 11.0), fract(float(sceneObjectId) / 13.0), 1.0);
 #else
-    outputColor = uint(sceneObjectId);
+    outputColor = sceneObjectId;
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/picking.vert
+++ b/GUI/Types/Renderer/Shaders/picking.vert
@@ -4,7 +4,7 @@
 #include "animation.incl"
 //End of includes
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 
 uniform mat4 uProjectionViewMatrix;
 uniform mat4 transform;

--- a/GUI/Types/Renderer/Shaders/picking.vert
+++ b/GUI/Types/Renderer/Shaders/picking.vert
@@ -1,0 +1,14 @@
+#version 330
+
+//Includes - resolved by VRF
+#include "animation.incl"
+//End of includes
+
+in vec3 vPOSITION;
+
+uniform mat4 uProjectionViewMatrix;
+uniform mat4 transform;
+
+void main(void) {
+    gl_Position = uProjectionViewMatrix * transform * getSkinMatrix() * vec4(vPOSITION, 1.0);
+}

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -9,7 +9,7 @@
 #define param_fulltangent 1
 //End of parameter defines
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 in vec4 vTANGENT;

--- a/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
+++ b/GUI/Types/Renderer/Shaders/vr_black_unlit.vert
@@ -2,7 +2,7 @@
 
 #include "animation.incl"
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 
 out vec3 vFragPosition;
 

--- a/GUI/Types/Renderer/Shaders/vr_unlit.vert
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.vert
@@ -2,7 +2,7 @@
 
 #include "animation.incl"
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec2 vTEXCOORD;
 
 out vec3 vFragPosition;

--- a/GUI/Types/Renderer/Shaders/water.vert
+++ b/GUI/Types/Renderer/Shaders/water.vert
@@ -8,7 +8,7 @@
 #define param_fulltangent 1
 //End of parameter defines
 
-in vec3 vPOSITION;
+layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 in vec4 vTANGENT;

--- a/GUI/Types/Renderer/WorldNodeLoader.cs
+++ b/GUI/Types/Renderer/WorldNodeLoader.cs
@@ -72,6 +72,7 @@ namespace GUI.Types.Renderer
                         Transform = matrix,
                         Tint = tintColor,
                         LayerName = layerIndex > -1 ? worldLayers[layerIndex] : "No layer",
+                        Name = renderableModel,
                     };
 
                     scene.Add(modelNode, false);
@@ -93,6 +94,7 @@ namespace GUI.Types.Renderer
                         Transform = matrix,
                         Tint = tintColor,
                         LayerName = layerIndex > -1 ? worldLayers[layerIndex] : "No layer",
+                        Name = renderable,
                     };
 
                     scene.Add(meshNode, false);

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -235,15 +235,15 @@ namespace GUI.Types.Viewers
 
                         Console.WriteLine($"Opening {name} from external refs");
 
-                        var file = vrfGuiContext.CurrentPackage?.FindEntry(name);
-
-                        file ??= vrfGuiContext.CurrentPackage?.FindEntry(name + "_c");
-
-                        if (file != null)
+                        var foundFile = vrfGuiContext.FileLoader.FindFileWithContext(name);
+                        if (foundFile.Context == null)
                         {
-                            var newVrfGuiContext = new VrfGuiContext(file.GetFileName(), vrfGuiContext);
+                            foundFile = vrfGuiContext.FileLoader.FindFileWithContext(name + "_c");
+                        }
 
-                            Program.MainForm.OpenFile(newVrfGuiContext, file);
+                        if (foundFile.Context != null)
+                        {
+                            Program.MainForm.OpenFile(foundFile.Context, foundFile.PackageEntry);
                         }
                     }
 

--- a/GUI/Utils/AdvancedGuiFileLoader.cs
+++ b/GUI/Utils/AdvancedGuiFileLoader.cs
@@ -65,19 +65,8 @@ namespace GUI.Utils
             CachedResources.Clear();
         }
 
-        public Resource LoadFile(string file)
+        public (string PathOnDisk, Package Package, PackageEntry PackageEntry) FindFile(string file)
         {
-            // TODO: Might conflict where same file name is available in different paths
-            if (CachedResources.TryGetValue(file, out var resource) && resource.Reader != null)
-            {
-                return resource;
-            }
-
-            resource = new Resource
-            {
-                FileName = file,
-            };
-
             var entry = GuiContext.CurrentPackage?.FindEntry(file);
 
             if (entry != null)
@@ -86,16 +75,12 @@ namespace GUI.Utils
                 Console.WriteLine($"Loaded \"{file}\" from current vpk");
 #endif
 
-                var stream = GetPackageEntryStream(GuiContext.CurrentPackage, entry);
-                resource.Read(stream);
-                CachedResources[file] = resource;
-
-                return resource;
+                return (null, GuiContext.CurrentPackage, entry);
             }
 
             if (GuiContext.ParentGuiContext != null)
             {
-                return GuiContext.ParentGuiContext.LoadFileByAnyMeansNecessary(file);
+                return GuiContext.ParentGuiContext.FileLoader.FindFile(file);
             }
 
             if (!GamePackagesScanned)
@@ -152,32 +137,59 @@ namespace GUI.Utils
                     Console.WriteLine($"Loaded \"{file}\" from preloaded vpk \"{package.FileName}\"");
 #endif
 
-                    var stream = GetPackageEntryStream(package, entry);
-                    resource.Read(stream);
-                    CachedResources[file] = resource;
-
-                    return resource;
+                    return (null, package, entry);
                 }
             }
 
             var path = FindResourcePath(paths.Concat(CurrentGameSearchPaths).ToList(), file, GuiContext.FileName);
 
-            if (path == null)
+            if (path != null)
             {
-                Console.Error.WriteLine($"Failed to load \"{file}\". Did you configure VPK paths in settings correctly?");
-
-                if (string.IsNullOrEmpty(file) || file == "_c")
-                {
-                    Console.Error.WriteLine($"Empty string passed to file loader here: {Environment.StackTrace}");
-                }
-
-                return null;
+                return (path, null, null);
             }
 
-            resource.Read(path);
-            CachedResources[file] = resource;
+            Console.Error.WriteLine($"Failed to load \"{file}\". Did you configure VPK paths in settings correctly?");
 
-            return resource;
+            if (string.IsNullOrEmpty(file) || file == "_c")
+            {
+                Console.Error.WriteLine($"Empty string passed to file loader here: {Environment.StackTrace}");
+            }
+
+            return (null, null, null);
+        }
+
+        public Resource LoadFile(string file)
+        {
+            // TODO: Might conflict where same file name is available in different paths
+            if (CachedResources.TryGetValue(file, out var resource) && resource.Reader != null)
+            {
+                return resource;
+            }
+
+            resource = new Resource
+            {
+                FileName = file,
+            };
+
+            var foundFile = FindFile(file);
+
+            if (foundFile.PathOnDisk != null)
+            {
+                resource.Read(foundFile.PathOnDisk);
+                CachedResources[file] = resource;
+
+                return resource;
+            }
+            else if (foundFile.PackageEntry != null)
+            {
+                var stream = GetPackageEntryStream(foundFile.Package, foundFile.PackageEntry);
+                resource.Read(stream);
+                CachedResources[file] = resource;
+
+                return resource;
+            }
+
+            return null;
         }
 
         public void AddPackageToSearch(Package package)


### PR DESCRIPTION
To Do:
- [x] Fix `GL.ReadPixels` access violation
- [x] Debug view
- [x] Merge debug view with other modes
- [x] Only render to picker on double click.
- [x] Improve node search, maybe with a name cache.
- [x] Maybe outline the object on first click.
- [x] Test other scenes (model, particle)
- [ ] Fix 3D Skybox
- [x] Copy camera position when opening to separate tab
- [x] Select and identify model on scene using a separate frame buffer
- [x] Unbind events on dispose
- [ ] Better node search that supports changing ids, possibly incorporating octree node ids + queried with frustum
- [x] Double clicking in model viewer opens vmesh if available
- [x] Set meshgroups and animation same as in the map (e.g. tree model in dota)

Resolves #505 