### PR TITLE
Create separate render loop thread

### DIFF
--- a/GUI/Controls/GLViewerControl.Designer.cs
+++ b/GUI/Controls/GLViewerControl.Designer.cs
@@ -16,6 +16,11 @@ namespace GUI.Controls
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+            {
+                OnDisposing();
+            }
+
             if (disposing && (components != null))
             {
                 components.Dispose();

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -40,7 +40,6 @@ namespace GUI.Controls
         private static bool hasCheckedOpenGL;
 
         long lastFpsUpdate;
-        long lastUpdate;
         int frames;
 
         Vector2 initialMousePosition;
@@ -237,27 +236,16 @@ namespace GUI.Controls
             GLPostLoad?.Invoke(this);
             GLPostLoad = null;
 
-            GLControl.Paint += OnPaint;
-
             RenderLoopThread.RegisterInstance();
 
             if (GLControl.Visible)
             {
-                RenderLoopThread.SetCurrentGLControl(GLControl);
+                RenderLoopThread.SetCurrentGLControl(this);
             }
         }
 
-        private void Draw()
+        public void Draw(long currentTime, long elapsed)
         {
-            var currentTime = Stopwatch.GetTimestamp();
-            var elapsed = currentTime - lastUpdate;
-            lastUpdate = currentTime;
-
-            if (elapsed <= TickFrequency)
-            {
-                return;
-            }
-
             var frameTime = elapsed * TickFrequency / TicksPerSecond;
 
             Camera.HandleInput(Mouse.GetState(), Keyboard.GetState());
@@ -282,15 +270,9 @@ namespace GUI.Controls
             }
         }
 
-        private void OnPaint(object sender, EventArgs e)
-        {
-            Draw();
-        }
-
         private void OnDisposing()
         {
             GLControl.Load -= OnLoad;
-            GLControl.Paint -= OnPaint;
             GLControl.Resize -= OnResize;
             GLControl.MouseEnter -= OnMouseEnter;
             GLControl.MouseLeave -= OnMouseLeave;
@@ -299,7 +281,7 @@ namespace GUI.Controls
             GLControl.MouseWheel -= OnMouseWheel;
             GLControl.VisibleChanged -= OnVisibleChanged;
 
-            RenderLoopThread.UnsetCurrentGLControl(GLControl);
+            RenderLoopThread.UnsetCurrentGLControl(this);
             RenderLoopThread.UnregisterInstance();
         }
 
@@ -309,7 +291,7 @@ namespace GUI.Controls
             {
                 HandleResize();
 
-                RenderLoopThread.SetCurrentGLControl(GLControl);
+                RenderLoopThread.SetCurrentGLControl(this);
             }
         }
 

--- a/GUI/Controls/GLViewerControl.cs
+++ b/GUI/Controls/GLViewerControl.cs
@@ -68,9 +68,7 @@ namespace GUI.Controls
             GLControl.MouseUp += OnMouseUp;
             GLControl.MouseDown += OnMouseDown;
             GLControl.MouseWheel += OnMouseWheel;
-            GLControl.GotFocus += OnGotFocus;
             GLControl.VisibleChanged += OnVisibleChanged;
-            GLControl.Disposed += OnDisposed;
 
             GLControl.Dock = DockStyle.Fill;
             glControlContainer.Controls.Add(GLControl);
@@ -170,21 +168,6 @@ namespace GUI.Controls
         {
             control.Location = new Point(0, currentControlsHeight);
             currentControlsHeight += control.Height;
-        }
-
-        private void OnDisposed(object sender, EventArgs e)
-        {
-            GLControl.Load -= OnLoad;
-            GLControl.Paint -= OnPaint;
-            GLControl.Resize -= OnResize;
-            GLControl.MouseEnter -= OnMouseEnter;
-            GLControl.MouseLeave -= OnMouseLeave;
-            GLControl.MouseUp -= OnMouseUp;
-            GLControl.MouseDown -= OnMouseDown;
-            GLControl.MouseWheel -= OnMouseWheel;
-            GLControl.GotFocus -= OnGotFocus;
-            GLControl.VisibleChanged -= OnVisibleChanged;
-            GLControl.Disposed -= OnDisposed;
         }
 
         private void OnMouseLeave(object sender, EventArgs e)
@@ -306,6 +289,16 @@ namespace GUI.Controls
 
         private void OnDisposing()
         {
+            GLControl.Load -= OnLoad;
+            GLControl.Paint -= OnPaint;
+            GLControl.Resize -= OnResize;
+            GLControl.MouseEnter -= OnMouseEnter;
+            GLControl.MouseLeave -= OnMouseLeave;
+            GLControl.MouseUp -= OnMouseUp;
+            GLControl.MouseDown -= OnMouseDown;
+            GLControl.MouseWheel -= OnMouseWheel;
+            GLControl.VisibleChanged -= OnVisibleChanged;
+
             RenderLoopThread.UnsetCurrentGLControl(GLControl);
             RenderLoopThread.UnregisterInstance();
         }
@@ -321,11 +314,6 @@ namespace GUI.Controls
         }
 
         private void OnResize(object sender, EventArgs e)
-        {
-            HandleResize();
-        }
-
-        private void OnGotFocus(object sender, EventArgs e)
         {
             HandleResize();
         }

--- a/GUI/Forms/SettingsForm.Designer.cs
+++ b/GUI/Forms/SettingsForm.Designer.cs
@@ -37,7 +37,11 @@ namespace GUI.Forms
             maxTextureSizeLabel = new System.Windows.Forms.Label();
             maxTextureSizeInput = new System.Windows.Forms.NumericUpDown();
             divider1 = new System.Windows.Forms.Label();
+            maxFpsInput = new System.Windows.Forms.NumericUpDown();
+            maxFpsLabel = new System.Windows.Forms.Label();
+            vsyncLabel = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)maxTextureSizeInput).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)maxFpsInput).BeginInit();
             SuspendLayout();
             // 
             // gamePaths
@@ -133,11 +137,44 @@ namespace GUI.Forms
             divider1.Size = new System.Drawing.Size(640, 2);
             divider1.TabIndex = 9;
             // 
+            // maxFpsInput
+            // 
+            maxFpsInput.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+            maxFpsInput.Location = new System.Drawing.Point(116, 292);
+            maxFpsInput.Maximum = new decimal(new int[] { 500, 0, 0, 0 });
+            maxFpsInput.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            maxFpsInput.Name = "maxFpsInput";
+            maxFpsInput.Size = new System.Drawing.Size(120, 23);
+            maxFpsInput.TabIndex = 10;
+            maxFpsInput.Value = new decimal(new int[] { 1, 0, 0, 0 });
+            maxFpsInput.ValueChanged += OnMaxFpsValueChanged;
+            // 
+            // maxFpsLabel
+            // 
+            maxFpsLabel.AutoSize = true;
+            maxFpsLabel.Location = new System.Drawing.Point(15, 294);
+            maxFpsLabel.Name = "maxFpsLabel";
+            maxFpsLabel.Size = new System.Drawing.Size(55, 15);
+            maxFpsLabel.TabIndex = 11;
+            maxFpsLabel.Text = "Max FPS:";
+            // 
+            // vsyncLabel
+            // 
+            vsyncLabel.AutoSize = true;
+            vsyncLabel.Location = new System.Drawing.Point(242, 294);
+            vsyncLabel.Name = "vsyncLabel";
+            vsyncLabel.Size = new System.Drawing.Size(152, 15);
+            vsyncLabel.TabIndex = 12;
+            vsyncLabel.Text = "(might be limited by vsync)";
+            // 
             // SettingsForm
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(668, 301);
+            ClientSize = new System.Drawing.Size(668, 338);
+            Controls.Add(vsyncLabel);
+            Controls.Add(maxFpsInput);
+            Controls.Add(maxFpsLabel);
             Controls.Add(divider1);
             Controls.Add(maxTextureSizeInput);
             Controls.Add(maxTextureSizeLabel);
@@ -154,6 +191,7 @@ namespace GUI.Forms
             Text = "Settings";
             Load += SettingsForm_Load;
             ((System.ComponentModel.ISupportInitialize)maxTextureSizeInput).EndInit();
+            ((System.ComponentModel.ISupportInitialize)maxFpsInput).EndInit();
             ResumeLayout(false);
             PerformLayout();
         }
@@ -169,5 +207,8 @@ namespace GUI.Forms
         private System.Windows.Forms.Label maxTextureSizeLabel;
         private System.Windows.Forms.NumericUpDown maxTextureSizeInput;
         private System.Windows.Forms.Label divider1;
+        private System.Windows.Forms.NumericUpDown maxFpsInput;
+        private System.Windows.Forms.Label maxFpsLabel;
+        private System.Windows.Forms.Label vsyncLabel;
     }
 }

--- a/GUI/Forms/SettingsForm.cs
+++ b/GUI/Forms/SettingsForm.cs
@@ -21,6 +21,7 @@ namespace GUI.Forms
             }
 
             maxTextureSizeInput.Value = Settings.Config.MaxTextureSize;
+            maxFpsInput.Value = Settings.Config.MaxFPS;
         }
 
         private void GamePathRemoveClick(object sender, EventArgs e)
@@ -120,6 +121,19 @@ namespace GUI.Forms
             }
 
             Settings.Config.MaxTextureSize = newValue;
+            Settings.Save();
+        }
+
+        private void OnMaxFpsValueChanged(object sender, EventArgs e)
+        {
+            var newValue = (int)maxFpsInput.Value;
+
+            if (newValue == Settings.Config.MaxFPS)
+            {
+                return;
+            }
+
+            Settings.Config.MaxFPS = newValue;
             Settings.Save();
         }
     }

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -275,12 +275,13 @@ namespace GUI
 
             //Close the requested tab
             Console.WriteLine($"Closing {tab.Text}");
-            mainTabs.TabPages.Remove(tab);
 
             if (isClosingCurrentTab && tabIndex > 0)
             {
                 mainTabs.SelectedIndex = tabIndex - 1;
             }
+
+            mainTabs.TabPages.Remove(tab);
 
             ShowHideSearch();
 

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -14,6 +14,7 @@ using System.Windows.Forms;
 using GUI.Controls;
 using GUI.Forms;
 using GUI.Types.Exporter;
+using GUI.Types.Renderer;
 using GUI.Utils;
 using SteamDatabase.ValvePak;
 
@@ -275,6 +276,8 @@ namespace GUI
 
             //Close the requested tab
             Console.WriteLine($"Closing {tab.Text}");
+
+            RenderLoopThread.UnsetIfClosingParentOfCurrentGLControl(tab);
 
             if (isClosingCurrentTab && tabIndex > 0)
             {

--- a/GUI/Types/Renderer/RenderLoopThread.cs
+++ b/GUI/Types/Renderer/RenderLoopThread.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GUI.Controls;
+using OpenTK;
+using static GUI.Controls.GLViewerControl;
+
+namespace GUI.Types.Renderer
+{
+    internal class RenderLoopThread
+    {
+        private const int TicksPerMillisecond = 10_000;
+        private const long TicksPerSecond = TicksPerMillisecond * 1_000;
+
+        private static class WinApi
+        {
+            [DllImport("winmm.dll", EntryPoint = "timeBeginPeriod")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            public static extern uint TimeBeginPeriod(uint uMilliseconds);
+
+            [DllImport("winmm.dll", EntryPoint = "timeEndPeriod")]
+            [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+            public static extern uint TimeEndPeriod(uint uMilliseconds);
+        }
+
+        private static int instances;
+        private static Thread loopThread;
+        private static GLControl currentGLControl;
+
+        public static void RegisterInstance()
+        {
+            if (instances++ == 0)
+            {
+                Start();
+            }
+
+#if DEBUG
+            Console.WriteLine($"Registered GL instance, current count: {instances}");
+#endif
+        }
+
+        public static void UnregisterInstance()
+        {
+            if (--instances == 0)
+            {
+                Stop();
+            }
+
+#if DEBUG
+            Console.WriteLine($"Unregistered GL instance, current count: {instances}");
+#endif
+        }
+
+        public static void SetCurrentGLControl(GLControl glControl)
+        {
+            if (currentGLControl == null)
+            {
+                _ = WinApi.TimeBeginPeriod(1);
+            }
+
+            Interlocked.Exchange(ref currentGLControl, glControl);
+        }
+
+        public static void UnsetCurrentGLControl(GLControl glControl)
+        {
+            Interlocked.CompareExchange(ref currentGLControl, null, glControl);
+
+            if (currentGLControl == null)
+            {
+                _ = WinApi.TimeEndPeriod(1);
+            }
+        }
+
+        private static void Start()
+        {
+            loopThread = new Thread(RenderLoop)
+            {
+                Name = nameof(RenderLoopThread)
+            };
+            loopThread.Start();
+        }
+
+        public static void Stop()
+        {
+            loopThread = null;
+        }
+
+        private static void RenderLoop()
+        {
+#if DEBUG
+            Console.WriteLine("RenderLoop thread started");
+#endif
+
+            var desiredInterval = TicksPerSecond / 120;
+
+            while (instances > 0)
+            {
+                var nextFrame = Stopwatch.GetTimestamp() + desiredInterval;
+                var control = currentGLControl;
+
+                if (control == null)
+                {
+                    // If there is no control currently visible, sleep for 100ms
+                    Thread.Sleep(100);
+                    continue;
+                }
+
+                if (!control.Visible)
+                {
+                    // Work around the issue that VisibleChanged is not raised when control becomes invisible
+                    UnsetCurrentGLControl(control);
+                    continue;
+                }
+
+                // We're relying on the fact that Invalidate() will block for the duration of Draw() call
+                try
+                {
+                    control.Invoke(control.Invalidate);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Due to wonky Invoke, checking IsDisposed is not enough
+                }
+
+                var currentTime = Stopwatch.GetTimestamp();
+                var sleep = Math.Max(1, (int)(nextFrame - currentTime) / TicksPerMillisecond);
+
+                Thread.Sleep(sleep);
+            }
+
+#if DEBUG
+            Console.WriteLine("RenderLoop thread quit");
+#endif
+        }
+    }
+}

--- a/GUI/Types/Renderer/RenderLoopThread.cs
+++ b/GUI/Types/Renderer/RenderLoopThread.cs
@@ -1,14 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using GUI.Controls;
+using GUI.Utils;
 using OpenTK;
-using static GUI.Controls.GLViewerControl;
 
 namespace GUI.Types.Renderer
 {
@@ -96,10 +91,9 @@ namespace GUI.Types.Renderer
             Console.WriteLine("RenderLoop thread started");
 #endif
 
-            var desiredInterval = TicksPerSecond / 120;
-
             while (instances > 0)
             {
+                var desiredInterval = TicksPerSecond / Settings.Config.MaxFPS;
                 var nextFrame = Stopwatch.GetTimestamp() + desiredInterval;
                 var control = currentGLControl;
 

--- a/GUI/Types/Renderer/RenderLoopThread.cs
+++ b/GUI/Types/Renderer/RenderLoopThread.cs
@@ -56,6 +56,10 @@ namespace GUI.Types.Renderer
             if (currentGLControl == null)
             {
                 _ = WinApi.TimeBeginPeriod(1);
+
+#if DEBUG
+                Console.WriteLine("Called TimeBeginPeriod");
+#endif
             }
 
             Interlocked.Exchange(ref currentGLControl, glControl);
@@ -68,6 +72,10 @@ namespace GUI.Types.Renderer
             if (currentGLControl == null)
             {
                 _ = WinApi.TimeEndPeriod(1);
+
+#if DEBUG
+                Console.WriteLine("Called TimeEndPeriod");
+#endif
             }
         }
 

--- a/GUI/Utils/Settings.cs
+++ b/GUI/Utils/Settings.cs
@@ -20,6 +20,7 @@ namespace GUI.Utils
             public string SaveDirectory { get; set; } = string.Empty;
             public Dictionary<string, float[]> SavedCameras { get; set; } = new Dictionary<string, float[]>();
             public int MaxTextureSize { get; set; }
+            public int MaxFPS { get; set; }
             public int WindowTop { get; set; }
             public int WindowLeft { get; set; }
             public int WindowWidth { get; set; }
@@ -99,6 +100,15 @@ namespace GUI.Utils
             else if (Config.MaxTextureSize > 10240)
             {
                 Config.MaxTextureSize = 10240;
+            }
+
+            if (Config.MaxFPS <= 0)
+            {
+                Config.MaxFPS = 120;
+            }
+            else if (Config.MaxFPS > 500)
+            {
+                Config.MaxFPS = 500;
             }
         }
 


### PR DESCRIPTION
This fixes our renderer from basically infinite looping on OnPaint -> Invalidate -> OnPaint calls.

This allows configuring max fps. To fix Thread.Sleep calls, timeBeginPeriod API is used. When no GL control is visible, it calls timeEndPeriod.

There is only one global thread as long as there is any GL view, when all GL tabs are closed, the thread exits.