### PR TITLE
Renderer improvements

### DIFF
--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="AssetTypes\*" />
-    <EmbeddedResource Include="Types\Renderer\Shaders\*" />
+    <EmbeddedResource Include="Types\Renderer\Shaders\**" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ValveResourceFormat\ValveResourceFormat.csproj">

--- a/GUI/Types/Renderer/DrawCall.cs
+++ b/GUI/Types/Renderer/DrawCall.cs
@@ -11,11 +11,15 @@ namespace GUI.Types.Renderer
         //public uint VertexCount { get; set; }
         public uint StartIndex { get; set; }
         public int IndexCount { get; set; }
-        //public uint InstanceIndex { get; set; }   //TODO
-        //public uint InstanceCount { get; set; }   //TODO
         //public float UvDensity { get; set; }     //TODO
         //public string Flags { get; set; }        //TODO
         public Vector3 TintColor { get; set; } = Vector3.One;
+
+        public AABB? DrawBounds { get; set; }
+
+        public int MeshId { get; set; }
+        public int FirstMeshlet { get; set; }
+        public int NumMeshlets { get; set; }
         public RenderMaterial Material { get; set; }
         public uint VertexArrayObject { get; set; }
         public DrawBuffer VertexBuffer { get; set; }

--- a/GUI/Types/Renderer/GLModelViewer.cs
+++ b/GUI/Types/Renderer/GLModelViewer.cs
@@ -224,7 +224,7 @@ namespace GUI.Types.Renderer
 
             if (pickingResponse.Intent == PickingTexture.PickingIntent.Select)
             {
-                Console.WriteLine("Selected mesh with index " + pickingResponse.PixelInfo.MeshId);
+                Console.WriteLine($"Selected mesh {pickingResponse.PixelInfo.MeshId}, ({pickingResponse.PixelInfo.ObjectId}.");
                 return;
             }
 

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -196,6 +196,7 @@ namespace GUI.Types.Renderer
                     ViewerControl.Camera.Picker.Resize(ViewerControl.GLControl.Width, ViewerControl.GLControl.Height);
                 }
 
+                GuiContext.ShaderLoader.ClearCache();
                 SetRenderMode(renderModeComboBox?.SelectedItem as string);
                 SetAvailableRenderModes(renderModeComboBox?.SelectedIndex ?? 0);
             };
@@ -231,20 +232,7 @@ namespace GUI.Types.Renderer
 
         private void SetRenderMode(string renderMode)
         {
-#if DEBUG_SHADERS
-            if (ViewerControl.Camera?.Picker.GetAvailableRenderModes().Contains(renderMode) == true)
-            {
-                ViewerControl.Camera?.Picker.SetRenderMode(renderMode);
-                return;
-            }
-            else if (ViewerControl.Camera?.Picker.DebugShader != null)
-            {
-                ViewerControl.Camera?.Picker.SetRenderMode(null);
-                return;
-            }
-#else
             ViewerControl.Camera?.Picker.SetRenderMode(renderMode);
-#endif
 
             foreach (var node in Scene.AllNodes)
             {

--- a/GUI/Types/Renderer/GLSceneViewer.cs
+++ b/GUI/Types/Renderer/GLSceneViewer.cs
@@ -126,15 +126,7 @@ namespace GUI.Types.Renderer
             staticOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.StaticOctree, Scene.GuiContext, false);
             dynamicOctreeRenderer = new OctreeDebugRenderer<SceneNode>(Scene.DynamicOctree, Scene.GuiContext, true);
 
-            if (renderModeComboBox != null)
-            {
-                var supportedRenderModes = Scene.AllNodes
-                    .SelectMany(r => r.GetSupportedRenderModes())
-                    .Distinct()
-                    .Concat(ViewerControl.Camera.Picker.Shader.RenderModes);
-
-                SetAvailableRenderModes(supportedRenderModes);
-            }
+            SetAvailableRenderModes();
 
             if (ShowSkybox && SkyboxScene != null)
             {
@@ -205,6 +197,7 @@ namespace GUI.Types.Renderer
                 }
 
                 SetRenderMode(renderModeComboBox?.SelectedItem as string);
+                SetAvailableRenderModes(renderModeComboBox?.SelectedIndex ?? 0);
             };
             ViewerControl.AddControl(button);
 #endif
@@ -212,13 +205,22 @@ namespace GUI.Types.Renderer
             renderModeComboBox ??= ViewerControl.AddSelection("Render Mode", (renderMode, _) => SetRenderMode(renderMode));
         }
 
-        private void SetAvailableRenderModes(IEnumerable<string> renderModes)
+        private void SetAvailableRenderModes(int index = 0)
         {
-            renderModeComboBox.Items.Clear();
-            renderModeComboBox.Enabled = true;
-            renderModeComboBox.Items.Add("Default Render Mode");
-            renderModeComboBox.Items.AddRange(renderModes.ToArray());
-            renderModeComboBox.SelectedIndex = 0;
+            if (renderModeComboBox != null)
+            {
+                var supportedRenderModes = Scene.AllNodes
+                    .SelectMany(r => r.GetSupportedRenderModes())
+                    .Distinct()
+                    .Concat(ViewerControl.Camera.Picker.Shader.RenderModes);
+
+                renderModeComboBox.Items.Clear();
+                renderModeComboBox.Enabled = true;
+                renderModeComboBox.Items.Add("Default Render Mode");
+                renderModeComboBox.Items.AddRange(supportedRenderModes.ToArray());
+                renderModeComboBox.SelectedIndex = index;
+            }
+
         }
 
         protected void SetEnabledLayers(HashSet<string> layers)

--- a/GUI/Types/Renderer/MaterialLoader.cs
+++ b/GUI/Types/Renderer/MaterialLoader.cs
@@ -22,8 +22,12 @@ namespace GUI.Types.Renderer
 
         private readonly Dictionary<string, string[]> TextureAliases = new()
         {
+            ["g_tLayer2Color"] = new[] { "g_tColorB" },
             ["g_tColor"] = new[] { "g_tColor2", "g_tColor1", "g_tColorA", "g_tColorB", "g_tColorC" },
             ["g_tNormal"] = new[] { "g_tNormalA", "g_tNormalRoughness", "g_tLayer1NormalRoughness" },
+            ["g_tLayer2NormalRoughness"] = new[] { "g_tNormalB" },
+            ["g_tBlendModulation"] = new[] { "g_tMask" },
+
         };
 
         public MaterialLoader(VrfGuiContext guiContext)

--- a/GUI/Types/Renderer/MaterialRenderer.cs
+++ b/GUI/Types/Renderer/MaterialRenderer.cs
@@ -19,7 +19,7 @@ namespace GUI.Types.Renderer
         public MaterialRenderer(VrfGuiContext vrfGuiContext, Resource resource)
         {
             material = vrfGuiContext.MaterialLoader.LoadMaterial(resource);
-            shader = vrfGuiContext.ShaderLoader.LoadShader(material.Material.ShaderName, material.Material.GetShaderArguments());
+            shader = material.Shader;
             quadVao = SetupQuadBuffer();
         }
 

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -105,7 +105,7 @@ namespace GUI.Types.Renderer
 
                     foreach (var request in materialGroup)
                     {
-                        Draw(uniforms, request);
+                        Draw(uniforms, request, context.Time);
                     }
 
                     material.PostRender();
@@ -116,7 +116,7 @@ namespace GUI.Types.Renderer
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Draw(Uniforms uniforms, Request request)
+        private static void Draw(Uniforms uniforms, Request request, float time)
         {
             var transformTk = request.Transform.ToOpenTK();
             GL.UniformMatrix4(uniforms.Transform, false, ref transformTk);
@@ -133,7 +133,7 @@ namespace GUI.Types.Renderer
 
             if (uniforms.Time != 1)
             {
-                GL.Uniform1(uniforms.Time, request.Mesh.Time);
+                GL.Uniform1(uniforms.Time, time);
             }
 
             if (uniforms.Animated != -1)

--- a/GUI/Types/Renderer/MeshSceneNode.cs
+++ b/GUI/Types/Renderer/MeshSceneNode.cs
@@ -38,7 +38,6 @@ namespace GUI.Types.Renderer
 
         public override void Update(Scene.UpdateContext context)
         {
-            meshRenderer.Update(context.Timestep);
         }
 
         public override void Render(Scene.RenderContext context)

--- a/GUI/Types/Renderer/PhysSceneNode.cs
+++ b/GUI/Types/Renderer/PhysSceneNode.cs
@@ -236,7 +236,7 @@ namespace GUI.Types.Renderer
                 var name = $"[{string.Join(", ", tags)}]";
                 if (group != null)
                 {
-                    name = $"{group} {name}";
+                    name = $"{name} {group}";
                 }
 
                 var physSceneNode = new PhysSceneNode(scene, verts[i], inds[i])

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -12,20 +12,12 @@ namespace GUI.Types.Renderer
         public bool IsBlended { get; }
         public bool IsToolsMaterial { get; }
 
-        private readonly float flAlphaTestReference;
         private readonly bool isAdditiveBlend;
         private readonly bool isRenderBackfaces;
 
         public RenderMaterial(Material material)
         {
             Material = material;
-
-            if (material.IntParams.ContainsKey("F_ALPHA_TEST") &&
-                material.IntParams["F_ALPHA_TEST"] == 1 &&
-                material.FloatParams.ContainsKey("g_flAlphaTestReference"))
-            {
-                flAlphaTestReference = material.FloatParams["g_flAlphaTestReference"];
-            }
 
             IsToolsMaterial = material.IntAttributes.ContainsKey("tools.toolsmaterial");
             IsBlended = (material.IntParams.ContainsKey("F_TRANSLUCENT") && material.IntParams["F_TRANSLUCENT"] == 1)
@@ -75,13 +67,6 @@ namespace GUI.Types.Renderer
                 {
                     GL.Uniform4(uniformLocation, new Vector4(param.Value.X, param.Value.Y, param.Value.Z, param.Value.W));
                 }
-            }
-
-            var alphaReference = shader.GetUniformLocation("g_flAlphaTestReference");
-
-            if (alphaReference > -1)
-            {
-                GL.Uniform1(alphaReference, flAlphaTestReference);
             }
 
             if (IsBlended)

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -14,6 +14,7 @@ namespace GUI.Types.Renderer
 
         private readonly bool isAdditiveBlend;
         private readonly bool isRenderBackfaces;
+        private readonly bool isOverlay;
 
         public RenderMaterial(Material material)
         {
@@ -27,6 +28,9 @@ namespace GUI.Types.Renderer
                 || material.ShaderName == "tools_sprite.vfx";
             isAdditiveBlend = material.IntParams.ContainsKey("F_ADDITIVE_BLEND") && material.IntParams["F_ADDITIVE_BLEND"] == 1;
             isRenderBackfaces = material.IntParams.ContainsKey("F_RENDER_BACKFACES") && material.IntParams["F_RENDER_BACKFACES"] == 1;
+            isOverlay = (material.IntParams.ContainsKey("F_OVERLAY") && material.IntParams["F_OVERLAY"] == 1)
+                || material.IntParams.ContainsKey("F_DEPTH_BIAS") && material.IntParams["F_DEPTH_BIAS"] == 1
+                || material.ShaderName.EndsWith("static_overlay.vfx", System.StringComparison.Ordinal);
         }
 
         public void Render(Shader shader)
@@ -76,6 +80,12 @@ namespace GUI.Types.Renderer
                 GL.BlendFunc(BlendingFactor.SrcAlpha, isAdditiveBlend ? BlendingFactor.One : BlendingFactor.OneMinusSrcAlpha);
             }
 
+            if (isOverlay)
+            {
+                GL.Enable(EnableCap.PolygonOffsetFill);
+                GL.PolygonOffset(-0.05f, -64);
+            }
+
             if (isRenderBackfaces)
             {
                 GL.Disable(EnableCap.CullFace);
@@ -88,6 +98,12 @@ namespace GUI.Types.Renderer
             {
                 GL.DepthMask(true);
                 GL.Disable(EnableCap.Blend);
+            }
+
+            if (isOverlay)
+            {
+                GL.Disable(EnableCap.PolygonOffsetFill);
+                GL.PolygonOffset(0, 0);
             }
 
             if (isRenderBackfaces)

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -7,18 +7,21 @@ namespace GUI.Types.Renderer
 {
     public class RenderMaterial
     {
+        public Shader Shader => shader;
         public Material Material { get; }
         public Dictionary<string, int> Textures { get; } = new Dictionary<string, int>();
         public bool IsBlended { get; }
         public bool IsToolsMaterial { get; }
 
+        private readonly Shader shader;
         private readonly bool isAdditiveBlend;
         private readonly bool isRenderBackfaces;
         private readonly bool isOverlay;
 
-        public RenderMaterial(Material material)
+        public RenderMaterial(Material material, ShaderLoader shaderLoader)
         {
             Material = material;
+            shader = shaderLoader.LoadShader(material.ShaderName, material.GetShaderArguments());
 
             IsToolsMaterial = material.IntAttributes.ContainsKey("tools.toolsmaterial");
             IsBlended = (material.IntParams.ContainsKey("F_TRANSLUCENT") && material.IntParams["F_TRANSLUCENT"] == 1)
@@ -33,11 +36,13 @@ namespace GUI.Types.Renderer
                 || material.ShaderName.EndsWith("static_overlay.vfx", System.StringComparison.Ordinal);
         }
 
-        public void Render(Shader shader)
+        public void Render(Shader shader = default)
         {
             //Start at 1, texture unit 0 is reserved for the animation texture
             var textureUnit = 1;
             int uniformLocation;
+
+            shader ??= this.shader;
 
             foreach (var texture in Textures)
             {

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -24,8 +24,6 @@ namespace GUI.Types.Renderer
         public int? AnimationTexture { get; private set; }
         public int AnimationTextureSize { get; private set; }
 
-        public float Time { get; private set; }
-
         public int MeshIndex { get; }
 
         private readonly Mesh mesh;
@@ -84,11 +82,6 @@ namespace GUI.Types.Renderer
         {
             AnimationTexture = texture;
             AnimationTextureSize = animationTextureSize;
-        }
-
-        public void Update(float timeStep)
-        {
-            Time += timeStep;
         }
 
         public void SetSkin(Dictionary<string, string> skinMaterials)

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -129,7 +129,7 @@ namespace GUI.Types.Renderer
 
                     if (Mesh.IsCompressedNormalTangent(objectDrawCall))
                     {
-                        shaderArguments.Add("fulltangent", false);
+                        shaderArguments.Add("param_fulltangent", false);
                     }
 
                     if (firstSetup)

--- a/GUI/Types/Renderer/RenderableMesh.cs
+++ b/GUI/Types/Renderer/RenderableMesh.cs
@@ -122,7 +122,7 @@ namespace GUI.Types.Renderer
 
                     if (Mesh.IsCompressedNormalTangent(objectDrawCall))
                     {
-                        shaderArguments.Add("param_fulltangent", false);
+                        shaderArguments.Add("fulltangent", false);
                     }
 
                     if (firstSetup)

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -20,6 +20,7 @@ namespace GUI.Types.Renderer
         public class RenderContext
         {
             public Camera Camera { get; init; }
+            public float Time { get; init; }
             public Vector3? LightPosition { get; init; }
             public RenderPass RenderPass { get; set; }
             public Shader ReplacementShader { get; set; }
@@ -27,6 +28,7 @@ namespace GUI.Types.Renderer
         }
 
         public Camera MainCamera { get; set; }
+        public float Time { get; set; }
         public Vector3? LightPosition { get; set; }
         public VrfGuiContext GuiContext { get; }
         public Octree<SceneNode> StaticOctree { get; }
@@ -96,6 +98,8 @@ namespace GUI.Types.Renderer
         public void Update(float timestep)
         {
             var updateContext = new UpdateContext(timestep);
+            Time += timestep;
+
             foreach (var node in staticNodes)
             {
                 node.Update(updateContext);
@@ -181,6 +185,7 @@ namespace GUI.Types.Renderer
             var renderContext = new RenderContext
             {
                 Camera = camera,
+                Time = Time,
                 LightPosition = LightPosition,
                 RenderPass = RenderPass.Opaque,
                 RenderToolsMaterials = ShowToolsMaterials,

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -133,7 +133,6 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
-                                MeshId = (uint)mesh.MeshIndex,
                             });
                         }
 
@@ -146,10 +145,23 @@ namespace GUI.Types.Renderer
                                 Call = call,
                                 DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
                                 NodeId = node.Id,
-                                MeshId = (uint)mesh.MeshIndex,
                             });
                         }
                     }
+                }
+                else if (node is SceneAggregate aggregate)
+                {
+                }
+                else if (node is SceneAggregate.Fragment fragment)
+                {
+                    opaqueDrawCalls.Add(new MeshBatchRenderer.Request
+                    {
+                        Transform = fragment.Parent.Transform,
+                        Mesh = fragment.RenderMesh,
+                        Call = fragment.DrawCall,
+                        DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),
+                        NodeId = node.Id,
+                    });
                 }
                 else
                 {
@@ -179,11 +191,11 @@ namespace GUI.Types.Renderer
                 if (camera.Picker.IsActive)
                 {
                     camera.Picker.Render();
-                    renderContext.ReplacementShader = camera.Picker.shader;
+                    renderContext.ReplacementShader = camera.Picker.Shader;
                 }
-                else if (camera.Picker.Debug)
+                else if (camera.Picker.DebugShader is not null)
                 {
-                    renderContext.ReplacementShader = camera.Picker.debugShader;
+                    renderContext.ReplacementShader = camera.Picker.DebugShader;
                 }
             }
 

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -160,7 +160,7 @@ namespace GUI.Types.Renderer
                 {
                     opaqueDrawCalls.Add(new MeshBatchRenderer.Request
                     {
-                        Transform = fragment.Parent.Transform,
+                        Transform = fragment.Transform,
                         Mesh = fragment.RenderMesh,
                         Call = fragment.DrawCall,
                         DistanceFromCamera = (node.BoundingBox.Center - camera.Location).LengthSquared(),

--- a/GUI/Types/Renderer/SceneAggregate.cs
+++ b/GUI/Types/Renderer/SceneAggregate.cs
@@ -68,7 +68,6 @@ namespace GUI.Types.Renderer
 
         public override void Update(Scene.UpdateContext context)
         {
-            RenderMesh.Update(context.Timestep);
         }
 
         public override IEnumerable<string> GetSupportedRenderModes() => RenderMesh.GetSupportedRenderModes();

--- a/GUI/Types/Renderer/SceneAggregate.cs
+++ b/GUI/Types/Renderer/SceneAggregate.cs
@@ -1,0 +1,81 @@
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.Serialization;
+
+namespace GUI.Types.Renderer
+{
+    internal class SceneAggregate : SceneNode
+    {
+        private Model Model { get; }
+        public RenderableMesh RenderMesh { get; }
+
+        internal class Fragment : SceneNode
+        {
+            public SceneNode Parent { get; init; }
+            public RenderableMesh RenderMesh { get; init; }
+            public DrawCall DrawCall { get; init; }
+
+            /// <summary>
+            /// In the format of 255,255,255
+            /// </summary>
+            public Vector3 Tint { get; set; }
+
+            public Fragment(Scene scene, SceneNode parent, AABB bounds) : base(scene)
+            {
+                Parent = parent;
+                LocalBoundingBox = bounds;
+                Name = parent.Name;
+                LayerName = parent.LayerName;
+            }
+
+            public override void Render(Scene.RenderContext context) { }
+            public override void Update(Scene.UpdateContext context) { }
+        }
+
+        public SceneAggregate(Scene scene, Model model)
+            : base(scene)
+        {
+            Model = model;
+            RenderMesh = new RenderableMesh(Model.GetEmbeddedMeshesAndLoD().First().Mesh, 0, Scene.GuiContext);
+            LocalBoundingBox = RenderMesh.BoundingBox;
+        }
+
+        public IEnumerable<Fragment> CreateFragments(IKeyValueCollection[] aggregateMeshes)
+        {
+            foreach (var fragmentData in aggregateMeshes)
+            {
+                var drawCallIndex = fragmentData.GetInt32Property("m_nDrawCallIndex");
+                var drawCall = RenderMesh.DrawCallsOpaque[drawCallIndex];
+                var drawBounds = RenderMesh.DrawCallsOpaque[drawCallIndex].DrawBounds ?? RenderMesh.BoundingBox;
+                var fragment = new Fragment(Scene, this, drawBounds)
+                {
+                    Tint = fragmentData.GetSubCollection("m_vTintColor").ToVector3(),
+                    DrawCall = drawCall,
+                    RenderMesh = RenderMesh,
+                    Parent = this,
+                };
+
+                yield return fragment;
+            }
+        }
+
+        public override void Render(Scene.RenderContext context)
+        {
+        }
+
+        public override void Update(Scene.UpdateContext context)
+        {
+            RenderMesh.Update(context.Timestep);
+        }
+
+        public override IEnumerable<string> GetSupportedRenderModes() => RenderMesh.GetSupportedRenderModes();
+
+        public override void SetRenderMode(string renderMode)
+        {
+            RenderMesh.SetRenderMode(renderMode);
+        }
+    }
+}

--- a/GUI/Types/Renderer/ShaderLoader.cs
+++ b/GUI/Types/Renderer/ShaderLoader.cs
@@ -251,6 +251,8 @@ namespace GUI.Types.Renderer
                     return "dota_hero";
                 case "multiblend.vfx":
                     return "multiblend";
+                case "csgo_effects.vfx":
+                    return "csgo_effects";
                 default:
                     return "simple";
             }

--- a/GUI/Types/Renderer/ShaderLoader.cs
+++ b/GUI/Types/Renderer/ShaderLoader.cs
@@ -1,4 +1,4 @@
-//#define DEBUG_SHADERS
+#define DEBUG_SHADERS
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,7 +20,7 @@ namespace GUI.Types.Renderer
         private const string ShaderDirectory = "GUI.Types.Renderer.Shaders.";
         private const int ShaderSeed = 0x13141516;
         private static readonly Regex RegexInclude = new(@"^#include ""(?<IncludeName>[^""]+)""\r?$", RegexOptions.Multiline);
-        private static readonly Regex RegexDefine = new(@"^#define param_(?<ParamName>\S+) (?<DefaultValue>\S+)", RegexOptions.Multiline);
+        private static readonly Regex RegexDefine = new(@"^#define (?<ParamName>\S+) (?<DefaultValue>\S+)", RegexOptions.Multiline);
 
 #if !DEBUG_SHADERS || !DEBUG
         private readonly Dictionary<uint, Shader> CachedShaders = new();

--- a/GUI/Types/Renderer/ShaderLoader.cs
+++ b/GUI/Types/Renderer/ShaderLoader.cs
@@ -22,10 +22,8 @@ namespace GUI.Types.Renderer
         private static readonly Regex RegexInclude = new(@"^#include ""(?<IncludeName>[^""]+)""\r?$", RegexOptions.Multiline);
         private static readonly Regex RegexDefine = new(@"^#define (?<ParamName>\S+) (?<DefaultValue>\S+)", RegexOptions.Multiline);
 
-#if !DEBUG_SHADERS || !DEBUG
         private readonly Dictionary<uint, Shader> CachedShaders = new();
         private readonly Dictionary<string, List<string>> ShaderDefines = new();
-#endif
 
         public Shader LoadShader(string shaderName, IDictionary<string, bool> arguments)
         {
@@ -145,15 +143,12 @@ namespace GUI.Types.Renderer
             GL.DetachShader(shader.Program, fragmentShader);
             GL.DeleteShader(fragmentShader);
 
-#if !DEBUG_SHADERS || !DEBUG
             ShaderDefines[shaderFileName] = defines;
             var newShaderCacheHash = CalculateShaderCacheHash(shaderFileName, arguments);
 
             CachedShaders[newShaderCacheHash] = shader;
 
             Console.WriteLine($"Shader {newShaderCacheHash} ('{shaderName}' as '{shaderFileName}') ({string.Join(", ", arguments.Keys)}) compiled and linked succesfully");
-#endif
-
             return shader;
         }
 
@@ -261,7 +256,6 @@ namespace GUI.Types.Renderer
             }
         }
 
-#if !DEBUG_SHADERS || !DEBUG
         private uint CalculateShaderCacheHash(string shaderFileName, IDictionary<string, bool> arguments)
         {
             var shaderCacheHashString = new StringBuilder();
@@ -277,7 +271,6 @@ namespace GUI.Types.Renderer
 
             return MurmurHash2.Hash(shaderCacheHashString.ToString(), ShaderSeed);
         }
-#endif
 
 #if DEBUG_SHADERS && DEBUG
         // Reload shaders at runtime

--- a/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
+++ b/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
@@ -1,0 +1,7 @@
+#define param_renderMode_FullBright 0
+#define param_renderMode_Color 0
+#define param_renderMode_Normals 0
+#define param_renderMode_Tangents 0
+#define param_renderMode_BumpMap 0
+#define param_renderMode_BumpNormals 0
+#define param_renderMode_Illumination 0

--- a/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
+++ b/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
@@ -1,7 +1,7 @@
-#define param_renderMode_FullBright 0
-#define param_renderMode_Color 0
-#define param_renderMode_Normals 0
-#define param_renderMode_Tangents 0
-#define param_renderMode_BumpMap 0
-#define param_renderMode_BumpNormals 0
-#define param_renderMode_Illumination 0
+#define renderMode_FullBright 0
+#define renderMode_Color 0
+#define renderMode_Normals 0
+#define renderMode_Tangents 0
+#define renderMode_BumpMap 0
+#define renderMode_BumpNormals 0
+#define renderMode_Illumination 0

--- a/GUI/Types/Renderer/Shaders/csgo_effects.frag
+++ b/GUI/Types/Renderer/Shaders/csgo_effects.frag
@@ -1,0 +1,101 @@
+#version 330
+
+#define renderMode_Color 0
+#define renderMode_SpriteEffects 0
+#define renderMode_VertexColor 0
+
+in vec3 vFragPosition;
+in vec3 vNormalOut;
+in vec3 vTangentOut;
+in vec3 vBitangentOut;
+in vec2 vTexCoordOut;
+in vec4 vColorOut;
+
+out vec4 outputColor;
+
+#define F_TINT_MASK 0
+
+uniform sampler2D g_tColor;
+uniform sampler2D g_tMask1;
+uniform sampler2D g_tMask2;
+uniform sampler2D g_tMask3;
+#if F_TINT_MASK == 1
+    uniform sampler2D g_tTintMask;
+#endif
+
+uniform vec4 g_vTexCoordScrollSpeed;
+uniform vec4 g_vMask1PanSpeed;
+uniform vec4 g_vMask2PanSpeed;
+uniform vec4 g_vMask3PanSpeed;
+uniform vec4 g_vMask1Scale;
+uniform vec4 g_vMask2Scale;
+uniform vec4 g_vMask3Scale;
+
+uniform float g_flColorBoost = 1.0;
+uniform float g_flFadeDistance = 5000;
+uniform float g_flFadeFalloff = 1.0;
+uniform float g_flFadeMax = 1.0;
+uniform float g_flFadeMin;
+uniform float g_flFeatherDistance = 2000;
+uniform float g_flFeatherFalloff = 1.0;
+uniform float g_flFresnelExponent = 1.0;
+uniform float g_flFresnelFalloff = 1.0;
+uniform float g_flFresnelMax = 1.0;
+uniform float g_flFresnelMin;
+uniform float g_flOpacityScale = 1.0;
+
+uniform vec3 m_vTintColorDrawCall;
+
+uniform float g_flTime;
+
+uniform vec3 vLightPosition;
+uniform vec3 vEyePosition;
+
+//Main entry point
+void main()
+{
+    //Get the ambient color from the color texture
+    vec4 color = texture(g_tColor, vTexCoordOut);
+    float mask1 = texture(g_tMask1, vTexCoordOut * g_vMask1Scale.xy + (g_vMask1PanSpeed.xy * g_flTime)).x;
+    float mask2 = texture(g_tMask2, vTexCoordOut * g_vMask2Scale.xy + (g_vMask2PanSpeed.xy * g_flTime)).x;
+    float mask3 = texture(g_tMask3, vTexCoordOut * g_vMask3Scale.xy + (g_vMask3PanSpeed.xy * g_flTime)).x;
+
+    //Calculate tint color
+    vec3 tintColor = m_vTintColorDrawCall.rgb;
+
+    #if F_TINT_MASK == 1
+        float tintFactor = texture(g_tTintMask, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordScale.xy).x;
+        tintColor = tintFactor * tintColor + (1 - tintFactor) * vec3(1);
+    #endif
+
+    float opacity = color.a * mask1 * mask2 * mask3 * g_flOpacityScale;
+
+    // Calculate fresnel
+    vec3 viewDirection = normalize(vEyePosition - vFragPosition);
+    float fresnel = abs(dot(viewDirection, vNormalOut));
+    fresnel = pow(fresnel, g_flFresnelExponent);
+    fresnel = fresnel * g_flFresnelFalloff + (1 - g_flFresnelFalloff);
+    fresnel = fresnel * (g_flFresnelMax - g_flFresnelMin) + g_flFresnelMin;
+
+    // Calculate fade
+    float fade = distance(vFragPosition, vEyePosition) * 0.05;
+    fade = fade - g_flFadeDistance;
+    fade = fade * (g_flFadeFalloff*0.05) + (1 - (g_flFadeFalloff*0.05));
+    fade = (1-fade) * (g_flFadeMax - g_flFadeMin) + g_flFadeMin;
+    fade = clamp(fade, 0, 1);
+
+    opacity = opacity * fresnel * fade * (vColorOut.a / 255.0);
+
+    outputColor = vec4(
+        color.rgb * tintColor * g_flColorBoost * (vColorOut.rgb / 255.0),
+        opacity
+    );
+
+#if renderMode_Color == 1
+    outputColor = color * mask1;
+#elif renderMode_VertexColor == 1
+    outputColor = vColorOut / 255.0;
+#elif renderMode_SpriteEffects
+    outputColor = vec4(mask1, mask2, mask3, 1);
+#endif
+}

--- a/GUI/Types/Renderer/Shaders/csgo_effects.vert
+++ b/GUI/Types/Renderer/Shaders/csgo_effects.vert
@@ -1,0 +1,39 @@
+#version 330
+
+layout (location = 0) in vec3 vPOSITION;
+layout (location = 1) in vec2 vTEXCOORD;
+layout (location = 2) in vec4 vNORMAL;
+layout (location = 3) in vec4 vCOLOR;
+
+#include "animation.incl"
+#include "compression.incl"
+
+out vec3 vFragPosition;
+
+out vec3 vNormalOut;
+out vec3 vTangentOut;
+out vec3 vBitangentOut;
+
+out vec2 vTexCoordOut;
+out vec4 vColorOut;
+
+uniform mat4 uProjectionViewMatrix;
+uniform mat4 transform;
+
+void main()
+{
+    mat4 skinTransform = transform * getSkinMatrix();
+    vec4 fragPosition = skinTransform * vec4(vPOSITION, 1.0);
+    gl_Position = uProjectionViewMatrix * fragPosition;
+    vFragPosition = fragPosition.xyz / fragPosition.w;
+
+    mat3 normalTransform = transpose(inverse(mat3(skinTransform)));
+
+    vec4 tangent = DecompressTangent(vNORMAL);
+    vNormalOut = normalize(normalTransform * DecompressNormal(vNORMAL));
+    vTangentOut = normalize(normalTransform * tangent.xyz);
+    vBitangentOut = tangent.w * cross( vNormalOut, vTangentOut );
+
+    vTexCoordOut = vTEXCOORD;
+    vColorOut = vCOLOR;
+}

--- a/GUI/Types/Renderer/Shaders/dota_hero.frag
+++ b/GUI/Types/Renderer/Shaders/dota_hero.frag
@@ -1,13 +1,7 @@
 #version 330
 
 // Render modes -- Switched on/off by code
-#define param_renderMode_FullBright 0
-#define param_renderMode_Color 0
-#define param_renderMode_Normals 0
-#define param_renderMode_Tangents 0
-#define param_renderMode_BumpMap 0
-#define param_renderMode_BumpNormals 0
-#define param_renderMode_Illumination 0
+#include "common/rendermodes.glsl"
 #define param_renderMode_Mask1 0
 #define param_renderMode_Mask2 0
 #define param_renderMode_Metalness 0

--- a/GUI/Types/Renderer/Shaders/dota_hero.frag
+++ b/GUI/Types/Renderer/Shaders/dota_hero.frag
@@ -2,17 +2,17 @@
 
 // Render modes -- Switched on/off by code
 #include "common/rendermodes.glsl"
-#define param_renderMode_Mask1 0
-#define param_renderMode_Mask2 0
-#define param_renderMode_Metalness 0
-#define param_renderMode_Specular 0
-#define param_renderMode_RimLight 0
+#define renderMode_Mask1 0
+#define renderMode_Mask2 0
+#define renderMode_Metalness 0
+#define renderMode_Specular 0
+#define renderMode_RimLight 0
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_F_MASKS_1 0
-#define param_F_MASKS_2 0
-#define param_F_ALPHA_TEST 0
-#define param_F_SPECULAR_CUBE_MAP 0
+#define F_MASKS_1 0
+#define F_MASKS_2 0
+#define F_ALPHA_TEST 0
+#define F_SPECULAR_CUBE_MAP 0
 //End of parameter defines
 
 in vec3 vFragPosition;
@@ -71,18 +71,18 @@ void main()
     //Read textures
     vec4 color = texture(g_tColor, vTexCoordOut);
 
-#if param_F_ALPHA_TEST == 1
+#if F_ALPHA_TEST == 1
     if (color.a < g_flAlphaTestReference)
     {
        discard;
     }
 #endif
 
-#if param_F_MASKS_1
+#if F_MASKS_1
     vec4 mask1 = texture(g_tMasks1, vTexCoordOut);
 #endif
 
-#if param_F_MASKS_2
+#if F_MASKS_2
     vec4 mask2 = texture(g_tMasks2, vTexCoordOut);
 #endif
 
@@ -92,7 +92,7 @@ void main()
     //Get shadow and light color
     //vec3 shadowColor = texture(g_tDiffuseWarp, vec2(0, mask1.g)).rgb;
 
-#if param_renderMode_FullBright == 1
+#if renderMode_FullBright == 1
     float illumination = 1.0;
 #else
     //Calculate half-lambert lighting
@@ -100,7 +100,7 @@ void main()
     illumination = illumination * 0.5 + 0.5;
     illumination = illumination * illumination;
 
-    #if param_F_MASKS_1
+    #if F_MASKS_1
         //Self illumination - mask 1 channel A
         illumination = illumination + mask1.a;
     #endif
@@ -109,7 +109,7 @@ void main()
     //Calculate ambient color
     vec3 ambientColor = illumination * color.rgb;
 
-#if param_F_MASKS_1
+#if F_MASKS_1
     //Get metalness for future use - mask 1 channel B
     float metalness = mask1.b;
 #else
@@ -120,7 +120,7 @@ void main()
     vec3 halfDir = normalize(lightDirection + viewDirection);
     float specularAngle = max(dot(halfDir, worldNormal), 0.0);
 
-#if param_F_MASKS_2 && !param_F_SPECULAR_CUBE_MAP
+#if F_MASKS_2 && !F_SPECULAR_CUBE_MAP
     //Calculate final specular based on specular exponent - mask 2 channel A
     float specular = pow(specularAngle, mask2.a * g_flSpecularExponent);
     //Multiply by mapped specular intensity - mask 2 channel R
@@ -137,7 +137,7 @@ void main()
     float rimLight = 1.0 - abs(dot(worldNormal, viewDirection));
     rimLight = pow(rimLight, 2);
 
-#if param_F_MASKS_2
+#if F_MASKS_2
     //Multiply the rim light by the rim light intensity - mask 2 channel G
     rimLight = rimLight * mask2.g;
 #endif
@@ -151,47 +151,47 @@ void main()
     // == End of shader
 
     // Different render mode definitions
-#if param_renderMode_Color == 1
+#if renderMode_Color == 1
     outputColor = vec4(color.rgb, 1.0);
 #endif
 
-#if param_renderMode_Illumination == 1
+#if renderMode_Illumination == 1
     outputColor = vec4(illumination, 0.0, 0.0, 1.0);
 #endif
 
-#if param_renderMode_Mask1 == 1 && param_F_MASKS_1
+#if renderMode_Mask1 == 1 && F_MASKS_1
     outputColor = vec4(mask1.rgb, 1.0);
 #endif
 
-#if param_renderMode_Mask2 == 1 && param_F_MASKS_2
+#if renderMode_Mask2 == 1 && F_MASKS_2
     outputColor = vec4(mask2.rgb, 1.0);
 #endif
 
-#if param_renderMode_BumpMap == 1
+#if renderMode_BumpMap == 1
     outputColor = texture(g_tNormal, vTexCoordOut);
 #endif
 
-#if param_renderMode_Tangents == 1
+#if renderMode_Tangents == 1
     outputColor = vec4(vTangentOut.xyz * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Normals == 1
+#if renderMode_Normals == 1
     outputColor = vec4(vNormalOut * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_BumpNormals == 1
+#if renderMode_BumpNormals == 1
     outputColor = vec4(worldNormal * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Metalness == 1
+#if renderMode_Metalness == 1
     outputColor = vec4(metalness, metalness, metalness, 1.0);
 #endif
 
-#if param_renderMode_Specular == 1
+#if renderMode_Specular == 1
     outputColor = vec4(specularColor * specular, 1.0);
 #endif
 
-#if param_renderMode_RimLight == 1
+#if renderMode_RimLight == 1
     outputColor = vec4(color.rgb * rimLight, 1.0);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/dota_hero.vert
+++ b/GUI/Types/Renderer/Shaders/dota_hero.vert
@@ -6,13 +6,15 @@
 //End of includes
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_fulltangent 1
+#define fulltangent 1
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
-in vec4 vTANGENT;
+#if fulltangent == 1
+    in vec4 vTANGENT;
+#endif
 
 out vec3 vFragPosition;
 
@@ -35,7 +37,7 @@ void main()
     mat3 normalTransform = transpose(inverse(mat3(skinTransformMatrix)));
 
     //Unpack normals
-#if param_fulltangent == 1
+#if fulltangent == 1
     vNormalOut = normalize(normalTransform * vNORMAL.xyz);
     vTangentOut = normalize(normalTransform * vTANGENT.xyz);
     vBitangentOut = cross(vNormalOut, vTangentOut);

--- a/GUI/Types/Renderer/Shaders/multiblend.frag
+++ b/GUI/Types/Renderer/Shaders/multiblend.frag
@@ -2,13 +2,13 @@
 
 // Render modes -- Switched on/off by code
 #include "common/rendermodes.glsl"
-#define param_renderMode_Terrain_Blend 0
-#define param_renderMode_Ambient_Occlusion 0
+#define renderMode_Terrain_Blend 0
+#define renderMode_Ambient_Occlusion 0
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_F_TINT_MASK 0
-#define param_F_NORMAL_MAP 0
-#define param_F_TWO_LAYER_BLEND 0
+#define F_TINT_MASK 0
+#define F_NORMAL_MAP 0
+#define F_TWO_LAYER_BLEND 0
 //End of parameter defines
 
 in vec3 vFragPosition;
@@ -88,7 +88,7 @@ void main()
     //Calculate coordinates
     vec2 coord0 = getTexCoord(g_flTexCoordScale0, g_flTexCoordRotate0);
     vec2 coord1 = getTexCoord(g_flTexCoordScale1, g_flTexCoordRotate1);
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     vec2 coord2 = getTexCoord(g_flTexCoordScale2, g_flTexCoordRotate2);
     vec2 coord3 = getTexCoord(g_flTexCoordScale3, g_flTexCoordRotate3);
 #endif
@@ -96,7 +96,7 @@ void main()
     //Get the ambient color from the color texture
     vec4 color0 = texture(g_tColor0, coord0);
     vec4 color1 = texture(g_tColor1, coord1);
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     vec4 color2 = texture(g_tColor2, coord2);
     vec4 color3 = texture(g_tColor3, coord3);
 #endif
@@ -104,7 +104,7 @@ void main()
     //Get normal
     vec4 normal0 = texture(g_tNormal0, coord0);
     vec4 normal1 = texture(g_tNormal1, coord1);
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     vec4 normal2 = texture(g_tNormal2, coord2);
     vec4 normal3 = texture(g_tNormal3, coord3);
 #endif
@@ -112,7 +112,7 @@ void main()
     //Get specular
     vec4 specular0 = texture(g_tSpecular0, coord0);
     vec4 specular1 = texture(g_tSpecular1, coord1);
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     vec4 specular2 = texture(g_tSpecular2, coord2);
     vec4 specular3 = texture(g_tSpecular3, coord3);
 #endif
@@ -123,25 +123,25 @@ void main()
 
     //Simple blending
     //Calculate each of the 4 colours to blend
-#if param_F_TINT_MASK
+#if F_TINT_MASK
     // Include tint mask
     vec4 c0 = blend.x * color0 * interpolateTint(0, g_vColorTint0, g_vColorTintB0, g_flTexCoordScale0, g_flTexCoordRotate0);
     vec4 c1 = blend.y * color1 * interpolateTint(1, g_vColorTint1, g_vColorTintB1, g_flTexCoordScale1, g_flTexCoordRotate1);
-    #if param_F_TWO_LAYER_BLEND == 0
+    #if F_TWO_LAYER_BLEND == 0
         vec4 c2 = blend.z * color2 * interpolateTint(2, g_vColorTint2, g_vColorTintB2, g_flTexCoordScale2, g_flTexCoordRotate2);
         vec4 c3 = blend.w * color3 * interpolateTint(3, g_vColorTint3, g_vColorTintB3, g_flTexCoordScale3, g_flTexCoordRotate3);
     #endif
 #else
     vec4 c0 = blend.x * color0;
     vec4 c1 = blend.y * color1;
-    #if param_F_TWO_LAYER_BLEND == 0
+    #if F_TWO_LAYER_BLEND == 0
         // TODO: this blending is probably wrong
         vec4 c2 = blend.z * color2;
         vec4 c3 = blend.w * color3;
     #endif
 #endif
 
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     //Add up the result
     vec4 finalColor = c0 + c1 + c2 + c3;
 #else
@@ -149,8 +149,8 @@ void main()
     vec4 finalColor = c0 + c1;
 #endif
 
-#if param_F_NORMAL_MAP
-    #if param_F_TWO_LAYER_BLEND == 0
+#if F_NORMAL_MAP
+    #if F_TWO_LAYER_BLEND == 0
         //calculate blended normal
         vec4 bumpNormal = blend.x * normal0 + blend.y * normal1 + blend.z * normal2 + blend.w * normal3;
     #else
@@ -178,7 +178,7 @@ void main()
     //Get the direction from the fragment to the light - light position == camera position for now
     vec3 lightDirection = normalize(vLightPosition - vFragPosition);
 
-#if param_renderMode_FullBright == 1
+#if renderMode_FullBright == 1
     float illumination = 1.0;
 #else
     //Calculate half-lambert lighting
@@ -188,7 +188,7 @@ void main()
     illumination = min(illumination + 0.3, 1.0);
 #endif
 
-#if param_F_TWO_LAYER_BLEND == 0
+#if F_TWO_LAYER_BLEND == 0
     //Calculate specular
     vec4 blendSpecular = blend.x * specular0 + blend.y * specular1 + blend.z * specular2 + blend.w * specular3;
 #else
@@ -203,35 +203,35 @@ void main()
 
     outputColor = vec4(illumination * occludedColor.xyz + vec3(0.7) * specular, 1);
 
-#if param_renderMode_Color == 1
+#if renderMode_Color == 1
     outputColor = vec4(finalColor.rgb, 1.0);
 #endif
 
-#if param_renderMode_Terrain_Blend == 1
+#if renderMode_Terrain_Blend == 1
     outputColor = vec4(blend.xyz, 1.0);
 #endif
 
-#if param_renderMode_Ambient_Occlusion == 1
+#if renderMode_Ambient_Occlusion == 1
     outputColor = vec4(vWeightsOut2.xyz, 1.0);
 #endif
 
-#if param_renderMode_Normals == 1
+#if renderMode_Normals == 1
     outputColor = vec4(vNormalOut * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Tangents == 1 && param_F_NORMAL_MAP == 1
+#if renderMode_Tangents == 1 && F_NORMAL_MAP == 1
     outputColor = vec4(tangent * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_BumpMap == 1 && param_F_NORMAL_MAP == 1
+#if renderMode_BumpMap == 1 && F_NORMAL_MAP == 1
     outputColor = vec4(bumpNormal.xyz, 1.0);
 #endif
 
-#if param_renderMode_BumpNormals == 1
+#if renderMode_BumpNormals == 1
     outputColor = vec4(finalNormal * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Illumination == 1
+#if renderMode_Illumination == 1
     outputColor = vec4(illumination, 0.0, 0.0, 1.0);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/multiblend.frag
+++ b/GUI/Types/Renderer/Shaders/multiblend.frag
@@ -1,15 +1,9 @@
 #version 330
 
 // Render modes -- Switched on/off by code
-#define param_renderMode_FullBright 0
-#define param_renderMode_Color 0
+#include "common/rendermodes.glsl"
 #define param_renderMode_Terrain_Blend 0
 #define param_renderMode_Ambient_Occlusion 0
-#define param_renderMode_Normals 0
-#define param_renderMode_Tangents 0
-#define param_renderMode_BumpMap 0
-#define param_renderMode_BumpNormals 0
-#define param_renderMode_Illumination 0
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define param_F_TINT_MASK 0

--- a/GUI/Types/Renderer/Shaders/multiblend.vert
+++ b/GUI/Types/Renderer/Shaders/multiblend.vert
@@ -5,7 +5,7 @@
 //End of includes
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_fulltangent 1
+#define fulltangent 1
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
@@ -14,7 +14,9 @@ in vec2 vTEXCOORD;
 in vec4 vTEXCOORD1;
 in vec4 vTEXCOORD2;
 in vec4 vTEXCOORD3;
-in vec4 vTANGENT;
+#if fulltangent == 1
+    in vec4 vTANGENT;
+#endif
 in ivec4 vBLENDINDICES;
 in vec4 vBLENDWEIGHT;
 
@@ -40,7 +42,7 @@ void main()
     vFragPosition = fragPosition.xyz / fragPosition.w;
 
     //Unpack normals
-#if param_fulltangent == 1
+#if fulltangent == 1
     vNormalOut = vNORMAL.xyz;
 #else
     vNormalOut = DecompressNormal(vNORMAL);

--- a/GUI/Types/Renderer/Shaders/particle_sprite.frag
+++ b/GUI/Types/Renderer/Shaders/particle_sprite.frag
@@ -1,7 +1,7 @@
 #version 400
 
 // Render modes -- Switched on/off by code
-#define param_renderMode_Color 0
+#define renderMode_Color 0
 
 uniform sampler2D uTexture;
 uniform float uOverbrightFactor;
@@ -19,7 +19,7 @@ void main(void) {
 
     fragColor = vec4(finalColor, vColor.w * color.w * blendingFactor);
 
-#if param_renderMode_Color == 1
+#if renderMode_Color == 1
     fragColor = vec4(finalColor, 1.0);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/particle_trail.frag
+++ b/GUI/Types/Renderer/Shaders/particle_trail.frag
@@ -1,7 +1,7 @@
 #version 400
 
 // Render modes -- Switched on/off by code
-#define param_renderMode_Color 0
+#define renderMode_Color 0
 
 uniform vec3 uColor;
 uniform sampler2D uTexture;
@@ -24,7 +24,7 @@ void main(void) {
 
     fragColor = vec4(finalColor, uAlpha * color.w * blendingFactor);
 
-#if param_renderMode_Color == 1
+#if renderMode_Color == 1
     fragColor = vec4(finalColor, 1.0);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -1,14 +1,14 @@
 #version 330
 
-#define param_F_DEBUG_PICKER 0
+#define F_DEBUG_PICKER 0
 
-#define param_renderMode_ObjectId 0
-#define param_renderMode_MeshId 0
+#define renderMode_ObjectId 0
+#define renderMode_MeshId 0
 
 uniform uint sceneObjectId;
 uniform uint meshId;
 
-#if param_F_DEBUG_PICKER == 1
+#if F_DEBUG_PICKER == 1
     out vec4 outputColor;
 
     vec4 ColorFromId(uint id, uint offset)
@@ -23,9 +23,9 @@ uniform uint meshId;
 
     void main()
     {
-        #if param_renderMode_ObjectId == 1
+        #if renderMode_ObjectId == 1
             outputColor = ColorFromId(sceneObjectId, 0);
-        #elif param_renderMode_MeshId == 1
+        #elif renderMode_MeshId == 1
             outputColor = ColorFromId(meshId, 19);
         #endif
     }

--- a/GUI/Types/Renderer/Shaders/picking.frag
+++ b/GUI/Types/Renderer/Shaders/picking.frag
@@ -2,20 +2,37 @@
 
 #define param_F_DEBUG_PICKER 0
 
+#define param_renderMode_ObjectId 0
+#define param_renderMode_MeshId 0
+
 uniform uint sceneObjectId;
 uniform uint meshId;
 
 #if param_F_DEBUG_PICKER == 1
     out vec4 outputColor;
+
+    vec4 ColorFromId(uint id, uint offset)
+    {
+        return vec4(
+            fract(float(id + offset) / 7.0),
+            fract(float(id + offset) / 11.0),
+            fract(float(id + offset) / 13.0),
+            1.0
+        );
+    }
+
+    void main()
+    {
+        #if param_renderMode_ObjectId == 1
+            outputColor = ColorFromId(sceneObjectId, 0);
+        #elif param_renderMode_MeshId == 1
+            outputColor = ColorFromId(meshId, 19);
+        #endif
+    }
 #else
     out uvec2 outputColor;
+    void main()
+    {
+        outputColor = uvec2(sceneObjectId, meshId);
+    }
 #endif
-
-void main()
-{
-#if param_F_DEBUG_PICKER == 1
-    outputColor = vec4(fract(float(sceneObjectId) / 7.0), fract(float(sceneObjectId) / 11.0), fract(float(sceneObjectId) / 13.0), 1.0);
-#else
-    outputColor = uvec2(sceneObjectId, meshId);
-#endif
-}

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -1,13 +1,7 @@
 #version 330
 
 // Render modes -- Switched on/off by code
-#define param_renderMode_FullBright 0
-#define param_renderMode_Color 0
-#define param_renderMode_Normals 0
-#define param_renderMode_Tangents 0
-#define param_renderMode_BumpMap 0
-#define param_renderMode_BumpNormals 0
-#define param_renderMode_Illumination 0
+#include "common/rendermodes.glsl"
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define param_F_FULLBRIGHT 0

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -4,10 +4,10 @@
 #include "common/rendermodes.glsl"
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_F_FULLBRIGHT 0
-#define param_F_TINT_MASK 0
-#define param_F_ALPHA_TEST 0
-#define param_F_GLASS 0
+#define F_FULLBRIGHT 0
+#define F_TINT_MASK 0
+#define F_ALPHA_TEST 0
+#define F_GLASS 0
 #define param_HemiOctIsoRoughness_RG_B 0
 //End of parameter defines
 
@@ -37,7 +37,7 @@ uniform vec4 g_vColorTint;
 uniform float g_flAlphaTestReference = 0.5;
 
 // glass specific params
-#if param_F_GLASS == 1
+#if F_GLASS == 1
 uniform bool g_bFresnel = true;
 uniform float g_flEdgeColorFalloff = 3.0;
 uniform float g_flEdgeColorMaxOpacity = 0.5;
@@ -89,7 +89,7 @@ void main()
     //Get the ambient color from the color texture
     vec4 color = texture(g_tColor, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy);
 
-#if param_F_ALPHA_TEST == 1
+#if F_ALPHA_TEST == 1
     if (color.a < g_flAlphaTestReference)
     {
        discard;
@@ -103,7 +103,7 @@ void main()
     //Get the world normal for this fragment
     vec3 worldNormal = calculateWorldNormal();
 
-#if param_renderMode_FullBright == 1 || param_F_FULLBRIGHT == 1
+#if renderMode_FullBright == 1 || F_FULLBRIGHT == 1
     float illumination = 1.0;
 #else
     //Calculate lambert lighting
@@ -114,14 +114,14 @@ void main()
     //Calculate tint color
     vec3 tintColor = m_vTintColorSceneObject.xyz * m_vTintColorDrawCall;
 
-#if param_F_TINT_MASK == 1
+#if F_TINT_MASK == 1
     float tintStrength = texture(g_tTintMask, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordScale.xy).x;
     vec3 tintFactor = tintStrength * tintColor + (1 - tintStrength) * vec3(1);
 #else
     vec3 tintFactor = tintColor;
 #endif
 
-#if param_F_GLASS == 1
+#if F_GLASS == 1
     vec4 glassColor = vec4(illumination * color.rgb * g_vColorTint.rgb, color.a);
 
     float viewDotNormalInv = clamp(1.0 - (dot(viewDirection, worldNormal) - g_flEdgeColorThickness), 0.0, 1.0);
@@ -135,27 +135,27 @@ void main()
 #endif
 
     // Different render mode definitions
-#if param_renderMode_Color == 1
+#if renderMode_Color == 1
     outputColor = vec4(color.rgb, 1.0);
 #endif
 
-#if param_renderMode_BumpMap == 1
+#if renderMode_BumpMap == 1
     outputColor = texture(g_tNormal, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy);
 #endif
 
-#if param_renderMode_Tangents == 1
+#if renderMode_Tangents == 1
     outputColor = vec4(vTangentOut.xyz * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Normals == 1
+#if renderMode_Normals == 1
     outputColor = vec4(vNormalOut * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_BumpNormals == 1
+#if renderMode_BumpNormals == 1
     outputColor = vec4(worldNormal * vec3(0.5) + vec3(0.5), 1.0);
 #endif
 
-#if param_renderMode_Illumination == 1
+#if renderMode_Illumination == 1
     outputColor = vec4(illumination, illumination, illumination, 1.0);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -11,7 +11,7 @@
 #define F_TINT_MASK 0
 #define F_ALPHA_TEST 0
 #define F_GLASS 0
-#define param_HemiOctIsoRoughness_RG_B 0
+#define HemiOctIsoRoughness_RG_B 0
 //End of parameter defines
 
 in vec3 vFragPosition;
@@ -66,7 +66,7 @@ vec3 calculateWorldNormal()
     vec4 bumpNormal = texture(g_tNormal, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy);
 
     //Reconstruct the tangent vector from the map
-#if param_HemiOctIsoRoughness_RG_B == 1
+#if HemiOctIsoRoughness_RG_B == 1
     vec2 temp = vec2(bumpNormal.x + bumpNormal.y -1.003922, bumpNormal.x - bumpNormal.y);
     vec3 tangentNormal = oct_to_float32x3(temp);
 #else

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -2,6 +2,9 @@
 
 // Render modes -- Switched on/off by code
 #include "common/rendermodes.glsl"
+#define renderMode_VertexColor 0
+
+#define VERTEX_COLOR 1
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define F_FULLBRIGHT 0
@@ -17,6 +20,9 @@ in vec3 vNormalOut;
 in vec3 vTangentOut;
 in vec3 vBitangentOut;
 in vec2 vTexCoordOut;
+#if VERTEX_COLOR == 1
+    in vec4 vColorOut;
+#endif
 
 out vec4 outputColor;
 
@@ -157,5 +163,9 @@ void main()
 
 #if renderMode_Illumination == 1
     outputColor = vec4(illumination, illumination, illumination, 1.0);
+#endif
+
+#if renderMode_VertexColor == 1
+    outputColor = vColorOut == vec4(vec3(0), 1) ? outputColor : vColorOut;
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -14,6 +14,7 @@
 #define F_GLASS 0
 #define F_LAYERS 0
 #define F_FANCY_BLENDING 0
+#define simple_2way_blend 0
 #define HemiOctIsoRoughness_RG_B 0
 //End of parameter defines
 
@@ -115,7 +116,11 @@ void main()
     // 0: VertexBlend 1: BlendModulateTexture,rg 2: NewLayerBlending,g 3: NewLayerBlending,a
     #if (F_FANCY_BLENDING == 1)
         vec4 blendModTexel = texture(g_tBlendModulation, texCoord);
-        float blendModFactor = blendModTexel.r;
+        float blendModFactor = blendModTexel.g;
+        #if simple_2way_blend == 1
+            blendModFactor = blendModTexel.r;
+        #endif
+
         float minb = max(0, blendModFactor - g_flBlendSoftness);
         float maxb = min(1, blendModFactor + g_flBlendSoftness);
         blendFactor = smoothstep(minb, maxb, blendFactor);

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -22,12 +22,10 @@ in vec3 vFragPosition;
 in vec3 vNormalOut;
 in vec3 vTangentOut;
 in vec3 vBitangentOut;
-
 in vec2 vTexCoordOut;
 
 out vec4 outputColor;
 
-uniform float g_flAlphaTestReference;
 uniform sampler2D g_tColor;
 uniform sampler2D g_tNormal;
 uniform sampler2D g_tTintMask;
@@ -41,6 +39,8 @@ uniform vec3 m_vTintColorDrawCall;
 uniform vec4 g_vTexCoordOffset;
 uniform vec4 g_vTexCoordScale;
 uniform vec4 g_vColorTint;
+
+uniform float g_flAlphaTestReference = 0.5;
 
 // glass specific params
 #if param_F_GLASS == 1

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -6,17 +6,22 @@
 //End of includes
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define VERTEX_COLOR 1
 #define fulltangent 1
+#define F_VERTEX_COLOR 1
+#define F_LAYERS 0
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
-#if VERTEX_COLOR == 1
+#if F_LAYERS > 0
+    in vec4 vTEXCOORD3; // Real semantic index is 4
+    out vec4 vColorBlendValues;
+#endif
 #if fulltangent == 1
     in vec3 vTANGENT;
 #endif
+#if F_VERTEX_COLOR == 1
     in vec4 vCOLOR;
     out vec4 vColorOut;
 #endif
@@ -55,7 +60,12 @@ void main()
 
     vTexCoordOut = vTEXCOORD;
 
-#if VERTEX_COLOR == 1
+#if F_VERTEX_COLOR == 1
     vColorOut = vCOLOR;
 #endif
+
+#if F_LAYERS > 0
+    vColorBlendValues = vTEXCOORD3 / 255.0f;
+#endif
+
 }

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -6,15 +6,17 @@
 //End of includes
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_fulltangent 1
 #define VERTEX_COLOR 1
+#define fulltangent 1
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
-in vec4 vTANGENT;
 #if VERTEX_COLOR == 1
+#if fulltangent == 1
+    in vec3 vTANGENT;
+#endif
     in vec4 vCOLOR;
     out vec4 vColorOut;
 #endif
@@ -40,7 +42,7 @@ void main()
     mat3 normalTransform = transpose(inverse(mat3(skinTransform)));
 
     //Unpack normals
-#if param_fulltangent == 1
+#if fulltangent == 1
     vNormalOut = normalize(normalTransform * vNORMAL.xyz);
     vTangentOut = normalize(normalTransform * vTANGENT.xyz);
     vBitangentOut = cross(vNormalOut, vTangentOut);

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -7,12 +7,17 @@
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define param_fulltangent 1
+#define VERTEX_COLOR 1
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 in vec4 vTANGENT;
+#if VERTEX_COLOR == 1
+    in vec4 vCOLOR;
+    out vec4 vColorOut;
+#endif
 
 out vec3 vFragPosition;
 
@@ -47,4 +52,8 @@ void main()
 #endif
 
     vTexCoordOut = vTEXCOORD;
+
+#if VERTEX_COLOR == 1
+    vColorOut = vCOLOR;
+#endif
 }

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -7,15 +7,22 @@
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define fulltangent 1
-#define F_VERTEX_COLOR 1
+#define F_VERTEX_COLOR 0
 #define F_LAYERS 0
+#define simple_2way_blend 0
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
 in vec2 vTEXCOORD;
 #if F_LAYERS > 0
-    in vec4 vTEXCOORD3; // Real semantic index is 4
+    #if simple_2way_blend == 1
+        #define vBLEND_COLOR vTEXCOORD2
+    #else
+        // ligthtmappedgeneric - real semantic index is 4
+        #define vBLEND_COLOR vTEXCOORD3
+    #endif
+    in vec4 vBLEND_COLOR;
     out vec4 vColorBlendValues;
 #endif
 #if fulltangent == 1
@@ -65,7 +72,7 @@ void main()
 #endif
 
 #if F_LAYERS > 0
-    vColorBlendValues = vTEXCOORD3 / 255.0f;
+    vColorBlendValues = vBLEND_COLOR / 255.0f;
 #endif
 
 }

--- a/GUI/Types/Renderer/Shaders/sprite.frag
+++ b/GUI/Types/Renderer/Shaders/sprite.frag
@@ -1,7 +1,7 @@
 #version 330
 
 //Parameter defines - These are default values and can be overwritten based on material parameters
-#define param_F_ALPHA_TEST 0
+#define F_ALPHA_TEST 0
 //End of parameter defines
 
 in vec2 vTexCoordOut;
@@ -15,7 +15,7 @@ void main()
 {
     vec4 color = texture(g_tColor, vTexCoordOut);
 
-#if param_F_ALPHA_TEST == 1
+#if F_ALPHA_TEST == 1
     if (color.a < g_flAlphaTestReference)
     {
        discard;

--- a/GUI/Types/Renderer/Shaders/vr_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.frag
@@ -1,7 +1,7 @@
 #version 330
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_F_ALPHA_TEST 0
+#define F_ALPHA_TEST 0
 //End of parameter defines
 
 in vec3 vFragPosition;
@@ -28,7 +28,7 @@ void main()
     //Get the ambient color from the color texture
     vec4 color = texture(g_tColor2, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy) * vec4(m_vTintColorDrawCall.xyz, 1);
 
-#if param_F_ALPHA_TEST == 1
+#if F_ALPHA_TEST == 1
     if (color.a < g_flAlphaTestReference)
     {
        discard;

--- a/GUI/Types/Renderer/Shaders/water.vert
+++ b/GUI/Types/Renderer/Shaders/water.vert
@@ -5,7 +5,7 @@
 //End of includes
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
-#define param_fulltangent 1
+#define fulltangent 1
 //End of parameter defines
 
 layout (location = 0) in vec3 vPOSITION;
@@ -33,7 +33,7 @@ void main()
     vFragPosition = fragPosition.xyz / fragPosition.w;
 
     //Unpack normals
-#if param_fulltangent == 1
+#if fulltangent == 1
     vNormalOut = vNORMAL.xyz;
 #else
     vNormalOut = DecompressNormal(vNORMAL);

--- a/GUI/Types/Renderer/SpriteSceneNode.cs
+++ b/GUI/Types/Renderer/SpriteSceneNode.cs
@@ -21,7 +21,7 @@ namespace GUI.Types.Renderer
             : base(scene)
         {
             material = vrfGuiContext.MaterialLoader.LoadMaterial(resource);
-            shader = vrfGuiContext.ShaderLoader.LoadShader(material.Material.ShaderName, material.Material.GetShaderArguments());
+            shader = material.Shader;
 
             if (quadVao == 0)
             {

--- a/GUI/Types/Renderer/WorldNodeLoader.cs
+++ b/GUI/Types/Renderer/WorldNodeLoader.cs
@@ -115,20 +115,23 @@ namespace GUI.Types.Renderer
                 if (renderableModel != null)
                 {
                     var newResource = guiContext.LoadFileByAnyMeansNecessary(renderableModel + "_c");
-
                     if (newResource == null)
                     {
                         continue;
                     }
 
                     var layerIndex = sceneObject.GetIntegerProperty("m_nLayer");
-                    var modelNode = new ModelSceneNode(scene, (Model)newResource.DataBlock, null, false)
+                    var aggregate = new SceneAggregate(scene, (Model)newResource.DataBlock)
                     {
                         LayerName = worldLayers[layerIndex],
                         Name = renderableModel,
                     };
 
-                    scene.Add(modelNode, false);
+                    scene.Add(aggregate, false);
+                    foreach (var fragment in aggregate.CreateFragments(sceneObject.GetArray("m_aggregateMeshes")))
+                    {
+                        scene.Add(fragment, false);
+                    }
                 }
             }
         }

--- a/GUI/Types/Renderer/WorldNodeLoader.cs
+++ b/GUI/Types/Renderer/WorldNodeLoader.cs
@@ -128,7 +128,7 @@ namespace GUI.Types.Renderer
                     };
 
                     scene.Add(aggregate, false);
-                    foreach (var fragment in aggregate.CreateFragments(sceneObject.GetArray("m_aggregateMeshes")))
+                    foreach (var fragment in aggregate.CreateFragments(sceneObject))
                     {
                         scene.Add(fragment, false);
                     }

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -441,6 +441,14 @@ namespace GUI.Types.Viewers
                 {
                     Dock = DockStyle.Fill,
                 };
+                cubemapContainer.MouseWheel += (sender, args) =>
+                {
+                    var count = args.Delta > 0 ? -1 : 1;
+                    cubemapContainer.SelectedIndex = Math.Clamp(cubemapContainer.SelectedIndex + count,
+                        0,
+                        cubemapContainer.TabCount - 1
+                    );
+                };
 
                 var CUBEMAP_OFFSETS = new (float X, float Y)[]
                 {

--- a/GUI/Utils/VrfGuiContext.cs
+++ b/GUI/Utils/VrfGuiContext.cs
@@ -47,7 +47,11 @@ namespace GUI.Utils
         public Resource LoadFileByAnyMeansNecessary(string file) =>
             FileLoader.LoadFile(file);
 
-        public void ClearCache() => FileLoader.ClearCache();
+        public void ClearCache()
+        {
+            FileLoader.ClearCache();
+            //ShaderLoader.ClearCache();
+        }
 
         protected virtual void Dispose(bool disposing)
         {
@@ -62,6 +66,7 @@ namespace GUI.Utils
                 }
 
                 FileLoader.Dispose();
+                ShaderLoader.Dispose();
             }
         }
 

--- a/ValveResourceFormat/IO/MaterialExtract.cs
+++ b/ValveResourceFormat/IO/MaterialExtract.cs
@@ -459,6 +459,7 @@ public sealed class MaterialExtract
         var attributesThatAreSystemAttributes = new HashSet<string>
         {
             "physicssurfaceproperties",
+            "physicssurfaceproperties1",
             "physicssurfaceproperties2",
             "physicssurfaceproperties3",
             "physicssurfaceproperties4",

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -120,7 +120,7 @@ namespace ValveResourceFormat.ResourceTypes
             var hemiOctIsoRoughness_RG_B = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Mip HemiOctIsoRoughness_RG_B");
             if (hemiOctIsoRoughness_RG_B)
             {
-                arguments.Add("HemiOctIsoRoughness_RG_B", true);
+                arguments.Add("param_HemiOctIsoRoughness_RG_B", true);
             }
 
             if (ShaderName == "vr_glass.vfx")

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -123,7 +123,7 @@ namespace ValveResourceFormat.ResourceTypes
             var hemiOctIsoRoughness_RG_B = specialDeps.List.Any(dependancy => dependancy.CompilerIdentifier == "CompileTexture" && dependancy.String == "Texture Compiler Version Mip HemiOctIsoRoughness_RG_B");
             if (hemiOctIsoRoughness_RG_B)
             {
-                arguments.Add("param_HemiOctIsoRoughness_RG_B", true);
+                arguments.Add("HemiOctIsoRoughness_RG_B", true);
             }
 
             if (ShaderName == "vr_glass.vfx")

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -12,8 +12,8 @@ namespace ValveResourceFormat.ResourceTypes
 {
     public class Material : KeyValuesOrNTRO
     {
-        public string Name { get; set; }
-        public string ShaderName { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public string ShaderName { get; set; } = string.Empty;
 
         public Dictionary<string, long> IntParams { get; } = new Dictionary<string, long>();
         public Dictionary<string, float> FloatParams { get; } = new Dictionary<string, float>();
@@ -113,7 +113,10 @@ namespace ValveResourceFormat.ResourceTypes
                 var name = intParam.GetProperty<string>("m_name");
                 var value = intParam.GetIntegerProperty("m_nValue");
 
-                arguments.Add(name, value != 0);
+                if (name.StartsWith("F_", StringComparison.OrdinalIgnoreCase))
+                {
+                    arguments.Add(name, value != 0);
+                }
             }
 
             var specialDeps = (SpecialDependencies)Resource.EditInfo.Structs[ResourceEditInfo.REDIStruct.SpecialDependencies];

--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -131,6 +131,13 @@ namespace ValveResourceFormat.ResourceTypes
                 arguments.Add("F_GLASS", true);
             }
 
+            if (ShaderName.EndsWith("2way_blend.vfx", StringComparison.OrdinalIgnoreCase))
+            {
+                arguments.Add("F_LAYERS", true);
+                arguments.Add("F_FANCY_BLENDING", true);
+                arguments.Add("simple_2way_blend", true);
+            }
+
             return arguments;
         }
     }

--- a/ValveResourceFormat/Serialization/IKeyValueCollection.cs
+++ b/ValveResourceFormat/Serialization/IKeyValueCollection.cs
@@ -125,6 +125,19 @@ namespace ValveResourceFormat.Serialization
             return new Matrix4x4(column1.X, column2.X, column3.X, column4.X, column1.Y, column2.Y, column3.Y, column4.Y, column1.Z, column2.Z, column3.Z, column4.Z, column1.W, column2.W, column3.W, column4.W);
         }
 
+        public static Matrix4x4 ToMatrix4x4(this IKeyValueCollection array)
+        {
+            var column4 = array.Count() > 12
+                ? new Vector4(array.GetFloatProperty("12"), array.GetFloatProperty("13"), array.GetFloatProperty("14"), array.GetFloatProperty("15"))
+                : new Vector4(0, 0, 0, 1);
+            return new Matrix4x4(
+                array.GetFloatProperty("0"), array.GetFloatProperty("4"), array.GetFloatProperty("8"), column4.X,
+                array.GetFloatProperty("1"), array.GetFloatProperty("5"), array.GetFloatProperty("9"), column4.Y,
+                array.GetFloatProperty("2"), array.GetFloatProperty("6"), array.GetFloatProperty("10"), column4.Z,
+                array.GetFloatProperty("3"), array.GetFloatProperty("7"), array.GetFloatProperty("11"), column4.W
+            );
+        }
+
         public static string Print(this IKeyValueCollection collection) => PrintHelper(collection, 0);
 
         private static string PrintHelper(IKeyValueCollection collection, int indent)


### PR DESCRIPTION
Splitted aggregate draw call into individual scene objects, with accurate bbox for culling, which lowers the frame time.

Added a blend variant to the simple shader.
![image](https://github.com/SteamDatabase/ValveResourceFormat/assets/26466974/8d21edd7-0296-41b6-bc43-400fda2f186a)

Drawing overlays with a depth bias to fix z-fighting.
![image](https://github.com/SteamDatabase/ValveResourceFormat/assets/26466974/8965f85e-cc68-400e-ab64-80b44f8579e6)

Improved shader debug reloading, no longer creating one shader per material.

Made a custom sprite effects shader for CS2.

Renamed some defines in shaders for clarity.
