### PR TITLE
Support for multiple-select export

### DIFF
--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -143,23 +143,36 @@ namespace GUI.Forms
 
         public void QueueFiles(BetterTreeNode root)
         {
-            foreach (BetterTreeNode node in root.Nodes)
+            if (root.IsFolder)
             {
-                if (!node.IsFolder)
+                foreach (BetterTreeNode node in root.Nodes)
                 {
-                    var file = node.PackageEntry;
-                    if (decompile && filesToExtractSorted.TryGetValue(file.TypeName, out var specializedQueue))
+                    if (!node.IsFolder)
                     {
-                        specializedQueue.Enqueue(file);
-                        continue;
-                    }
+                        var file = node.PackageEntry;
+                        if (decompile && filesToExtractSorted.TryGetValue(file.TypeName, out var specializedQueue))
+                        {
+                            specializedQueue.Enqueue(file);
+                            continue;
+                        }
 
-                    filesToExtract.Enqueue(file);
+                        filesToExtract.Enqueue(file);
+                    }
+                    else
+                    {
+                        QueueFiles(node);
+                    }
                 }
-                else
+            }
+            else
+            {
+                var file = root.PackageEntry;
+                if (decompile && filesToExtractSorted.TryGetValue(file.TypeName, out var specializedQueue))
                 {
-                    QueueFiles(node);
+                    specializedQueue.Enqueue(file);
                 }
+
+                filesToExtract.Enqueue(file);
             }
         }
 

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -788,9 +788,14 @@ namespace GUI
             // Clicking context menu item in right side of the package view
             else if (owner.SourceControl is BetterListView listView)
             {
-                foreach (ListViewItem selectedNode in listView.SelectedItems)
+                if (listView.SelectedItems.Count > 1)
                 {
-                    ExportFile.ExtractFilesFromTreeNode((BetterTreeNode)selectedNode.Tag, listView.VrfGuiContext, decompile);
+                    // We're selecting multiple files
+                    ExportFile.ExtractFilesFromListViewNodes(listView.SelectedItems, listView.VrfGuiContext, decompile);
+                }
+                else
+                {
+                    ExportFile.ExtractFilesFromTreeNode((BetterTreeNode)listView.SelectedItems[0].Tag, listView.VrfGuiContext, decompile);
                 }
             }
             // Clicking context menu item when right clicking a tab

--- a/GUI/Types/Exporter/ExportFile.cs
+++ b/GUI/Types/Exporter/ExportFile.cs
@@ -154,5 +154,37 @@ namespace GUI.Types.Exporter
                 extractDialog.ShowDialog();
             }
         }
+
+        public static void ExtractFilesFromListViewNodes(BetterListView.SelectedListViewItemCollection items, VrfGuiContext vrfGuiContext, bool decompile)
+        {
+            using var dialog = new FolderBrowserDialog
+            {
+                InitialDirectory = Settings.Config.SaveDirectory,
+            };
+
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            Settings.Config.SaveDirectory = dialog.SelectedPath;
+            Settings.Save();
+
+            var exportData = new ExportData
+            {
+                VrfGuiContext = vrfGuiContext,
+            };
+
+            var extractDialog = new ExtractProgressForm(exportData, dialog.SelectedPath, decompile);
+
+            // When queuing files this way, it'll preserve the original tree
+            // which is probably unwanted behaviour? It works tho /shrug
+            foreach (ListViewItem item in items)
+            {
+                extractDialog.QueueFiles((BetterTreeNode)item.Tag);
+            }
+
+            extractDialog.ShowDialog();
+        }
     }
 }


### PR DESCRIPTION
- Add `ExportFile.ExtractFilesFromListViewNodes`
- Handle non-folder nodes being passed into `ExtractProgressForm.QueueFiles`

As mentioned in comments, the potential issue with this is that the exported files will preserve the original tree instead of being placed directly in the folder the user asks for.

Alternatively `ExtractFileFromStream` could be used for nodes that are files, but I would've had to rip out the dialog popup inside it, or make it optional or something which is probably not as clean

Addresses #180/#531
