### PR TITLE
Silently ignore invalid VBIB blend indices

### DIFF
--- a/ValveResourceFormat/Resource/Blocks/VBIB.cs
+++ b/ValveResourceFormat/Resource/Blocks/VBIB.cs
@@ -393,6 +393,7 @@ namespace ValveResourceFormat.Blocks
                     var formatSize = formatElementSize * formatElementCount;
                     buf.Data = buf.Data.ToArray();
                     var bufSpan = buf.Data.AsSpan();
+                    var maxRemapTableIdx = remapTable.Length - 1;
                     for (var i = (int)field.Offset; i < buf.Data.Length; i += (int)buf.ElementSizeInBytes)
                     {
                         for (var j = 0; j < formatSize; j += formatElementSize)
@@ -401,14 +402,14 @@ namespace ValveResourceFormat.Blocks
                             {
                                 case 4:
                                     BitConverter.TryWriteBytes(bufSpan.Slice(i + j),
-                                        remapTable[BitConverter.ToUInt32(buf.Data, i + j)]);
+                                        remapTable[Math.Min(BitConverter.ToUInt32(buf.Data, i + j), maxRemapTableIdx)]);
                                     break;
                                 case 2:
                                     BitConverter.TryWriteBytes(bufSpan.Slice(i + j),
-                                        (short)remapTable[BitConverter.ToUInt16(buf.Data, i + j)]);
+                                        (short)remapTable[Math.Min(BitConverter.ToUInt16(buf.Data, i + j), maxRemapTableIdx)]);
                                     break;
                                 case 1:
-                                    buf.Data[i + j] = (byte)remapTable[buf.Data[i + j]];
+                                    buf.Data[i + j] = (byte)remapTable[Math.Min(buf.Data[i + j], maxRemapTableIdx)];
                                     break;
                                 default:
                                     throw new NotImplementedException();


### PR DESCRIPTION
Fixes #517

Mentioned model `models/items/witchdoctor/wd_ti8_immortal_bonkers/wd_ti8_immortal_bonkers.vmdl` renders and exports just fine, at least as far as I can tell.

Although this is a crutch and should be avoided - it's a model problem, as skeleton bone count is less than remap table length and model references non-existent bones. It might be an issue of a poorly versioned model and mesh.
AFAIK this situation should trigger `remapping vertex %d[w%d] invalid: %d->%d >= %d` in `CMesh::RemapBlendIndices` in dota build with asserts, as could be seen in resourcecompiler and debug libserver binary. I suppose it's somehow ignored in release builds.