### PR TITLE
Shader mapping continuation

### DIFF
--- a/ValveResourceFormat/CompiledShader/PrintZFrameSummary.cs
+++ b/ValveResourceFormat/CompiledShader/PrintZFrameSummary.cs
@@ -147,17 +147,18 @@ namespace ValveResourceFormat.CompiledShader
                 "each configuration points to exactly one sequence. WRITESEQ[0] is always defined.");
 
             OutputFormatterTabulatedData tabulatedData = new(OutputWriter);
+            var emptyRow = new string[] { "", "", "", "", "" };
             tabulatedData.DefineHeaders(zframeFile.LeadingData.H0 > 0 ?
-                new string[] { "segment", "", nameof(WriteSeqField.Dest), nameof(WriteSeqField.Control) } :
-                new string[] { "", "", "", "" });
+                new string[] { "segment", "", nameof(WriteSeqField.Dest), nameof(WriteSeqField.Control), nameof(WriteSeqField.UnknBuff) } :
+                emptyRow);
             if (zframeFile.LeadingData.H0 > 0)
             {
-                tabulatedData.AddTabulatedRow(new string[] { "", "", "", "" });
+                tabulatedData.AddTabulatedRow(emptyRow);
             }
-            tabulatedData.AddTabulatedRow(new string[] { "WRITESEQ[0]", "", "", "" });
+            tabulatedData.AddTabulatedRow(new string[] { "WRITESEQ[0]", "", "", "", "" });
             var dataBlock0 = zframeFile.LeadingData;
             PrintParamWriteSequence(dataBlock0, tabulatedData);
-            tabulatedData.AddTabulatedRow(new string[] { "", "", "", "" });
+            tabulatedData.AddTabulatedRow(emptyRow);
 
             var lastSeq = writeSequences[-1];
             foreach (var item in writeSequences)
@@ -166,9 +167,9 @@ namespace ValveResourceFormat.CompiledShader
                 {
                     lastSeq = item.Value;
                     var dataBlock = zframeFile.DataBlocks[item.Key];
-                    tabulatedData.AddTabulatedRow(new string[] { $"WRITESEQ[{lastSeq}]", "", "", "" });
+                    tabulatedData.AddTabulatedRow(new string[] { $"WRITESEQ[{lastSeq}]", "", "", "", "" });
                     PrintParamWriteSequence(dataBlock, tabulatedData);
-                    tabulatedData.AddTabulatedRow(new string[] { "", "", "", "" });
+                    tabulatedData.AddTabulatedRow(emptyRow);
                 }
             }
             tabulatedData.PrintTabulatedValues(spacing: 2);
@@ -191,14 +192,15 @@ namespace ValveResourceFormat.CompiledShader
                     var field = segment[i];
                     var segmentDesc = i == 0 ? $"seg_{segId}" : "";
                     var paramDesc = $"[{field.ParamId}] {shaderFile.ParamBlocks[field.ParamId].Name}";
+                    var buffDesc = field.UnknBuff == 0x00 ? $"{"_",7}" : $"{field.UnknBuff,7}";
                     var arg1Desc = field.Dest == 0xff ? $"{"_",7}" : $"{field.Dest,7}";
                     var arg2Desc = field.Control == 0xff ? $"{"_",10}" : $"{field.Control,10}";
-                    tabulatedData.AddTabulatedRow(new string[] { segmentDesc, paramDesc, arg1Desc, arg2Desc });
+                    tabulatedData.AddTabulatedRow(new string[] { segmentDesc, paramDesc, arg1Desc, arg2Desc, buffDesc });
                 }
             }
             else
             {
-                tabulatedData.AddTabulatedRow(new string[] { $"seg_{segId}", "[empty]", "", "" });
+                tabulatedData.AddTabulatedRow(new string[] { $"seg_{segId}", "[empty]", "", "", "" });
             }
         }
 

--- a/ValveResourceFormat/CompiledShader/ShaderDataBlock.cs
+++ b/ValveResourceFormat/CompiledShader/ShaderDataBlock.cs
@@ -15,7 +15,7 @@ namespace ValveResourceFormat.CompiledShader
 
         protected static void ThrowIfNotSupported(int vcsFileVersion)
         {
-            if (vcsFileVersion != 62 && (vcsFileVersion < 64 || vcsFileVersion > 67))
+            if (vcsFileVersion != 62 && (vcsFileVersion < 64 || vcsFileVersion > 68))
             {
                 throw new UnexpectedMagicException($"Unsupported shader version, versions 67, 66, 65, 64 and 62 are supported",
                     vcsFileVersion, nameof(vcsFileVersion));

--- a/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
+++ b/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
@@ -57,13 +57,15 @@ namespace ValveResourceFormat.CompiledShader
             Arg3 = datareader.ReadInt32();
             Arg4 = datareader.ReadInt32();
             Arg5 = datareader.ReadInt32();
-            Arg6 = datareader.ReadInt32();
-
-            if (VcsFileVersion >= 64)
+            if (VcsFileVersion < 68)
             {
-                Arg7 = datareader.ReadInt32();
-            }
+                Arg6 = datareader.ReadInt32();
 
+                if (VcsFileVersion >= 64)
+                {
+                    Arg7 = datareader.ReadInt32();
+                }
+            }
             var modeCount = datareader.ReadInt32();
             for (var i = VcsAdditionalFiles.None; i < AdditionalFiles; i++)
             {
@@ -87,8 +89,12 @@ namespace ValveResourceFormat.CompiledShader
                 Modes.Add((name, shader, static_config));
             }
 
-            // Editor Id bytes, the length in-so-far is 16 bytes * (6 + AdditionalFiles + 1)
             var maxFileReference = (int)VcsProgramType.PixelShaderRenderState + (int)AdditionalFiles;
+            if (VcsFileVersion >= 68)
+            {
+                maxFileReference -= 2;
+            }
+
             for (var i = 0; i < maxFileReference; i++)
             {
                 EditorIDs.Add((datareader.ReadBytesAsString(16), $"// Editor ref {i} to program {(VcsProgramType)i}"));

--- a/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
+++ b/ValveResourceFormat/CompiledShader/ShaderDataBlocks.cs
@@ -289,7 +289,7 @@ namespace ValveResourceFormat.CompiledShader
         public int Arg0 { get; }
         public int RangeMin { get; }
         public int RangeMax { get; }
-        public int Arg3 { get; }
+        public int Arg3 { get; } // S_TOOLS_ENABLED = 1, S_SHADER_QUALITY = 2
         public int FeatureIndex { get; }
         public int Arg5 { get; }
         public List<string> CheckboxNames { get; } = new();

--- a/ValveResourceFormat/CompiledShader/ZFrameDataBlocks.cs
+++ b/ValveResourceFormat/CompiledShader/ZFrameDataBlocks.cs
@@ -39,13 +39,15 @@ namespace ValveResourceFormat.CompiledShader
 
     public class WriteSeqField : ShaderDataBlock
     {
-        public int ParamId { get; }
+        public byte ParamId { get; }
+        public byte UnknBuff { get; }
         public byte Dest { get; }
         public byte Control { get; }
 
         public WriteSeqField(ShaderDataReader datareader) : base(datareader)
         {
-            ParamId = datareader.ReadUInt16();
+            ParamId = datareader.ReadByte();
+            UnknBuff = datareader.ReadByte();
             Dest = datareader.ReadByte();
             Control = datareader.ReadByte();
         }

--- a/ValveResourceFormat/IO/ShaderExtract.cs
+++ b/ValveResourceFormat/IO/ShaderExtract.cs
@@ -343,6 +343,10 @@ public sealed class ShaderExtract
                     {
                         type = "float2";
                     }
+                    else if (symbol.Option == "PosXyz")
+                    {
+                        type = "float3";
+                    }
 
                     type = $"{type,-7}";
                 }


### PR DESCRIPTION
- [x] Make `TextureExtract.ToPngImageChannels` cover all possible ChannelMapping configurations, e.g swizzled (GA).
- [x] Fix variant parameter resolving on some edge cases i.e.
    > materials/skybox/sky_stars_01.vmat_c 
    > materials/rock/cliff_rock_003.vmat_c
    >Varying parameter 'g_tNormal' in 'vr_complex' could not be resolved. Features (F_UNLIT=1, F_MORPH_SUPPORTED=1, F_TRANSLUCENT=1)

