### PR TITLE
Add shader uniform utility functions

### DIFF
--- a/GUI/Types/Renderer/MaterialRenderer.cs
+++ b/GUI/Types/Renderer/MaterialRenderer.cs
@@ -1,8 +1,8 @@
 using System;
+using System.Numerics;
 using System.Collections.Generic;
 using System.Linq;
 using GUI.Utils;
-using OpenTK;
 using OpenTK.Graphics.OpenGL;
 using ValveResourceFormat;
 
@@ -81,31 +81,10 @@ namespace GUI.Types.Renderer
             GL.BindVertexArray(quadVao);
             GL.EnableVertexAttribArray(0);
 
-            var uniformLocation = shader.GetUniformLocation("m_vTintColorSceneObject");
-            if (uniformLocation > -1)
-            {
-                GL.Uniform4(uniformLocation, Vector4.One);
-            }
-
-            uniformLocation = shader.GetUniformLocation("m_vTintColorDrawCall");
-            if (uniformLocation > -1)
-            {
-                GL.Uniform3(uniformLocation, Vector3.One);
-            }
-
-            var identity = Matrix4.Identity;
-
-            uniformLocation = shader.GetUniformLocation("uProjectionViewMatrix");
-            if (uniformLocation > -1)
-            {
-                GL.UniformMatrix4(uniformLocation, false, ref identity);
-            }
-
-            uniformLocation = shader.GetUniformLocation("transform");
-            if (uniformLocation > -1)
-            {
-                GL.UniformMatrix4(uniformLocation, false, ref identity);
-            }
+            shader.SetUniform4("m_vTintColorSceneObject", Vector4.One);
+            shader.SetUniform3("m_vTintColorDrawCall", Vector3.One);
+            shader.SetUniform4x4("uProjectionViewMatrix", Matrix4x4.Identity);
+            shader.SetUniform4x4("transform", Matrix4x4.Identity);
 
             material.Render(shader);
 

--- a/GUI/Types/Renderer/MeshBatchRenderer.cs
+++ b/GUI/Types/Renderer/MeshBatchRenderer.cs
@@ -63,10 +63,10 @@ namespace GUI.Types.Renderer
         {
             GL.Enable(EnableCap.DepthTest);
 
-            var viewProjectionMatrix = context.Camera.ViewProjectionMatrix.ToOpenTK();
-            var cameraPosition = context.Camera.Location.ToOpenTK();
-            var dirLight = (context.GlobalLightTransform ?? context.Camera.CameraViewMatrix).ToOpenTK();
-            var dirLightColor = context.GlobalLightColor.ToOpenTK();
+            var viewProjectionMatrix = context.Camera.ViewProjectionMatrix;
+            var cameraPosition = context.Camera.Location;
+            var dirLight = (context.GlobalLightTransform ?? context.Camera.CameraViewMatrix);
+            var dirLightColor = context.GlobalLightColor;
 
             var groupedDrawCalls = context.ReplacementShader == null
                 ? drawCalls.GroupBy(a => a.Call.Shader)
@@ -91,17 +91,17 @@ namespace GUI.Types.Renderer
 
                 GL.UseProgram(shader.Program);
 
-                GL.UniformMatrix4(shader.GetUniformLocation("vLightPosition"), false, ref dirLight);
-                GL.Uniform4(shader.GetUniformLocation("vLightColor"), dirLightColor);
-                GL.Uniform3(shader.GetUniformLocation("vEyePosition"), cameraPosition);
-                GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref viewProjectionMatrix);
+                shader.SetUniform4x4("vLightPosition", dirLight);
+                shader.SetUniform4("vLightColor", dirLightColor);
+                shader.SetUniform3("vEyePosition", cameraPosition);
+                shader.SetUniform4x4("uProjectionViewMatrix", viewProjectionMatrix);
 
                 if (context.LightingInfo?.EnvMapPositionsUniform is not null)
                 {
                     var count = context.LightingInfo.EnvMaps.Count;
-                    GL.Uniform4(shader.GetUniformLocation("g_vEnvMapPositionWs"), count, context.LightingInfo.EnvMapPositionsUniform);
-                    GL.Uniform4(shader.GetUniformLocation("g_vEnvMapBoxMins"), count, context.LightingInfo.EnvMapMinsUniform);
-                    GL.Uniform4(shader.GetUniformLocation("g_vEnvMapBoxMaxs"), count, context.LightingInfo.EnvMapMaxsUniform);
+                    shader.SetUniform4Array("g_vEnvMapPositionWs", count, context.LightingInfo.EnvMapPositionsUniform);
+                    shader.SetUniform4Array("g_vEnvMapBoxMins", count, context.LightingInfo.EnvMapMinsUniform);
+                    shader.SetUniform4Array("g_vEnvMapBoxMaxs", count, context.LightingInfo.EnvMapMaxsUniform);
                 }
 
                 foreach (var materialGroup in shaderGroup.GroupBy(a => a.Call.Material))

--- a/GUI/Types/Renderer/OctreeDebugRenderer.cs
+++ b/GUI/Types/Renderer/OctreeDebugRenderer.cs
@@ -141,8 +141,7 @@ namespace GUI.Types.Renderer
                 GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
                 GL.UseProgram(shader.Program);
 
-                var projectionViewMatrix = camera.ViewProjectionMatrix.ToOpenTK();
-                GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref projectionViewMatrix);
+                shader.SetUniform4x4("uProjectionViewMatrix", camera.ViewProjectionMatrix);
 
                 GL.BindVertexArray(vaoHandle);
                 GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);

--- a/GUI/Types/Renderer/PhysSceneNode.cs
+++ b/GUI/Types/Renderer/PhysSceneNode.cs
@@ -332,11 +332,12 @@ namespace GUI.Types.Renderer
                 return;
             }
 
-            var viewProjectionMatrix = (Transform * context.Camera.ViewProjectionMatrix).ToOpenTK();
 
             GL.UseProgram(shader.Program);
 
-            GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref viewProjectionMatrix);
+            var viewProjectionMatrix = Transform * context.Camera.ViewProjectionMatrix;
+            shader.SetUniform4x4("uProjectionViewMatrix", viewProjectionMatrix);
+
             GL.DepthMask(false);
 
             GL.BindVertexArray(vaoHandle);

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -58,12 +58,7 @@ namespace GUI.Types.Renderer
             {
                 textures = Textures.Concat(lightingInfo.Lightmaps);
 
-                uniformLocation = shader.GetUniformLocation("g_vLightmapUvScale");
-
-                if (uniformLocation > -1)
-                {
-                    GL.Uniform2(uniformLocation, lightingInfo.LightmapUvScale.ToOpenTK());
-                }
+                shader.SetUniform2("g_vLightmapUvScale", lightingInfo.LightmapUvScale);
 
                 var lut = new KeyValuePair<string, RenderTexture>("g_tBRDFLookup", lightingInfo.BRDFLookup);
                 textures = textures.Append(lut);
@@ -71,36 +66,20 @@ namespace GUI.Types.Renderer
 
             foreach (var (name, texture) in textures)
             {
-                uniformLocation = shader.GetUniformLocation(name);
-
-                if (uniformLocation > -1)
+                if (shader.SetTexture(textureUnit, name, texture.Handle, texture.Target))
                 {
-                    GL.ActiveTexture(TextureUnit.Texture0 + textureUnit);
-                    GL.BindTexture(texture.Target, texture.Handle);
-                    GL.Uniform1(uniformLocation, textureUnit);
-
                     textureUnit++;
                 }
             }
 
             foreach (var param in Material.FloatParams)
             {
-                uniformLocation = shader.GetUniformLocation(param.Key);
-
-                if (uniformLocation > -1)
-                {
-                    GL.Uniform1(uniformLocation, param.Value);
-                }
+                shader.SetUniform1(param.Key, param.Value);
             }
 
             foreach (var param in Material.VectorParams)
             {
-                uniformLocation = shader.GetUniformLocation(param.Key);
-
-                if (uniformLocation > -1)
-                {
-                    GL.Uniform4(uniformLocation, param.Value.ToOpenTK());
-                }
+                shader.SetUniform4(param.Key, param.Value);
             }
 
             if (IsBlended)

--- a/GUI/Types/Renderer/RenderMaterial.cs
+++ b/GUI/Types/Renderer/RenderMaterial.cs
@@ -48,7 +48,6 @@ namespace GUI.Types.Renderer
         {
             //Start at 2, texture unit 0 is reserved for the animation texture, and 1 is reserved for the brdf lookup.
             var textureUnit = 2;
-            int uniformLocation;
 
             shader ??= this.shader;
 

--- a/GUI/Types/Renderer/SelectedNodeRenderer.cs
+++ b/GUI/Types/Renderer/SelectedNodeRenderer.cs
@@ -63,8 +63,7 @@ namespace GUI.Types.Renderer
             GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             GL.UseProgram(shader.Program);
 
-            var projectionViewMatrix = camera.ViewProjectionMatrix.ToOpenTK();
-            GL.UniformMatrix4(shader.GetUniformLocation("uProjectionViewMatrix"), false, ref projectionViewMatrix);
+            shader.SetUniform4x4("uProjectionViewMatrix", camera.ViewProjectionMatrix);
 
             GL.BindVertexArray(vaoHandle);
             GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);

--- a/GUI/Types/Renderer/Shader.cs
+++ b/GUI/Types/Renderer/Shader.cs
@@ -1,5 +1,8 @@
+using System;
+using System.Numerics;
 using System.Collections.Generic;
 using OpenTK.Graphics.OpenGL;
+using GUI.Utils;
 
 namespace GUI.Types.Renderer
 {
@@ -24,6 +27,130 @@ namespace GUI.Types.Renderer
             Uniforms[name] = value;
 
             return value;
+        }
+
+        // One caviat for these functions: they MUST be used when this shader is the active program.
+        public bool SetUniform1(string name, float value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform1(uniformLocation, value);
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform1(string name, bool value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform1(uniformLocation, value ? 1 : 0);
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform1(string name, int value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform1(uniformLocation, value);
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform2(string name, Vector2 value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform2(uniformLocation, value.ToOpenTK());
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform3(string name, Vector3 value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform3(uniformLocation, value.ToOpenTK());
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform4(string name, Vector4 value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform4(uniformLocation, value.ToOpenTK());
+            }
+
+            return uniformLocation > -1;
+        }
+        public bool SetUniform4Array(string name, int count, float[] value)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                GL.Uniform4(uniformLocation, count, value);
+            }
+
+            return uniformLocation > -1;
+        }
+
+        public bool SetUniform4x4(string name, Matrix4x4 value, bool transpose = false)
+        {
+            var uniformLocation = GetUniformLocation(name);
+            if (uniformLocation > -1)
+            {
+                var matrix = value.ToOpenTK();
+
+                GL.UniformMatrix4(uniformLocation, transpose, ref matrix);
+            }
+
+            return uniformLocation > -1;
+        }
+
+        public bool SetTexture(int slot, string name, int texture, TextureTarget target = TextureTarget.Texture2D)
+        {
+            var uniformLocation = GetUniformLocation(name);
+
+            if (uniformLocation > -1)
+            {
+                //Console.WriteLine($"Uniform Location {name}, slot {slot} (ID {texture}): {uniformLocation}");
+                GL.ActiveTexture(TextureUnit.Texture0 + slot);
+                GL.BindTexture(target, texture);
+                GL.Uniform1(uniformLocation, slot);
+            }
+
+            return uniformLocation > -1;
+        }
+
+        private bool hasBeenValidated { get; set; }
+        public void Validate()
+        {
+            if (!hasBeenValidated)
+            {
+                GL.ValidateProgram(Program);
+                GL.GetProgram(Program, GetProgramParameterName.ValidateStatus, out var validateStatus);
+
+                if (validateStatus != 1)
+                {
+                    GL.GetProgramInfoLog(Program, out var programLog);
+                    throw new InvalidProgramException($"Error validating shader \"{Name}\": {programLog}");
+                }
+                hasBeenValidated = true;
+            }
         }
     }
 }

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -348,7 +348,7 @@ void main()
 
     // Environment Map
     #if (S_SPECULAR == 1)
-        vec3 specular = F * GetEnvironment(N, V, roughness, F0, irradiance);
+        vec3 specular = GetEnvironment(N, V, roughness, F0, irradiance);
         outputColor.rgb += specular * occlusion;
     #endif
 

--- a/GUI/Types/Renderer/SpriteSceneNode.cs
+++ b/GUI/Types/Renderer/SpriteSceneNode.cs
@@ -58,12 +58,7 @@ namespace GUI.Types.Renderer
             var transformTk = Transform.ToOpenTK();
             GL.UniformMatrix4(renderShader.GetUniformLocation("transform"), false, ref test2);
 
-            var objectId = renderShader.GetUniformLocation("sceneObjectId");
-
-            if (objectId > -1)
-            {
-                GL.Uniform1(objectId, Id);
-            }
+            renderShader.SetUniform1("sceneObjectId", Id);
 
             material.Render(renderShader);
 


### PR DESCRIPTION
This is mostly just for cleaner code. This both reduces the number of visible "getuniformlocation" instances in code, as well as reducing the number of manual conversions to OpenTK.
All this should be done automatically now.