### PR TITLE
Implement Material Struct, many shading updates

### DIFF
--- a/GUI/Types/Renderer/MaterialLoader.cs
+++ b/GUI/Types/Renderer/MaterialLoader.cs
@@ -31,6 +31,7 @@ namespace GUI.Types.Renderer
             ["g_tColor"] = new[] { "g_tColor2", "g_tColor1", "g_tColorA", "g_tColorB", "g_tColorC", "g_tGlassDust" },
             ["g_tNormal"] = new[] { "g_tNormalA", "g_tNormalRoughness", "g_tLayer1NormalRoughness" },
             ["g_tLayer2NormalRoughness"] = new[] { "g_tNormalB" },
+            ["g_tAmbientOcclusion"] = new[] { "g_tLayer1AmbientOcclusion" },
         };
 
         public MaterialLoader(VrfGuiContext guiContext)

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -328,25 +328,6 @@ namespace GUI.Types.Renderer
                         .ThenBy((envMap) => Vector3.Distance(lightingOrigin, envMap.BoundingBox.Center))
                         .ToList();
                 }
-
-#if DEBUG
-                if (node.CubeMapPrecomputedHandshake != 0)
-                {
-                    var vrfCalculated = node.EnvMaps.FirstOrDefault();
-                    var preCalculated = LightingInfo.EnvMaps[node.CubeMapPrecomputedHandshake];
-                    if (vrfCalculated is null)
-                    {
-                        Console.WriteLine($"Vrf couldn't find any envmaps for node at {node.BoundingBox.Center}. Valve precalculated envmap is at {preCalculated.BoundingBox.Center} [{node.CubeMapPrecomputedHandshake}]");
-                        continue;
-                    }
-
-                    var vrfDistance = Vector3.Distance(lightingOrigin, vrfCalculated.BoundingBox.Center);
-                    var precalculatedDistance = Vector3.Distance(lightingOrigin, LightingInfo.EnvMaps[node.CubeMapPrecomputedHandshake].BoundingBox.Center);
-
-                    Console.WriteLine($"Vrf calculated envmap doesn't match with the precalculated one" +
-                        $" (dists: vrf={vrfDistance} s2={precalculatedDistance}) for node at {node.BoundingBox.Center} [{node.CubeMapPrecomputedHandshake}]");
-                }
-#endif
             }
         }
     }

--- a/GUI/Types/Renderer/Scene.cs
+++ b/GUI/Types/Renderer/Scene.cs
@@ -328,6 +328,25 @@ namespace GUI.Types.Renderer
                         .ThenBy((envMap) => Vector3.Distance(lightingOrigin, envMap.BoundingBox.Center))
                         .ToList();
                 }
+
+#if DEBUG
+                if (node.CubeMapPrecomputedHandshake != 0)
+                {
+                    var vrfCalculated = node.EnvMaps.FirstOrDefault();
+                    var preCalculated = LightingInfo.EnvMaps[node.CubeMapPrecomputedHandshake];
+                    if (vrfCalculated is null)
+                    {
+                        Console.WriteLine($"Vrf couldn't find any envmaps for node at {node.BoundingBox.Center}. Valve precalculated envmap is at {preCalculated.BoundingBox.Center} [{node.CubeMapPrecomputedHandshake}]");
+                        continue;
+                    }
+
+                    var vrfDistance = Vector3.Distance(lightingOrigin, vrfCalculated.BoundingBox.Center);
+                    var precalculatedDistance = Vector3.Distance(lightingOrigin, LightingInfo.EnvMaps[node.CubeMapPrecomputedHandshake].BoundingBox.Center);
+
+                    Console.WriteLine($"Vrf calculated envmap doesn't match with the precalculated one" +
+                        $" (dists: vrf={vrfDistance} s2={precalculatedDistance}) for node at {node.BoundingBox.Center} [{node.CubeMapPrecomputedHandshake}]");
+                }
+#endif
             }
         }
     }

--- a/GUI/Types/Renderer/Shaders/common/environment.glsl
+++ b/GUI/Types/Renderer/Shaders/common/environment.glsl
@@ -27,8 +27,6 @@ float GetEnvMapLOD(float roughness, vec3 R, vec4 extraParams)
 }
 
 // Cubemap Normalization
-// Used in HLA, maybe later vr renderer games too.
-// Further explanation here: https://ubm-twvideo01.s3.amazonaws.com/o1/vault/gdc2019/presentations/Hobson_Josh_The_Indirect_Lighting.pdf
 #define bUseCubemapNormalization 0
 const vec2 CubemapNormalizationParams = vec2(34.44445, -2.44445); // Normalization value in Alyx. Haven't checked the other games
 
@@ -131,7 +129,7 @@ vec3 GetEnvironment(vec3 N, vec3 V, float rough, vec3 specColor, vec3 irradiance
             float weight = ((distanceFromEdge * distanceFromEdge) * (3.0 - (2.0 * distanceFromEdge))) * (1.0 - totalWeight);
             totalWeight += weight;
 
-            // blend
+            // blend reflection vector from roughness
             #if (F_CLOTH_SHADING == 1)
                 coords.xyz = mix(coords.xyz, localReflectionVector, sqrt(rough));
             #else
@@ -147,7 +145,7 @@ vec3 GetEnvironment(vec3 N, vec3 V, float rough, vec3 specColor, vec3 irradiance
         }
     #endif
 
-#if renderMode_Cubemaps == 1
+#if (renderMode_Cubemaps == 1)
     return envMap;
 #else
     vec3 brdf = EnvBRDF(specColor, rough, N, V);

--- a/GUI/Types/Renderer/Shaders/common/environment.glsl
+++ b/GUI/Types/Renderer/Shaders/common/environment.glsl
@@ -16,6 +16,9 @@
 
 float GetEnvMapLOD(float roughness, vec3 R, vec4 extraParams)
 {
+#if (renderMode_Cubemaps == 1)
+    return 0.0;
+#else
     float EnvMapMipCount = g_vEnvMapSizeConstants.x;
 
     #if F_CLOTH_SHADING == 1
@@ -24,6 +27,7 @@ float GetEnvMapLOD(float roughness, vec3 R, vec4 extraParams)
     #else
         return roughness * EnvMapMipCount;
     #endif
+#endif
 }
 
 // Cubemap Normalization
@@ -76,8 +80,14 @@ vec3 GetEnvironment(MaterialProperties_t mat, LightingTerms_t lighting)
         return g_vClearColor.rgb;
     #else
 
+#if (renderMode_Cubemaps == 1)
+    vec3 normal = mat.GeometricNormal;
+#else
+    vec3 normal = mat.AmbientNormal;
+#endif
+
     // Reflection Vector
-    vec3 R = normalize(reflect(-mat.ViewDir, mat.AmbientNormal));
+    vec3 R = normalize(reflect(-mat.ViewDir, normal));
 
     float lod = GetEnvMapLOD(mat.Roughness, R, mat.ExtraParams);
 
@@ -129,7 +139,7 @@ vec3 GetEnvironment(MaterialProperties_t mat, LightingTerms_t lighting)
             float weight = ((distanceFromEdge * distanceFromEdge) * (3.0 - (2.0 * distanceFromEdge))) * (1.0 - totalWeight);
             totalWeight += weight;
 
-            #if rendermode_Cubemaps == 0
+            #if renderMode_Cubemaps == 0
                 // blend
                 #if (F_CLOTH_SHADING == 1)
                     coords.xyz = mix(coords.xyz, localReflectionVector, sqrt(mat.Roughness));

--- a/GUI/Types/Renderer/Shaders/common/lighting.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting.glsl
@@ -88,6 +88,8 @@ uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 uniform vec4 g_vLightmapParams = vec4(0.0); // ???? directional non-intensity?? it's set to 0.0 in all places ive looked
 
+#define colorSpaceMul 0.996190845966339111328125 // 254/255
+
 // I don't actually understand much of this, but it's Valve's code.
 vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3 normalMap)
 {
@@ -100,6 +102,8 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3
     float sinTheta = dot(vTangentSpaceLightVector.xy, vTangentSpaceLightVector.xy);
 
 #if LightmapGameVersionNumber == 1
+    vTangentSpaceLightVector *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceLightVector.xy)));
+
     // Error in HLA code, fixed in DeskJob
     float cosTheta = 1.0 - sqrt(sinTheta);
 #else

--- a/GUI/Types/Renderer/Shaders/common/lighting.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting.glsl
@@ -1,23 +1,25 @@
-struct LightingTerms
-{
-    vec3 DiffuseDirect;
-    vec3 DiffuseIndirect;
-    vec3 SpecularDirect;
-    vec3 SpecularIndirect;
-#if defined(hasTransmission)
-    vec3 TransmissiveDirect;
+#if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1)
+    in vec3 vLightmapUVScaled;
+    uniform sampler2DArray g_tIrradiance;
+    uniform sampler2DArray g_tDirectionalIrradiance;
+    #if (LightmapGameVersionNumber == 1)
+        uniform sampler2DArray g_tDirectLightIndices;
+        uniform sampler2DArray g_tDirectLightStrengths;
+    #elif (LightmapGameVersionNumber == 2)
+        uniform sampler2DArray g_tDirectLightShadows;
+    #endif
+#elif (D_BAKED_LIGHTING_FROM_VERTEX_STREAM == 1)
+    in vec4 vPerVertexLightingOut;
+#elif (D_BAKED_LIGHTING_FROM_LIGHTPROBE == 1)
+    uniform sampler2D g_tLPV_Irradiance;
+    #if (LightmapGameVersionNumber == 1)
+        uniform sampler2D g_tLPV_Indices;
+        uniform sampler2D g_tLPV_Scalars;
+    #elif (LightmapGameVersionNumber == 2)
+        uniform sampler2D g_tLPV_Shadows;
+    #endif
 #endif
-    float SpecularOcclusion; // Lightmap AO
-};
 
-LightingTerms InitLighting()
-{
-#if defined(hasTransmission) // temp
-    return LightingTerms(vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), 1.0);
-#else
-    return LightingTerms(vec3(0), vec3(0), vec3(0), vec3(0), 1.0);
-#endif
-}
 
 
 uniform mat4 vLightPosition;
@@ -32,6 +34,59 @@ vec3 getSunColor()
 {
     return vLightColor.rgb; //pow(vLightColor.rgb, vec3(2.2)) * pow(vLightColor.a, 0.5);
 }
+
+
+
+
+
+
+
+
+
+
+void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialProperties_t mat)
+{
+    vec3 L = normalize(-getSunDir());
+    vec3 H = normalize(mat.ViewDir + L);
+
+
+
+    // Lighting
+    float visibility = 1.0;
+
+#if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1)
+    #if (LightmapGameVersionNumber == 1)
+        vec4 vLightStrengths = texture(g_tDirectLightStrengths, vLightmapUVScaled);
+        vec4 strengthSquared = pow2(vLightStrengths);
+        vec4 vLightIndices = texture(g_tDirectLightIndices, vLightmapUVScaled) * 255;
+        // TODO: figure this out, it's barely working
+        float index = 0.0;
+        if (vLightIndices.r == index) visibility = strengthSquared.r;
+        else if (vLightIndices.g == index) visibility = strengthSquared.g;
+        else if (vLightIndices.b == index) visibility = strengthSquared.b;
+        else if (vLightIndices.a == index) visibility = strengthSquared.a;
+        else visibility = 0.0;
+
+    #elif (LightmapGameVersionNumber == 2)
+        visibility = 1 - texture(g_tDirectLightShadows, vLightmapUVScaled).r;
+    #endif
+#endif
+
+    if (visibility > 0.0)
+    {
+        vec3 specularLight = specularLighting(L, mat.ViewDir, mat.Normal, mat.SpecularColor, mat.Roughness, mat.ExtraParams);
+#if defined(useDiffuseWrap)
+        vec3 diffuseLight = diffuseWrapped(mat.Normal, L);
+#else
+        float diffuseLight = diffuseLobe(max(dot(mat.Normal, L), 0.0), mat.Roughness);
+#endif
+        lighting.SpecularDirect += specularLight * visibility * getSunColor();
+        lighting.DiffuseDirect += diffuseLight * visibility * getSunColor();
+    }
+
+}
+
+
 
 
 
@@ -77,3 +132,53 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3
 }
 
 #endif
+
+
+
+
+void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialProperties_t mat)
+{
+    lighting.DiffuseIndirect = vec3(0.3);
+
+    // Indirect Lighting
+#if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1) && (LightmapGameVersionNumber > 0)
+    vec3 irradiance = texture(g_tIrradiance, vLightmapUVScaled).rgb;
+    vec4 vAHDData = texture(g_tDirectionalIrradiance, vLightmapUVScaled);
+
+    lighting.DiffuseIndirect = ComputeLightmapShading(irradiance, vAHDData, mat.NormalMap);
+
+    // In non-lightmap shaders, SpecularAO always does a min(1.0, specularAO) in the same place where lightmap
+    // shaders does min(bakedAO, specularAO). That means that bakedAO exists and is a constant 1.0 in those shaders!
+    mat.SpecularAO = min(mat.SpecularAO, vAHDData.a);
+#elif (D_BAKED_LIGHTING_FROM_VERTEX_STREAM == 1)
+    lighting.DiffuseIndirect = vPerVertexLightingOut.rgb;
+#endif
+
+
+    // Environment Maps
+#if (S_SPECULAR == 1)
+    lighting.SpecularIndirect = GetEnvironment(mat, lighting);
+#endif
+}
+
+
+
+
+uniform float g_flAmbientOcclusionDirectDiffuse = 1.0;
+uniform float g_flAmbientOcclusionDirectSpecular = 1.0;
+
+// AO Proxies would be merged here
+void ApplyAmbientOcclusion(inout LightingTerms_t o, MaterialProperties_t mat)
+{
+#if defined(DIFFUSE_AO_COLOR_BLEED)
+    SetDiffuseColorBleed(mat);
+#endif
+
+    vec3 DirectAODiffuse = mix(vec3(1.0), mat.DiffuseAO, g_flAmbientOcclusionDirectDiffuse);
+    float DirectAOSpecular = mix(1.0, mat.SpecularAO, g_flAmbientOcclusionDirectSpecular);
+
+    o.DiffuseDirect *= DirectAODiffuse;
+    o.DiffuseIndirect *= mat.DiffuseAO;
+    o.SpecularDirect *= DirectAOSpecular;
+    o.SpecularIndirect *= mat.SpecularAO;
+}

--- a/GUI/Types/Renderer/Shaders/common/lighting.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting.glsl
@@ -136,9 +136,8 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
 
     lighting.DiffuseIndirect = ComputeLightmapShading(irradiance, vAHDData, mat.NormalMap);
 
-    // In non-lightmap shaders, SpecularAO always does a min(1.0, specularAO) in the same place where lightmap
-    // shaders does min(bakedAO, specularAO). That means that bakedAO exists and is a constant 1.0 in those shaders!
-    mat.SpecularAO = min(mat.SpecularAO, vAHDData.a);
+    lighting.SpecularOcclusion = vAHDData.a;
+
 #elif (D_BAKED_LIGHTING_FROM_VERTEX_STREAM == 1)
     lighting.DiffuseIndirect = vPerVertexLightingOut.rgb;
 #endif
@@ -162,6 +161,10 @@ void ApplyAmbientOcclusion(inout LightingTerms_t o, MaterialProperties_t mat)
 #if defined(DIFFUSE_AO_COLOR_BLEED)
     SetDiffuseColorBleed(mat);
 #endif
+
+    // In non-lightmap shaders, SpecularAO always does a min(1.0, specularAO) in the same place where lightmap
+    // shaders does min(bakedAO, specularAO). That means that bakedAO exists and is a constant 1.0 in those shaders!
+    mat.SpecularAO = min(o.SpecularOcclusion, mat.SpecularAO);
 
     vec3 DirectAODiffuse = mix(vec3(1.0), mat.DiffuseAO, g_flAmbientOcclusionDirectDiffuse);
     float DirectAOSpecular = mix(1.0, mat.SpecularAO, g_flAmbientOcclusionDirectSpecular);

--- a/GUI/Types/Renderer/Shaders/common/lighting.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting.glsl
@@ -39,16 +39,10 @@ vec3 getSunColor()
 
 
 
-
-
-
-
-
+// This should contain our direct lighting loop
 void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialProperties_t mat)
 {
-    vec3 L = normalize(-getSunDir());
-    vec3 H = normalize(mat.ViewDir + L);
-
+    vec3 lightVector = normalize(-getSunDir());
 
 
     // Lighting
@@ -72,19 +66,14 @@ void CalculateDirectLighting(inout LightingTerms_t lighting, inout MaterialPrope
     #endif
 #endif
 
+    vec3 lightColor = visibility * getSunColor();
     if (visibility > 0.0)
     {
-        vec3 specularLight = specularLighting(L, mat.ViewDir, mat.Normal, mat.SpecularColor, mat.Roughness, mat.ExtraParams);
-#if defined(useDiffuseWrap)
-        vec3 diffuseLight = diffuseWrapped(mat.Normal, L);
-#else
-        float diffuseLight = diffuseLobe(max(dot(mat.Normal, L), 0.0), mat.Roughness);
-#endif
-        lighting.SpecularDirect += specularLight * visibility * getSunColor();
-        lighting.DiffuseDirect += diffuseLight * visibility * getSunColor();
+        CalculateShading(lighting, lightVector, vec3(visibility), mat);
     }
-
 }
+
+
 
 
 

--- a/GUI/Types/Renderer/Shaders/common/lighting.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting.glsl
@@ -88,7 +88,7 @@ uniform float g_flDirectionalLightmapStrength = 1.0;
 uniform float g_flDirectionalLightmapMinZ = 0.05;
 uniform vec4 g_vLightmapParams = vec4(0.0); // ???? directional non-intensity?? it's set to 0.0 in all places ive looked
 
-#define colorSpaceMul 0.996190845966339111328125 // 254/255
+const float colorSpaceMul = 254 / 255;
 
 // I don't actually understand much of this, but it's Valve's code.
 vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3 normalMap)
@@ -102,11 +102,11 @@ vec3 ComputeLightmapShading(vec3 irradianceColor, vec4 irradianceDirection, vec3
     float sinTheta = dot(vTangentSpaceLightVector.xy, vTangentSpaceLightVector.xy);
 
 #if LightmapGameVersionNumber == 1
-    vTangentSpaceLightVector *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceLightVector.xy)));
-
     // Error in HLA code, fixed in DeskJob
     float cosTheta = 1.0 - sqrt(sinTheta);
 #else
+    vTangentSpaceLightVector *= (colorSpaceMul / max(colorSpaceMul, length(vTangentSpaceLightVector.xy)));
+
     float cosTheta = sqrt(1.0 - sinTheta);
 #endif
     vTangentSpaceLightVector.z = cosTheta;
@@ -148,7 +148,7 @@ void CalculateIndirectLighting(inout LightingTerms_t lighting, inout MaterialPro
 
 
     // Environment Maps
-#if (S_SPECULAR == 1)
+#if defined(S_SPECULAR) && (S_SPECULAR == 1)
     lighting.SpecularIndirect = GetEnvironment(mat, lighting);
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/common/lighting_common.glsl
+++ b/GUI/Types/Renderer/Shaders/common/lighting_common.glsl
@@ -1,0 +1,22 @@
+// Todo: include all lighting glsl files within lighting.glsl, so it's only one include.
+// That would make the order of includes less important and easier to understand/maintain.
+struct LightingTerms_t
+{
+    vec3 DiffuseDirect;
+    vec3 DiffuseIndirect;
+    vec3 SpecularDirect;
+    vec3 SpecularIndirect;
+#if defined(hasTransmission)
+    vec3 TransmissiveDirect;
+#endif
+    float SpecularOcclusion; // Lightmap AO
+};
+
+LightingTerms_t InitLighting()
+{
+#if defined(hasTransmission) // temp
+    return LightingTerms_t(vec3(0), vec3(0), vec3(0), vec3(0), vec3(0), 1.0);
+#else
+    return LightingTerms_t(vec3(0), vec3(0), vec3(0), vec3(0), 1.0);
+#endif
+}

--- a/GUI/Types/Renderer/Shaders/common/pbr.glsl
+++ b/GUI/Types/Renderer/Shaders/common/pbr.glsl
@@ -10,6 +10,29 @@ float diffuseLobe(float NoL, float roughness)
 }
 
 
+#if (F_DIFFUSE_WRAP == 1) || (F_DIFFSUE_WRAP == 1) || defined(vr_xen_foliage) || defined(vr_eyeball)
+#define useDiffuseWrap
+#endif
+
+#if defined(useDiffuseWrap)
+// Used in vr_xen_foliage, vr_eyeball (not supported yet bc alt param names), and optionally in vr_complex
+uniform float g_flDiffuseExponent = 1.0;
+uniform float g_flDiffuseWrap = 1.0;
+uniform vec4 g_vDiffuseWrapColor = vec4(1.0, 0.5, 0.3, 0.0); // 1.0, 0.5, 0.3 -> srgbtolinear
+
+vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
+{
+
+    float NoL = dot(vNormal, vLightVector); //r9.w
+    float thing = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
+    float DiffuseWrapLighting = pow(thing, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
+    return mix(vec3(saturate(NoL)), vec3(DiffuseWrapLighting), g_vDiffuseWrapColor.rgb);
+}
+#endif
+
+
+
+
 
 // Normal Distribution function --------------------------------------
 float D_GGX(float NoH, float roughness)

--- a/GUI/Types/Renderer/Shaders/common/pbr.glsl
+++ b/GUI/Types/Renderer/Shaders/common/pbr.glsl
@@ -22,7 +22,6 @@ uniform vec4 g_vDiffuseWrapColor = vec4(1.0, 0.5, 0.3, 0.0); // 1.0, 0.5, 0.3 ->
 
 vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
 {
-
     float NoL = dot(vNormal, vLightVector);
     float diffuseWrapDenom = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
     float DiffuseWrapLighting = pow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
@@ -35,6 +34,7 @@ vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
 
 
 // Normal Distribution function --------------------------------------
+// D = Normal distribution (Distribution of the microfacets)
 float D_GGX(float NoH, float roughness)
 {
 	float alpha = pow2(roughness);
@@ -44,6 +44,7 @@ float D_GGX(float NoH, float roughness)
 
 
 // Geometric Shadowing visibility function --------------------------------------
+	// G = Geometric shadowing term (Microfacets shadowing)
 float G_SchlickSmithGGX(float NoL, float NoV, float roughness)
 {
     float VisRough = pow2(roughness + 1.0) / 8.0;
@@ -54,6 +55,7 @@ float G_SchlickSmithGGX(float NoL, float NoV, float roughness)
 }
 
 // Fresnel function ----------------------------------------------------
+// F = Fresnel factor (Reflectance depending on angle of incidence)
 float F_Schlick(float F0, float F90, float VoH)
 {
     return mix(F0, F90, pow(1.0 - VoH, 5.0));
@@ -123,11 +125,8 @@ vec3 specularLighting(vec3 L, vec3 V, vec3 N, vec3 specularColor, float roughnes
 #if defined(vr_complex) && (F_CLOTH_SHADING == 1)
     return SpecularCloth(roughness, NoL, NoH, NoV, VoH, specularColor);
 #endif
-    // D = Normal distribution (Distribution of the microfacets)
 	float NDF = D_GGX(NoH, roughness); 
-	// G = Geometric shadowing term (Microfacets shadowing)
 	float Vis = G_SchlickSmithGGX(NoL, NoV, roughness);
-	// F = Fresnel factor (Reflectance depending on angle of incidence)
 	vec3 F = F_Schlick(VoH, specularColor);
 
 #if (F_CLOTH_SHADING == 1)

--- a/GUI/Types/Renderer/Shaders/common/pbr.glsl
+++ b/GUI/Types/Renderer/Shaders/common/pbr.glsl
@@ -23,9 +23,9 @@ uniform vec4 g_vDiffuseWrapColor = vec4(1.0, 0.5, 0.3, 0.0); // 1.0, 0.5, 0.3 ->
 vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
 {
 
-    float NoL = dot(vNormal, vLightVector); //r9.w
-    float thing = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
-    float DiffuseWrapLighting = pow(thing, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
+    float NoL = dot(vNormal, vLightVector);
+    float diffuseWrapDenom = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
+    float DiffuseWrapLighting = pow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
     return mix(vec3(saturate(NoL)), vec3(DiffuseWrapLighting), g_vDiffuseWrapColor.rgb);
 }
 #endif

--- a/GUI/Types/Renderer/Shaders/common/pbr.glsl
+++ b/GUI/Types/Renderer/Shaders/common/pbr.glsl
@@ -7,14 +7,12 @@
 
 float diffuseLobe(float NoL, float roughness)
 {
-    // Pi is never factored into any lighting calculations in Source 2, for some reason (as of HLA)
     float diffuseExponent = (1.0 - roughness) * 0.8 + 0.6;
     return pow(NoL, diffuseExponent) * ((diffuseExponent + 1.0) / 2.0);
-    //return diffuse * (1.0 / PI);
 }
 
 
-#if (F_DIFFUSE_WRAP == 1) || (F_DIFFSUE_WRAP == 1) || defined(vr_xen_foliage) || defined(vr_eyeball)
+#if (F_DIFFUSE_WRAP == 1) || (F_DIFFSUE_WRAP == 1) || defined(vr_xen_foliage)
 // idea: what if we included individual features in tiny files per feature. they would all be used in #includes
 #define useDiffuseWrap
 
@@ -68,7 +66,7 @@ float D_AnisoGGX(vec2 roughness, vec3 halfVector, vec3 normal, vec3 tangent, vec
     vec3 Dots;
     Dots.x = dot(halfVector, tangent);
     Dots.y = dot(halfVector, bitangent);
-    Dots.z = dot(halfVector, normal); // this uses the actual optional normal though???
+    Dots.z = dot(halfVector, normal);
 
     Dots /= vec3(alpha, 1.0);
     float ndf = pow2(dot(Dots, Dots)) * alpha.x * alpha.y; // this is really weird
@@ -187,7 +185,7 @@ vec3 specularLighting(vec3 lightVector, vec3 normal, MaterialProperties_t mat)
 
 
 
-
+// Calculate PBR shading for a light
 void CalculateShading(inout LightingTerms_t lighting, vec3 lightVector, vec3 lightColor, MaterialProperties_t mat)
 {
 #if defined(useDiffuseWrap)

--- a/GUI/Types/Renderer/Shaders/common/pbr.glsl
+++ b/GUI/Types/Renderer/Shaders/common/pbr.glsl
@@ -83,7 +83,7 @@ vec3 SpecularCloth(float roughness, float NoL, float NoH, float NoV, float VoH, 
 #endif
 
 
-vec3 specularLighting(vec3 L, vec3 V, vec3 N, vec3 F0, vec3 specularColor, float roughness, vec4 extraParams)
+vec3 specularLighting(vec3 L, vec3 V, vec3 N, vec3 specularColor, float roughness, vec4 extraParams)
 {
 	float NoL = saturate( dot(N, L) );
 
@@ -105,7 +105,7 @@ vec3 specularLighting(vec3 L, vec3 V, vec3 N, vec3 F0, vec3 specularColor, float
 	// G = Geometric shadowing term (Microfacets shadowing)
 	float Vis = G_SchlickSmithGGX(NoL, NoV, roughness);
 	// F = Fresnel factor (Reflectance depending on angle of incidence)
-	vec3 F = F_Schlick(VoH, F0);
+	vec3 F = F_Schlick(VoH, specularColor);
 
 #if (F_CLOTH_SHADING == 1)
     // I'm not sure how they blend to the cloth shading, but I'm assuming it's just blending shading

--- a/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
+++ b/GUI/Types/Renderer/Shaders/common/rendermodes.glsl
@@ -12,7 +12,9 @@
 vec3 CalculateFullbrightLighting(vec3 albedo, vec3 normal, vec3 viewVector)
 {
     float flFakeDiffuseLighting = saturate(dot(normal, -viewVector)) * 0.7 + 0.3;
+
     vec3 vReflectionDirWs = reflect(viewVector, normal);
+
     float flFakeSpecularLighting = pow2(pow2(saturate(dot(-viewVector, vReflectionDirWs)))) * 0.05;
 
     float XtraLight1 = dot(vec3(0.6, 0.4, 1.0), pow2(saturate(normal)));

--- a/GUI/Types/Renderer/Shaders/common/texturing.glsl
+++ b/GUI/Types/Renderer/Shaders/common/texturing.glsl
@@ -1,3 +1,13 @@
+#if defined(NEED_CURVATURE) && (F_USE_PER_VERTEX_CURVATURE == 0)
+// Expensive, only used in skin shaders
+float GetCurvature(vec3 vNormal, vec3 vPositionWS)
+{
+	return length(fwidth(vNormal)) / length(fwidth(vPositionWS));
+}
+#endif
+
+
+
 // Geometric roughness. Essentially just Specular Anti-Aliasing
 float CalculateGeometricRoughnessFactor(vec3 geometricNormal)
 {
@@ -33,6 +43,130 @@ float applyBlendModulation(float blendFactor, float blendMask, float blendSoftne
 
 
 
+
+
+
+// Struct full of everything needed for lighting, for easy access around the shader.
+
+struct MaterialProperties
+{
+    vec3 PositionWS;
+    vec3 GeometricNormal;
+    vec3 Tangent;
+    vec3 Bitangent;
+    vec3 ViewDir;
+
+    vec3 Albedo;
+    float Opacity;
+    float Metalness;
+    vec3 Normal;
+    vec3 NormalMap;
+
+    float Roughness;
+    float RoughnessTex;
+
+    float AmbientOcclusion;
+    vec3 DiffuseAO; // vec3 because  Diffuse AO can be tinted
+    float SpecularAO;
+    vec4 ExtraParams;
+
+    vec3 DiffuseColor;
+    vec3 SpecularColor;
+    vec3 TransmissiveColor;
+    vec3 IllumColor;
+
+
+
+#if defined(NEED_CURVATURE)
+    float Curvature;
+#endif
+    //int NumDynamicLights;
+};
+
+void InitProperties(out MaterialProperties mat, vec3 GeometricNormal)
+{
+    mat.PositionWS = vFragPosition;
+    mat.ViewDir = normalize(vEyePosition - vFragPosition);
+    mat.GeometricNormal = normalize(GeometricNormal);
+    mat.Tangent = normalize(vTangentOut);
+    mat.Bitangent = normalize(vBitangentOut);
+    
+    mat.Albedo = vec3(0.0);
+    mat.Opacity = 1.0;
+    mat.Metalness = 0.0;
+    mat.Normal = vec3(0.0);
+    mat.NormalMap = vec3(0, 0, 1);
+
+#if 0 && defined(VEC2_ROUGHNESS)
+    mat.Roughness = vec2(0.0);
+    mat.RoughnessTex = vec2(0.0);
+#else
+    mat.Roughness = 0.0;
+    mat.RoughnessTex = 0.0;
+#endif
+    mat.AmbientOcclusion = 1.0;
+    mat.DiffuseAO = vec3(1.0);
+    mat.SpecularAO = 1.0;
+    // r = retro reflectivity, g = sss mask, b = cloth, a = ???
+    mat.ExtraParams = vec4(0.0);
+
+
+    mat.DiffuseColor = vec3(0.0);
+    mat.SpecularColor = vec3(0.04);
+    mat.TransmissiveColor = vec3(0.0);
+    mat.IllumColor = vec3(0.0);
+
+    mat.BentGeometricNormal = vec3(0.0); // Indirect geometric normal
+    mat.BentNormal = vec3(0.0); // Indirect normal
+#if defined(NEED_CURVATURE)// || renderMode_Curvature
+    #if F_USE_PER_VERTEX_CURVATURE == 1
+        mat.Curvature = flPerVertexCurvature;
+    #else
+        mat.Curvature = pow( GetCurvature(mat.GeometricNormal, mat.PositionWS), 0.333 );
+    #endif
+#endif
+    //prop.NumDynamicLights = 0;
+
+
+#if (F_RENDER_BACKFACES == 1) && (F_DONT_FLIP_BACKFACE_NORMALS == 0)
+    // when rendering backfaces, they invert normal so it appears front-facing
+    mat.GeometricNormal *= gl_FrontFacing ? 1.0 : -1.0;
+#endif
+}
+
+
+
+// AO Proxies would be merged with these
+uniform float g_flAmbientOcclusionDirectDiffuse = 1.0;
+uniform float g_flAmbientOcclusionDirectSpecular = 1.0;
+
+void ApplyAmbientOcclusion(inout LightingTerms o, MaterialProperties mat)
+{
+    vec3 DirectAODiffuse  = mix(vec3(1.0), mat.DiffuseAO, g_flAmbientOcclusionDirectDiffuse);
+	float DirectAOSpecular = mix(1.0, mat.SpecularAO, g_flAmbientOcclusionDirectSpecular);
+
+    o.DiffuseDirect    *= DirectAODiffuse;
+    o.DiffuseIndirect  *= mat.DiffuseAO;
+    o.SpecularDirect   *= DirectAOSpecular;
+    o.SpecularIndirect *= mat.SpecularAO;
+}
+
+float GetIsoRoughness(float Roughness)
+{
+    return Roughness;
+}
+
+float GetIsoRoughness(vec2 Roughness)
+{
+    return dot(Roughness, vec2(0.5));
+}
+
+
+
+
+
+
+
 //-------------------------------------------------------------------------
 //                              NORMALS
 //-------------------------------------------------------------------------
@@ -42,6 +176,7 @@ vec3 SwitchCentroidNormal(vec3 vNormalWs, vec3 vCentroidNormalWs)
 {
     return ( dot(vNormalWs, vNormalWs) >= 1.01 ) ? vCentroidNormalWs : vNormalWs;
 }
+
 
 vec3 oct_to_float32x3(vec2 e)
 {
@@ -63,7 +198,7 @@ vec3 unpackHemiOctNormal(vec4 bumpNormal)
 #endif
 
     // This is free, it gets compiled into the TS->WS matrix mul
-    tangentNormal.y *= -1.0;
+    tangentNormal.y = -tangentNormal.y;
 
     return tangentNormal;
 }
@@ -78,6 +213,18 @@ vec3 calculateWorldNormal(vec3 normalMap, vec3 normal, vec3 tangent, vec3 bitang
     return normalize(tangentSpace * normalMap);
 }
 
+#if 0 && (F_USE_BENT_NORMALS == 1)
+void GetBentNormal(inout MaterialProperties mat, vec2 texCoords)
+{
+    vec3 bentNormalTexel = unpackHemiOctNormal( texture(g_tBentNormal, texCoords) );
+    prop.BentGeometricNormal = calculateWorldNormal(bentNormalTexel, mat.GeometricNormal, mat.Tangent, mat.Bitangent);
+
+    // this is how they blend in the bent normal; by re-converting the normal map to tangent space using the bent geo normal
+    prop.BentNormal = calculateWorldNormal(mat.NormalMap, mat.BentGeometricNormal, mat.Tangent, mat.Bitangent);
+}
+#endif
+
+
 
 
 
@@ -86,7 +233,7 @@ vec3 calculateWorldNormal(vec3 normalMap, vec3 normal, vec3 tangent, vec3 bitang
 //-------------------------------------------------------------------------
 
 
-#if F_ALPHA_TEST == 1
+#if (F_ALPHA_TEST == 1)
 
 uniform float g_flAntiAliasedEdgeStrength = 1.0;
 
@@ -111,20 +258,25 @@ float AlphaTestAntiAliasing(float flOpacity, vec2 UVs)
 //                              DETAIL TEXTURING
 //-------------------------------------------------------------------------
 
-#if (F_DETAIL_TEXTURE != 0)
+#if (F_DETAIL_TEXTURE > 0)
+
+// Xen foliage detail textures always has both color and normal
+#define DETAIL_COLOR_MOD2X (F_DETAIL_TEXTURE == 1) && !defined(vr_xen_foliage)
+#define DETAIL_COLOR_OVERLAY ((F_DETAIL_TEXTURE == 2) || (F_DETAIL_TEXTURE == 4)) || defined(vr_xen_foliage)
+#define DETAIL_NORMALS ((F_DETAIL_TEXTURE == 3) || (F_DETAIL_TEXTURE == 4)) || defined(vr_xen_foliage)
+
 uniform float g_flDetailBlendFactor = 1.0;
 uniform float g_flDetailBlendToFull = 0.0;
 uniform float g_flDetailNormalStrength = 1.0;
 in vec2 vDetailTexCoords;
 
 uniform sampler2D g_tDetailMask;
-#if (F_DETAIL_TEXTURE > 0) && (F_DETAIL_TEXTURE != 3)
-uniform sampler2D g_tDetail;
+#if DETAIL_COLOR_MOD2X || DETAIL_COLOR_OVERLAY
+    uniform sampler2D g_tDetail;
 #endif
-#if (F_DETAIL_TEXTURE == 3) || (F_DETAIL_TEXTURE == 4)
-uniform sampler2D g_tNormalDetail;
+#if DETAIL_NORMALS
+    uniform sampler2D g_tNormalDetail;
 #endif
-in vec2 vDetailTexoords;
 
 #define MOD2X_MUL 1.9922
 #define DETAIL_CONST 0.9961
@@ -136,23 +288,23 @@ void applyDetailTexture(inout vec3 Albedo, inout vec3 NormalMap, vec2 detailMask
     detailMask = g_flDetailBlendFactor * max(detailMask, g_flDetailBlendToFull);
 
     // MOD2X
-#if F_DETAIL_TEXTURE == 1
+#if (DETAIL_COLOR_MOD2X)
 
     vec3 DetailTexture = texture(g_tDetail, vDetailTexCoords).rgb * MOD2X_MUL;
     Albedo *= mix(vec3(1.0), DetailTexture, detailMask);
 
 // OVERLAY
-#elif (F_DETAIL_TEXTURE == 2) || (F_DETAIL_TEXTURE == 4)
+#elif (DETAIL_COLOR_OVERLAY)
 
     vec3 DetailTexture = DETAIL_CONST * texture(g_tDetail, vDetailTexCoords).rgb;
 
-    // blend in linear space!!!
-    vec3 linearAlbedo = pow(Albedo, vec3(1.0 / 2.2));
+    // blend in linear space! this is actually in the code, so we're doing the right thing!
+    vec3 linearAlbedo = pow(Albedo, invGamma);
     vec3 overlayScreen = 1.0 - (1.0 - DetailTexture) * (1.0 - linearAlbedo) * 2.0;
     vec3 overlayMul = DetailTexture * linearAlbedo * 2.0;
 
     vec3 linearBlendedOverlay = mix(overlayMul, overlayScreen, greaterThanEqual(linearAlbedo, vec3(0.5)));
-    vec3 gammaBlendedOverlay = pow(linearBlendedOverlay, vec3(2.2));
+    vec3 gammaBlendedOverlay = pow(linearBlendedOverlay, gamma);
 
     Albedo = mix(Albedo, gammaBlendedOverlay, detailMask);
 
@@ -160,7 +312,7 @@ void applyDetailTexture(inout vec3 Albedo, inout vec3 NormalMap, vec2 detailMask
 
 
 // NORMALS
-#if (F_DETAIL_TEXTURE == 3) || (F_DETAIL_TEXTURE == 4)
+#if (DETAIL_NORMALS)
     vec3 DetailNormal = unpackHemiOctNormal(texture(g_tNormalDetail, vDetailTexCoords));
     DetailNormal = mix(vec3(0, 0, 1), DetailNormal, detailMask * g_flDetailNormalStrength);
     // literally i dont even know

--- a/GUI/Types/Renderer/Shaders/common/texturing.glsl
+++ b/GUI/Types/Renderer/Shaders/common/texturing.glsl
@@ -150,7 +150,7 @@ uniform vec4 g_vAmbientOcclusionColorBleed = vec4(0.4, 0.14902, 0.129412, 0.0);
 
 void SetDiffuseColorBleed(inout MaterialProperties_t mat)
 {
-    vec3 vAmbientOcclusionExponent = vec3(1.0) - SRGBtoLinear(g_vAmbientOcclusionColorBleed.rgb);
+    vec3 vAmbientOcclusionExponent = vec3(1.0) - SrgbGammaToLinear(g_vAmbientOcclusionColorBleed.rgb);
 #if (F_SSS_MASK == 1)
     vAmbientOcclusionExponent = mix(vec3(1.0), vAmbientOcclusionExponent, mat.ExtraParams.y);
 #endif

--- a/GUI/Types/Renderer/Shaders/common/utils.glsl
+++ b/GUI/Types/Renderer/Shaders/common/utils.glsl
@@ -100,7 +100,8 @@ vec2 Resize2D(vec2 Base, vec4 StartPos_Size)
 }
 
 
-
+const vec3 gamma = vec3(2.2);
+const vec3 invGamma = vec3(1.0 / gamma);
 
 
 

--- a/GUI/Types/Renderer/Shaders/common/utils.glsl
+++ b/GUI/Types/Renderer/Shaders/common/utils.glsl
@@ -134,6 +134,38 @@ vec2 Resize2D(vec2 Base, vec4 StartPos_Size)
 }
 
 
+vec2 RotateVector2D(vec2 vectorInput, float rotation, vec2 scale, vec2 offset)
+{
+    rotation = radians(rotation);
+    float sinRot = sin(rotation);
+    float cosRot = cos(rotation);
+
+    vec2 finalOffset = (scale.xy * -0.5) * vec2(cosRot - sinRot, sinRot - cosRot) + offset + vec2(0.5);
+    vec4 xform = scale.xxyy * vec4(cosRot, -sinRot, sinRot, cosRot);
+
+    return vec2(dot(xform.xy, vectorInput.xy), dot(xform.zw, vectorInput.xy)) + finalOffset;
+}
+
+vec2 RotateVector2D(vec2 vectorInput, float rotation, vec2 scale, vec2 offset, vec2 center)
+{
+
+    rotation = radians(rotation);
+    float sinRot = sin(rotation);
+    float cosRot = cos(rotation);
+
+    vec4 xform = vec4(cosRot * scale.x, -sinRot * scale.y, sinRot * scale.x, cosRot* scale.y);
+
+    vec2 finalOffset;
+    finalOffset.x = (center.x + offset.x) + (sinRot * center.y) - (cosRot * center.x);
+    finalOffset.y = (center.y + offset.y) - (sinRot * center.x) + (cosRot * center.y);
+    // ^ all of this should be precalculated
+
+    return vec2(dot(xform.xy, vectorInput.xy), dot(xform.zw, vectorInput.xy)) + finalOffset;
+}
+
+
+
+
 const vec3 gamma = vec3(2.2);
 const vec3 invGamma = vec3(1.0 / gamma);
 

--- a/GUI/Types/Renderer/Shaders/common/utils.glsl
+++ b/GUI/Types/Renderer/Shaders/common/utils.glsl
@@ -53,7 +53,6 @@ float max3( vec3 Vector )
 
 
 
-
 float length_squared(vec2 vector)
 {
 	return dot(vector, vector);
@@ -76,17 +75,39 @@ float GetLuma(vec3 Color) {
 	return dot( Color, vec3(0.2126, 0.7152, 0.0722) );
 }
 
-
-float SRGBtoLinear(float SRGB)
+float SrgbGammaToLinear(float color)
 {
-	return SRGB <= 0.0404 ? SRGB * 0.0774 : pow( SRGB * 0.9479 + 0.0521, 2.4 );
+    float vLinearSegment = color / 12.92;
+    float vExpSegment = pow((color / 1.055) + 0.0521327, 2.4);
+
+    const float cap = 0.04045;
+    float select = color > cap ? vExpSegment : vLinearSegment;
+
+    return select;
 }
+vec2 SrgbGammaToLinear(vec2 color)
+{
+    vec2 vLinearSegment = color / vec2(12.92);
+    vec2 vExpSegment = pow((color / vec2(1.055)) + vec2(0.0521327), vec2(2.4));
 
-vec2 SRGBtoLinear(vec2 SRGB) {  return vec2( SRGBtoLinear(SRGB.r), SRGBtoLinear(SRGB.g) );      }
+    const float cap = 0.04045;
+    float select = color.r > cap ? vExpSegment.r : vLinearSegment.r;
+    float select1 = color.g > cap ? vExpSegment.g : vLinearSegment.g;
 
-vec3 SRGBtoLinear(vec3 SRGB) {  return vec3( SRGBtoLinear(SRGB.rg), SRGBtoLinear(SRGB.b) );     }
+    return vec2(select, select1);
+}
+vec3 SrgbGammaToLinear(vec3 color)
+{
+    vec3 vLinearSegment = color / vec3(12.92);
+    vec3 vExpSegment = pow((color / vec3(1.055)) + vec3(0.0521327), vec3(2.4));
 
-vec4 SRGBtoLinear(vec4 SRGB) {  return vec4( SRGBtoLinear(SRGB.rgb), SRGBtoLinear(SRGB.a) );    }
+    const float cap = 0.04045;
+    float select = color.r > cap ? vExpSegment.r : vLinearSegment.r;
+    float select1 = color.g > cap ? vExpSegment.g : vLinearSegment.g;
+    float select2 = color.b > cap ? vExpSegment.b : vLinearSegment.b;
+
+    return vec3(select, select1, select2);
+}
 
 
 vec2 Resize2D(float Base, vec4 StartPos_Size)
@@ -136,12 +157,6 @@ vec4 ClampToPositive( vec4 vValue )
 float LinearRamp( float flMin, float flMax, float flInput )
 {
 	return saturate( ( flInput - flMin ) / ( flMax - flMin ) );
-}
-
-//-------------------------------------------------------------------------------------------------------------------------------------------------------------
-float fsel( float flComparand, float flValGE, float flLT )
-{
-	return ( flComparand >= 0.0 ) ? flValGE : flLT;
 }
 
 //-------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/GUI/Types/Renderer/Shaders/common/utils.glsl
+++ b/GUI/Types/Renderer/Shaders/common/utils.glsl
@@ -108,6 +108,19 @@ vec3 SrgbGammaToLinear(vec3 color)
 
     return vec3(select, select1, select2);
 }
+vec4 SrgbGammaToLinear(vec4 color)
+{
+    vec4 vLinearSegment = color / vec4(12.92);
+    vec4 vExpSegment = pow((color / vec4(1.055)) + vec4(0.0521327), vec4(2.4));
+
+    const float cap = 0.04045;
+    float select = color.r > cap ? vExpSegment.r : vLinearSegment.r;
+    float select1 = color.g > cap ? vExpSegment.g : vLinearSegment.g;
+    float select2 = color.b > cap ? vExpSegment.b : vLinearSegment.b;
+    float select3 = color.a > cap ? vExpSegment.a : vLinearSegment.a;
+
+    return vec4(select, select1, select2, select3);
+}
 
 
 vec2 Resize2D(float Base, vec4 StartPos_Size)

--- a/GUI/Types/Renderer/Shaders/csgo_effects.frag
+++ b/GUI/Types/Renderer/Shaders/csgo_effects.frag
@@ -66,7 +66,7 @@ void main()
     #if F_TINT_MASK == 1
         // does texcoord scale really only apply to the tint mask?
         float tintFactor = texture(g_tTintMask, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordScale.xy).x;
-        tintColor = tintFactor * tintColor + (1 - tintFactor);
+        tintColor = mix(vec3(1.0), tintColor, tintFactor);
     #endif
 
     float opacity = color.a * mask1 * mask2 * mask3 * g_flOpacityScale;

--- a/GUI/Types/Renderer/Shaders/global_lit_simple.vert
+++ b/GUI/Types/Renderer/Shaders/global_lit_simple.vert
@@ -25,6 +25,7 @@ out vec3 vNormalOut;
 out vec3 vTangentOut;
 out vec3 vBitangentOut;
 out vec2 vTexCoordOut;
+out vec4 vTintColorFadeOut;
 
 uniform vec4 g_vTexCoordOffset;
 uniform vec4 g_vTexCoordScale;
@@ -32,6 +33,11 @@ uniform vec4 g_vTexCoordScale;
 uniform mat4 uProjectionViewMatrix;
 uniform mat4 transform;
 uniform float g_flTime;
+
+uniform vec4 m_vTintColorSceneObject;
+uniform vec3 m_vTintColorDrawCall;
+
+uniform vec4 g_vColorTint;
 
 void main()
 {
@@ -53,6 +59,9 @@ void main()
     vTangentOut = normalize(normalTransform * tangent.xyz);
     vBitangentOut = tangent.w * cross( vNormalOut, vTangentOut );
 #endif
+
+    vTintColorFadeOut.rgb = m_vTintColorSceneObject.rgb * m_vTintColorDrawCall * g_vColorTint.rgb;
+    vTintColorFadeOut.a = m_vTintColorSceneObject.a * g_vColorTint.a;
 
     vTexCoordOut = vTEXCOORD * g_vTexCoordScale.xy + g_vTexCoordOffset.xy;
 

--- a/GUI/Types/Renderer/Shaders/multiblend.frag
+++ b/GUI/Types/Renderer/Shaders/multiblend.frag
@@ -4,7 +4,7 @@
 #include "common/utils.glsl"
 #include "common/rendermodes.glsl"
 #define renderMode_Terrain_Blend 0
-#define renderMode_TerrainTint 0
+#define renderMode_VertexColor 0
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define F_TINT_MASK 0
@@ -242,7 +242,7 @@ void main()
     outputColor = vec4(vBlendWeights.xyz, 1.0);
 #endif
 
-#if renderMode_TerrainTint == 1
+#if renderMode_VertexColor == 1
     outputColor = vec4(vVertexColor.rgb, 1.0);
 #endif
 

--- a/GUI/Types/Renderer/Shaders/multiblend.frag
+++ b/GUI/Types/Renderer/Shaders/multiblend.frag
@@ -4,12 +4,13 @@
 #include "common/utils.glsl"
 #include "common/rendermodes.glsl"
 #define renderMode_Terrain_Blend 0
-#define renderMode_Ambient_Occlusion 0
+#define renderMode_TerrainTint 0
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
 #define F_TINT_MASK 0
 #define F_NORMAL_MAP 0
 #define F_TWO_LAYER_BLEND 0
+#define F_WORLDSPACE_UVS 0
 //End of parameter defines
 
 in vec3 vFragPosition;
@@ -19,10 +20,15 @@ in vec3 vTangentOut;
 in vec3 vBitangentOut;
 
 in vec4 vBlendWeights;
-in vec4 vWeightsOut1;
-in vec4 vWeightsOut2;
+in vec4 vBlendAlphas;
+in vec4 vVertexColor;
 
 in vec2 vTexCoordOut;
+in vec2 vTexCoord1Out;
+#if (F_TWO_LAYER_BLEND == 0)
+in vec2 vTexCoord2Out;
+in vec2 vTexCoord3Out;
+#endif
 
 out vec4 outputColor;
 
@@ -43,141 +49,160 @@ uniform sampler2D g_tSpecular3;
 
 uniform sampler2D g_tTintMasks;
 
-uniform float g_flTexCoordScale0;
-uniform float g_flTexCoordScale1;
-uniform float g_flTexCoordScale2;
-uniform float g_flTexCoordScale3;
-
+uniform vec4 g_vGlobalTint = vec4(1.0);
 uniform vec4 g_vColorTint0;
-uniform vec4 g_vColorTintB0;
 uniform vec4 g_vColorTint1;
-uniform vec4 g_vColorTintB1;
 uniform vec4 g_vColorTint2;
-uniform vec4 g_vColorTintB2;
 uniform vec4 g_vColorTint3;
+uniform vec4 g_vColorTintB0;
+uniform vec4 g_vColorTintB1;
+uniform vec4 g_vColorTintB2;
 uniform vec4 g_vColorTintB3;
 
-uniform float g_flTexCoordRotate0;
-uniform float g_flTexCoordRotate1;
-uniform float g_flTexCoordRotate2;
-uniform float g_flTexCoordRotate3;
-
 uniform vec3 vEyePosition;
+uniform float g_flBumpStrength = 1.0;
 
-vec2 getTexCoord(float scale, float rotation) {
-
-    //Transform degrees to radians
-    float r = radians(rotation);
-
-    //Scale texture
-    vec2 coord = vTexCoordOut / scale;
-
-    float SinR = sin(r);
-    float CosR = cos(r);
-
-    //Rotate vector
-    return vec2(CosR * coord.x - SinR * coord.y,
-        SinR * coord.x + CosR * coord.y);
-}
-
-//Interpolate between two tint colors based on the tint mask and coordinate scale.
-vec4 interpolateTint(int id, vec4 tint1, vec4 tint2, float coordScale, float coordRotation)
+//Interpolate between two tint colors based on the tint mask.
+vec3 interpolateTint(int id, vec3 tint1, vec3 tint2, vec2 coords)
 {
-    float maskValue = texture(g_tTintMasks, getTexCoord(coordScale, coordRotation))[id];
+    float maskValue = texture(g_tTintMasks, coords)[id];
     return mix(tint1, tint2, maskValue);
 }
+
+// from texturing.glsl
+float applyBlendModulation(float blendFactor, float blendMask, float blendSoftness)
+{
+    float minb = max(0.0, blendMask - blendSoftness);
+    float maxb = min(1.0, blendMask + blendSoftness);
+
+    return smoothstep(minb, maxb, blendFactor);
+}
+
+
+
+#if (F_NORMAL_MAP == 1)
+
+vec3 DecodeNormal(vec4 bumpNormal)
+{
+    vec2 temp = vec2(bumpNormal.w, bumpNormal.y) * 2.0 - 1.0;
+    temp.y = -temp.y;
+    return vec3(temp, sqrt(saturate(1 - dot(temp,temp))));
+}
+
+//Calculate the normal of this fragment in world space
+vec3 calculateWorldNormal(vec3 normalMap, vec3 normal, vec3 tangent, vec3 bitangent)
+{
+    //vec3 tangent = vec3(vNormalOut.z, vNormalOut.y, -vNormalOut.x);
+    //vec3 bitangent = cross(vNormalOut, tangent);
+    //Make the tangent space matrix
+    mat3 tangentSpace = mat3(tangent, bitangent, normal);
+
+    //Calculate the tangent normal in world space and return it
+    return normalize(tangentSpace * normalMap);
+}
+#endif
 
 //Main entry point
 void main()
 {
-    //Calculate coordinates
-    vec2 coord0 = getTexCoord(g_flTexCoordScale0, g_flTexCoordRotate0);
-    vec2 coord1 = getTexCoord(g_flTexCoordScale1, g_flTexCoordRotate1);
+    //Get the base color from the color texture
+    vec4 color0 = texture(g_tColor0, vTexCoordOut);
+    vec4 color1 = texture(g_tColor1, vTexCoord1Out);
 #if F_TWO_LAYER_BLEND == 0
-    vec2 coord2 = getTexCoord(g_flTexCoordScale2, g_flTexCoordRotate2);
-    vec2 coord3 = getTexCoord(g_flTexCoordScale3, g_flTexCoordRotate3);
+    vec4 color2 = texture(g_tColor2, vTexCoord2Out);
+    vec4 color3 = texture(g_tColor3, vTexCoord3Out);
 #endif
 
-    //Get the ambient color from the color texture
-    vec4 color0 = texture(g_tColor0, coord0);
-    vec4 color1 = texture(g_tColor1, coord1);
-#if F_TWO_LAYER_BLEND == 0
-    vec4 color2 = texture(g_tColor2, coord2);
-    vec4 color3 = texture(g_tColor3, coord3);
-#endif
 
-    //Get normal
-    vec4 normal0 = texture(g_tNormal0, coord0);
-    vec4 normal1 = texture(g_tNormal1, coord1);
+    // Get blend weights
+    float blendWeight1 = applyBlendModulation(vBlendWeights.x, color1.w, vBlendAlphas.x);
+
+    float invBlendWeight1 = 1.0 - blendWeight1;
+
 #if F_TWO_LAYER_BLEND == 0
-    vec4 normal2 = texture(g_tNormal2, coord2);
-    vec4 normal3 = texture(g_tNormal3, coord3);
+    float blendWeight2 = applyBlendModulation(vBlendWeights.y, color2.w, vBlendAlphas.y);
+    blendWeight2 = clamp(blendWeight2, 0.0, invBlendWeight1);
+
+    float invBlendWeight2 = invBlendWeight1 - blendWeight2;
+
+    float blendWeight3 = applyBlendModulation(vBlendWeights.z, color3.w, vBlendAlphas.z);
+    blendWeight3 = clamp(blendWeight3, 0.0, invBlendWeight2);
+
+    // remaining weight
+    float blendWeight0 = invBlendWeight2 - blendWeight3;
+#else
+    float blendWeight0 = invBlendWeight1;
 #endif
 
     //Get specular
-    vec4 specular0 = texture(g_tSpecular0, coord0);
-    vec4 specular1 = texture(g_tSpecular1, coord1);
+    vec4 specular0 = texture(g_tSpecular0, vTexCoordOut);
+    vec4 specular1 = texture(g_tSpecular1, vTexCoord1Out);
 #if F_TWO_LAYER_BLEND == 0
-    vec4 specular2 = texture(g_tSpecular2, coord2);
-    vec4 specular3 = texture(g_tSpecular3, coord3);
+    vec4 specular2 = texture(g_tSpecular2, vTexCoord2Out);
+    vec4 specular3 = texture(g_tSpecular3, vTexCoord3Out);
 #endif
 
-    //calculate blend
-    vec4 blend = vec4(max(0, 1 - vBlendWeights.x - vBlendWeights.y - vBlendWeights.z), vBlendWeights.x, max(0, vBlendWeights.y - vBlendWeights.x), max(0, vBlendWeights.z - vBlendWeights.w - vBlendWeights.y));
-    blend = blend/(blend.x + blend.y + blend.z + blend.w);
 
     //Simple blending
     //Calculate each of the 4 colours to blend
 #if F_TINT_MASK
     // Include tint mask
-    vec4 c0 = blend.x * color0 * interpolateTint(0, g_vColorTint0, g_vColorTintB0, g_flTexCoordScale0, g_flTexCoordRotate0);
-    vec4 c1 = blend.y * color1 * interpolateTint(1, g_vColorTint1, g_vColorTintB1, g_flTexCoordScale1, g_flTexCoordRotate1);
+    vec3 tint0 = interpolateTint(0, SrgbGammaToLinear(g_vColorTint0.rgb), SrgbGammaToLinear(g_vColorTintB0.rgb), vTexCoordOut);
+    vec3 tint1 = interpolateTint(1, SrgbGammaToLinear(g_vColorTint1.rgb), SrgbGammaToLinear(g_vColorTintB1.rgb), vTexCoord1Out);
     #if F_TWO_LAYER_BLEND == 0
-        vec4 c2 = blend.z * color2 * interpolateTint(2, g_vColorTint2, g_vColorTintB2, g_flTexCoordScale2, g_flTexCoordRotate2);
-        vec4 c3 = blend.w * color3 * interpolateTint(3, g_vColorTint3, g_vColorTintB3, g_flTexCoordScale3, g_flTexCoordRotate3);
+        vec3 tint2 = interpolateTint(2, SrgbGammaToLinear(g_vColorTint2.rgb), SrgbGammaToLinear(g_vColorTintB2.rgb), vTexCoord2Out);
+        vec3 tint3 = interpolateTint(3, SrgbGammaToLinear(g_vColorTint3.rgb), SrgbGammaToLinear(g_vColorTintB3.rgb), vTexCoord3Out);
     #endif
 #else
-    vec4 c0 = blend.x * color0;
-    vec4 c1 = blend.y * color1;
-    #if F_TWO_LAYER_BLEND == 0
-        // TODO: this blending is probably wrong
-        vec4 c2 = blend.z * color2;
-        vec4 c3 = blend.w * color3;
-    #endif
+    vec3 tint0 = SrgbGammaToLinear(g_vColorTint0.rgb);
+    vec3 tint1 = SrgbGammaToLinear(g_vColorTint1.rgb);
+    vec3 tint2 = SrgbGammaToLinear(g_vColorTint2.rgb);
+    vec3 tint3 = SrgbGammaToLinear(g_vColorTint3.rgb);
 #endif
+    vec3 c0 = blendWeight0 * color0.rgb * tint0;
+    vec3 c1 = blendWeight1 * color1.rgb * tint1;
+    #if F_TWO_LAYER_BLEND == 0
+        vec3 c2 = blendWeight2 * color2.rgb * tint2;
+        vec3 c3 = blendWeight3 * color3.rgb * tint3;
+    #endif
 
 #if F_TWO_LAYER_BLEND == 0
     //Add up the result
-    vec4 finalColor = c0 + c1 + c2 + c3;
+    vec3 finalColor = c0 + c1 + c2 + c3;
 #else
     //Add up the result
-    vec4 finalColor = c0 + c1;
+    vec3 finalColor = c0 + c1;
 #endif
 
-#if F_NORMAL_MAP
+    finalColor *= vVertexColor.rgb * SrgbGammaToLinear(g_vGlobalTint.rgb);
+
+#if (F_NORMAL_MAP == 1)
+    //Get normal
+    // horribly, they actually correct normal orientations to match with texcoord rotation. We're not doing that.
+    vec4 normal0 = texture(g_tNormal0, vTexCoordOut);
+    vec4 normal1 = texture(g_tNormal1, vTexCoord1Out);
+
     #if F_TWO_LAYER_BLEND == 0
+        vec4 normal2 = texture(g_tNormal2, vTexCoord2Out);
+        vec4 normal3 = texture(g_tNormal3, vTexCoord3Out);
+
         //calculate blended normal
-        vec4 bumpNormal = blend.x * normal0 + blend.y * normal1 + blend.z * normal2 + blend.w * normal3;
+        vec4 bumpNormal = blendWeight0 * normal0 + blendWeight1 * normal1 + blendWeight2 * normal2 + blendWeight3 * normal3;
     #else
         //calculate blended normal
-        vec4 bumpNormal = blend.x * normal0 + blend.y * normal1;
+        vec4 bumpNormal = blendWeight0 * normal0 + blendWeight1 * normal1;
     #endif
 
     //Reconstruct the tangent vector from the map
-    vec2 temp = vec2(bumpNormal.w, bumpNormal.y) * 2 - 1;
-    vec3 finalBumpNormal = vec3(temp, 1 - dot(temp,temp));
+    vec3 finalBumpNormal = DecodeNormal(bumpNormal);
 
-    // isn't this super incorrect?
-    //vec3 tangent = vec3(vNormalOut.z, vNormalOut.y, -vNormalOut.x);
-    //vec3 bitangent = cross(vNormalOut, tangent);
+    finalBumpNormal.xy *= g_flBumpStrength;
+
+    vec3 normal = normalize(vNormalOut.xyz);
     vec3 tangent = normalize(vTangentOut.xyz);
     vec3 bitangent = normalize(vBitangentOut.xyz);
 
-    //Make the tangent space matrix
-    mat3 tangentSpace = mat3(tangent, bitangent, vNormalOut);
-
-    //Calculate the tangent normal in world space and return it
-    vec3 finalNormal = normalize(tangentSpace * finalBumpNormal);
+    vec3 finalNormal = calculateWorldNormal(finalBumpNormal, normal, tangent, bitangent);
 #else
     vec3 finalNormal = normalize(vNormalOut.xyz);
 #endif
@@ -198,30 +223,27 @@ void main()
 
 #if F_TWO_LAYER_BLEND == 0
     //Calculate specular
-    vec4 blendSpecular = blend.x * specular0 + blend.y * specular1 + blend.z * specular2 + blend.w * specular3;
+    vec4 blendSpecular = blendWeight0 * specular0 + blendWeight1 * specular1 + blendWeight2 * specular2 + blendWeight3 * specular3;
 #else
     //Calculate specular
-    vec4 blendSpecular = blend.x * specular0 + blend.y * specular1;
+    vec4 blendSpecular = blendWeight0 * specular0 + blendWeight1 * specular1;
 #endif
 
     float NoL = ClampToPositive(dot(lightDirection, finalNormal));
-    float specular = blendSpecular.x * pow(NoL, 6);
+    float specular = blendSpecular.x * pow(NoL, 6.0);
 
-    //Apply ambient occlusion
-    vec4 occludedColor = finalColor * vec4(vWeightsOut2.xyz, 1.0);
-
-    outputColor = vec4(illumination * occludedColor.rgb + vec3(0.7) * specular, 1);
+    outputColor = vec4(illumination * finalColor.rgb + vec3(0.7) * specular, vVertexColor.a);
 
 #if renderMode_Color == 1
-    outputColor = vec4(finalColor.rgb, 1.0);
+    outputColor = vec4(finalColor, 1.0);
 #endif
 
 #if renderMode_Terrain_Blend == 1
-    outputColor = vec4(blend.xyz, 1.0);
+    outputColor = vec4(vBlendWeights.xyz, 1.0);
 #endif
 
-#if renderMode_Ambient_Occlusion == 1
-    outputColor = vec4(vWeightsOut2.xyz, 1.0);
+#if renderMode_TerrainTint == 1
+    outputColor = vec4(vVertexColor.rgb, 1.0);
 #endif
 
 #if renderMode_Normals == 1

--- a/GUI/Types/Renderer/Shaders/multiblend.vert
+++ b/GUI/Types/Renderer/Shaders/multiblend.vert
@@ -1,9 +1,12 @@
 #version 460
 
 //Includes - resolved by VRF
+#include "common/utils.glsl"
 #include "compression.incl"
 #include "animation.incl"
 //End of includes
+
+#define F_WORLDSPACE_UVS 0
 
 layout (location = 0) in vec3 vPOSITION;
 in vec4 vNORMAL;
@@ -22,13 +25,65 @@ out vec3 vTangentOut;
 out vec3 vBitangentOut;
 
 out vec4 vBlendWeights;
-out vec4 vWeightsOut1;
-out vec4 vWeightsOut2;
+out vec4 vBlendAlphas;
+out vec4 vVertexColor;
 
 out vec2 vTexCoordOut;
+out vec2 vTexCoord1Out;
+#if (F_TWO_LAYER_BLEND == 0)
+out vec2 vTexCoord2Out;
+out vec2 vTexCoord3Out;
+#endif
 
 uniform mat4 uProjectionViewMatrix;
 uniform mat4 transform;
+
+uniform float g_flTime;
+
+uniform float g_flTexCoordScale0;
+uniform float g_flTexCoordScale1;
+uniform float g_flTexCoordScale2;
+uniform float g_flTexCoordScale3;
+
+uniform float g_flTexCoordRotate0;
+uniform float g_flTexCoordRotate1;
+uniform float g_flTexCoordRotate2;
+uniform float g_flTexCoordRotate3;
+
+// TODO: reset uniforms to default when not present in the vmat. Otherwise the entire landscape will be scrolling
+/*uniform vec4 g_vTexCoordOffset0 = vec4(0.0);
+uniform vec4 g_vTexCoordOffset1 = vec4(0.0);
+uniform vec4 g_vTexCoordOffset2 = vec4(0.0);
+uniform vec4 g_vTexCoordOffset3 = vec4(0.0);
+
+uniform vec4 g_vTexCoordScroll0 = vec4(0.0);
+uniform vec4 g_vTexCoordScroll1 = vec4(0.0);
+uniform vec4 g_vTexCoordScroll2 = vec4(0.0);
+uniform vec4 g_vTexCoordScroll3 = vec4(0.0);*/
+
+uniform vec4 m_vTintColorSceneObject = vec4(1.0);
+uniform vec3 m_vTintColorDrawCall = vec3(1.0);
+
+
+vec2 getTexCoord(float scale, float rotation) {//, vec4 offset, vec4 scroll) {
+
+    //Transform degrees to radians
+    float r = radians(rotation);
+
+    vec2 totalOffset = vec2(0.0);//(scroll.xy * g_flTime) + offset.xy;
+
+    //Scale texture
+    vec2 coord = vTEXCOORD;
+
+    float SinR = sin(r);
+    float CosR = cos(r);
+
+    //Rotate vector
+    vec2 rotatedCoords = vec2(CosR * vTEXCOORD.x - SinR * vTEXCOORD.y,
+        SinR * vTEXCOORD.x + CosR * vTEXCOORD.y);
+
+    return (rotatedCoords / scale) + vec2(0.5) + totalOffset;
+}
 
 void main()
 {
@@ -51,13 +106,21 @@ void main()
     vBitangentOut = tangent.w * cross( vNormalOut, vTangentOut );
 #endif
 
-    vTexCoordOut = vTEXCOORD;
+    vTexCoordOut = getTexCoord(g_flTexCoordScale0, g_flTexCoordRotate0);//, g_vTexCoordOffset0, g_vTexCoordScroll0);
+    vTexCoord1Out = getTexCoord(g_flTexCoordScale1, g_flTexCoordRotate1);//, g_vTexCoordOffset1, g_vTexCoordScroll1);
+    vTexCoord2Out = getTexCoord(g_flTexCoordScale2, g_flTexCoordRotate2);//, g_vTexCoordOffset2, g_vTexCoordScroll2);
+    vTexCoord3Out = getTexCoord(g_flTexCoordScale3, g_flTexCoordRotate3);//, g_vTexCoordOffset3, g_vTexCoordScroll3);
 
-    //Normalize (?)
-    //vTEXCOORD1 - seems empty
-    //vTEXCOORD2 - (X,Y,Z) - Ambient occlusion, W - ???
-    //vTEXCOORD3 - X - amount of tex1, Y - amount of tex2, Z - amount of tex3, W - ???
-    vBlendWeights = vTEXCOORD3/255.0;
-    vWeightsOut1 = vTEXCOORD1;
-    vWeightsOut2 = vTEXCOORD2/255.0;
+
+    //vTEXCOORD1 - (X,Y,Z) - tex1, 2, and 3 blend softness (not working right now), W - reserved for worldspace uvs
+    //vTEXCOORD2 - Painted tint color
+    //vTEXCOORD3 - X - amount of tex1, Y - amount of tex2, Z - amount of tex3, W - reserved for worldspace uvs
+
+    vBlendWeights.xyz = vTEXCOORD3.xyz / 255.0;
+    vBlendWeights.w = 0.0;
+    vBlendAlphas.xyz = vec3(0.25);//max(vTEXCOORD1.xyz * 0.5, 1e-6);
+    vBlendAlphas.w = 0.0;
+
+    vVertexColor.rgb = SrgbGammaToLinear(m_vTintColorDrawCall.rgb) * m_vTintColorSceneObject.rgb * SrgbGammaToLinear(vTEXCOORD2.rgb/255);
+    vVertexColor.a = m_vTintColorSceneObject.a;
 }

--- a/GUI/Types/Renderer/Shaders/multiblend.vert
+++ b/GUI/Types/Renderer/Shaders/multiblend.vert
@@ -73,7 +73,7 @@ vec2 getTexCoord(float scale, float rotation) {//, vec4 offset, vec4 scroll) {
     vec2 totalOffset = vec2(0.0);//(scroll.xy * g_flTime) + offset.xy;
 
     //Scale texture
-    vec2 coord = vTEXCOORD;
+    vec2 coord = vTEXCOORD - vec2(0.5);
 
     float SinR = sin(r);
     float CosR = cos(r);

--- a/GUI/Types/Renderer/Shaders/particle_sprite.frag
+++ b/GUI/Types/Renderer/Shaders/particle_sprite.frag
@@ -1,12 +1,14 @@
 #version 460
 
+#include "common/utils.glsl"
+
 // Render modes -- Switched on/off by code
 #define renderMode_Color 0
 
 uniform sampler2D uTexture;
 uniform float uOverbrightFactor;
 
-in vec2 vTexCoords;
+in vec2 vTexCoordOut;
 in vec4 vColor;
 
 out vec4 fragColor;
@@ -14,10 +16,10 @@ out vec4 fragColor;
 void main(void) {
     vec4 color = texture(uTexture, vTexCoords);
 
-    vec3 finalColor = vColor.xyz * color.xyz;
-    float blendingFactor = uOverbrightFactor * (0.212 * finalColor.x + 0.715 * finalColor.y + 0.0722 * finalColor.z);
+    vec3 finalColor = vColor.rgb * color.rgb;
+    float blendingFactor = uOverbrightFactor * GetLuma(finalColor.rgb);
 
-    fragColor = vec4(finalColor, vColor.w * color.w * blendingFactor);
+    fragColor = vec4(finalColor, vColor.a * color.a * blendingFactor);
 
 #if renderMode_Color == 1
     fragColor = vec4(finalColor, 1.0);

--- a/GUI/Types/Renderer/Shaders/particle_sprite.vert
+++ b/GUI/Types/Renderer/Shaders/particle_sprite.vert
@@ -6,11 +6,11 @@ in vec2 aTexCoords;
 
 uniform mat4 uProjectionViewMatrix;
 
-out vec2 vTexCoords;
+out vec2 vTexCoordOut;
 out vec4 vColor;
 
 void main(void) {
     vColor = aVertexColor;
-    vTexCoords = aTexCoords;
+    vTexCoordOut = aTexCoords;
     gl_Position = uProjectionViewMatrix * vec4(aVertexPosition, 1.0);
 }

--- a/GUI/Types/Renderer/Shaders/particle_trail.frag
+++ b/GUI/Types/Renderer/Shaders/particle_trail.frag
@@ -1,5 +1,7 @@
 #version 460
 
+#include "common/utils.glsl"
+
 // Render modes -- Switched on/off by code
 #define renderMode_Color 0
 
@@ -19,10 +21,10 @@ out vec4 fragColor;
 void main(void) {
     vec4 color = texture(uTexture, uUvOffset + uv * uUvScale);
 
-    vec3 finalColor = uColor * color.xyz;
-    float blendingFactor = uOverbrightFactor * (finalColor.x + finalColor.y + finalColor.z) / 3.0;
+    vec3 finalColor = uColor * color.rgb;
+    float blendingFactor = uOverbrightFactor * GetLuma(finalColor.rgb);
 
-    fragColor = vec4(finalColor, uAlpha * color.w * blendingFactor);
+    fragColor = vec4(finalColor, uAlpha * color.a * blendingFactor);
 
 #if renderMode_Color == 1
     fragColor = vec4(finalColor, 1.0);

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -117,6 +117,9 @@ in vec4 vVertexColorOut;
     #if F_DETAIL_TEXTURE > 0
         uniform bool g_bUseSecondaryUvForDetailMask = true;
     #endif
+    #if F_SELF_ILLUM == 1
+        uniform bool g_bUseSecondaryUvForSelfIllum = false;
+    #endif
 #endif
 
 #if (LightmapGameVersionNumber == 0)
@@ -132,7 +135,7 @@ in vec4 vVertexColorOut;
 #endif
 
 
-#if (defined(simple_2way_blend) || F_LAYERS > 0)
+#if (defined(simple_2way_blend) || (F_LAYERS > 0))
     in vec4 vColorBlendValues;
     uniform sampler2D g_tLayer2Color;
     uniform sampler2D g_tLayer2NormalRoughness;
@@ -140,9 +143,11 @@ in vec4 vVertexColorOut;
 
 #if F_SELF_ILLUM == 1
     uniform sampler2D g_tSelfIllumMask;
-    uniform float g_flSelfIllumBrightness;
-    uniform vec4 g_vSelfIllumTint = vec4(1.0);
+    uniform float g_flSelfIllumAlbedoFactor = 0.0;
+    uniform float g_flSelfIllumBrightness = 0.0;
     uniform float g_flSelfIllumScale = 1.0;
+    uniform vec4 g_vSelfIllumScrollSpeed = vec4(0.0);
+    uniform vec4 g_vSelfIllumTint = vec4(1.0);
 #endif
 
 out vec4 outputColor;
@@ -154,11 +159,11 @@ uniform sampler2D g_tTintMask;
 #include "common/lighting.glsl"
 uniform vec3 vEyePosition;
 
+uniform float g_flTime;
+
 uniform float g_flAlphaTestReference = 0.5;
 uniform float g_flOpacityScale = 1.0;
 
-uniform float g_flAmbientOcclusionDirectDiffuse = 1.0;
-uniform float g_flAmbientOcclusionDirectSpecular = 1.0;
 
 // glass specific params
 #if (F_GLASS == 1) || defined(glass)
@@ -172,13 +177,16 @@ uniform float g_flRefractScale = 0.1;
 
 #define hasUniformMetalness (defined(simple) || defined(complex)) && (F_METALNESS_TEXTURE == 0)
 #define hasColorAlphaMetalness (defined(simple) || defined(complex)) && (F_METALNESS_TEXTURE == 1)
+#define hasColorAlphaAO (defined(vr_simple) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 0)) || (defined(simple_2way_blend) && (F_ENABLE_AMBIENT_OCCLUSION == 1)) // only vr_simple
 #define hasMetalnessTexture (defined(complex) && (F_METALNESS_TEXTURE == 1) && ((F_RETRO_REFLECTIVE == 1) || (F_ALPHA_TEST == 1) || (F_TRANSLUCENT == 1)))
 #define hasAnisoGloss (defined(complex) && (F_ANISOTROPIC_GLOSS == 1))
 #define unlit (defined(csgo_unlitgeneric) || (F_FULLBRIGHT == 1) || (F_UNLIT == 1) || (defined(static_overlay) && F_LIT == 0))
 
+#define blendMembrane defined(vr_complex) && (F_TRANSLUCENT == 2)
+
 #if hasUniformMetalness
     uniform float g_flMetalness = 0.0;
-#elif hasMetalnessTexture && !hasColorAlphaMetalness
+#elif hasMetalnessTexture
     uniform sampler2D g_tMetalness;
 #endif
 
@@ -212,6 +220,7 @@ uniform float g_flBumpStrength = 1.0;
 #endif
 
 #if hasAnisoGloss
+//#define VEC2_ROUGHNESS
     uniform sampler2D g_tAnisoGloss;
 #endif
 
@@ -229,38 +238,32 @@ const vec3 invGamma = vec3(1.0 / gamma);
 #include "common/environment.glsl"
 #endif
 
-void main()
+
+
+// Get material properties
+MaterialProperties GetMaterial(vec3 vertexNormals)
 {
-    // Get vs inputs
-    vec2 texCoord = vTexCoordOut;
-    vec3 vertexNormal = SwitchCentroidNormal(vNormalOut, vCentroidNormalOut);
+    MaterialProperties mat;
+    InitProperties(mat, vertexNormals);
 
-    // Get the view direction vector for this fragment
-    vec3 V = normalize(vEyePosition - vFragPosition);
+    vec4 color = texture(g_tColor, vTexCoordOut);
+    vec4 normalTexture = texture(g_tNormal, vTexCoordOut);
 
-    #if F_RENDER_BACKFACES == 1 && (F_DONT_FLIP_BACKFACE_NORMALS == 0)
-        vertexNormal = faceforward(vertexNormal, V, vertexNormal);
-    #endif
+    color.rgb = pow(color.rgb, gamma);
 
-    // Get material properties
-    vec4 color = texture(g_tColor, texCoord);
-    vec4 normalTexture = texture(g_tNormal, texCoord);
 
-    vec3 normal = unpackHemiOctNormal(normalTexture);
-    float roughness = normalTexture.b;
-
+    // Blending
 #if (F_LAYERS > 0) || defined(simple_2way_blend)
-    vec4 color2 = texture(g_tLayer2Color, texCoord);
-    vec4 normalTexture2 = texture(g_tLayer2NormalRoughness, texCoord);
+    vec4 color2 = texture(g_tLayer2Color, vTexCoordOut);
+    vec4 normalTexture2 = texture(g_tLayer2NormalRoughness, vTexCoordOut);
 
-    vec3 normal2 = unpackHemiOctNormal(normalTexture2);
-    float roughness2 = normalTexture2.b;
+    color2.rgb = pow(color2.rgb, gamma);
 
     float blendFactor = vColorBlendValues.r;
 
     // 0: VertexBlend 1: BlendModulateTexture,rg 2: NewLayerBlending,g 3: NewLayerBlending,a
     #if (F_FANCY_BLENDING > 0)
-        vec4 blendModTexel = texture(g_tBlendModulation, texCoord);
+        vec4 blendModTexel = texture(g_tBlendModulation, vTexCoordOut);
 
         #if (F_FANCY_BLENDING == 1)
             blendFactor = applyBlendModulation(blendFactor, blendModTexel.g, blendModTexel.r);
@@ -272,7 +275,7 @@ void main()
     #endif
 
     #if (defined(simple_2way_blend))
-        vec4 blendModTexel = texture(g_tMask, texCoord);
+        vec4 blendModTexel = texture(g_tMask, vTexCoordOut);
 
         float softnessPaint = vColorBlendValues.g;
 
@@ -280,7 +283,7 @@ void main()
     #endif
 
     #if (F_ENABLE_TINT_MASKS == 1)
-        vec2 tintMasks = texture(g_tTintMask, texCoord).xy;
+        vec2 tintMasks = texture(g_tTintMask, vTexCoordOut).xy;
 
         vec3 tintFactorA = 1.0 - tintMasks.x * (1.0 - vVertexColorOut.rgb);
         vec3 tintFactorB = 1.0 - tintMasks.y * (1.0 - vVertexColorOut.rgb);
@@ -290,159 +293,211 @@ void main()
     #endif
 
 
-    // It's more correct to blend normals after hemioct unpacking (like we are doing), but it's not actually how S2 does it
     color = mix(color, color2, blendFactor);
-    normal = normalize(mix(normal, normal2, blendFactor));
-    roughness = mix(roughness, roughness2, blendFactor);
+    // It's more correct to blend normals after hemioct unpacking, but it's not actually how S2 does it
+    normalTexture = mix(normalTexture, normalTexture2, blendFactor);
 #endif
 
-#if (F_ALPHA_TEST == 1) || (defined(static_overlay) && F_BLEND_MODE == 2)
-    color.a = AlphaTestAntiAliasing(color.a, texCoord);
 
-    if (color.a - 0.001 < g_flAlphaTestReference)   discard;
-#endif
-
-#if (F_DETAIL_TEXTURE > 0)
-    #if F_SECONDARY_UV == 1
-        applyDetailTexture(color.rgb, normal, g_bUseSecondaryUvForDetailMask ? vTexCoord2 : texCoord);
-    #else
-        applyDetailTexture(color.rgb, normal, texCoord);
-    #endif
-#endif
-
-#if (F_SCALE_NORMAL_MAP == 1)
-    normal = mix(vec3(0, 0, 1), normal, g_flNormalMapScaleFactor);
-#else
-    normal = mix(vec3(0, 0, 1), normal, g_flBumpStrength);
-#endif
-
-#if F_TINT_MASK == 1
-    #if F_SECONDARY_UV == 1
-        vec2 tintMaskTexcoord = g_bUseSecondaryUvForTintMask ? vTexCoord2 : texCoord;
-    #else
-        vec2 tintMaskTexcoord = texCoord;
-    #endif
-    float tintStrength = texture(g_tTintMask, tintMaskTexcoord).x;
-    vec3 tintFactor = 1.0 - tintStrength * (1.0 - vVertexColorOut.rgb);
-#elif F_ENABLE_TINT_MASKS == 1
-    vec3 tintFactor = vec3(1.0); // Skip this as we already did tint mul
-#else
-    vec3 tintFactor = vVertexColorOut.rgb;
-#endif
-
-    vec3 albedo = pow(color.rgb, gamma) * tintFactor;
-    float opacity = color.a;
+    mat.Albedo = color.rgb;
+    mat.Opacity = color.a;
+    // this should be on regardless, right?
 #if defined(static_overlay) && F_PAINT_VERTEX_COLORS == 1
-    opacity *= vVertexColorOut.a;
+    mat.Opacity *= vVertexColorOut.a;
 #endif
 #if F_TRANSLUCENT == 1
-    opacity *= g_flOpacityScale;
+    mat.Opacity *= g_flOpacityScale;
 #endif
-    float metalness = 0.0;
-    float occlusion = 1.0;
-    vec4 extraParams = vec4(0); // r = retro reflectivity, g = sss mask, b = cloth, a = ???
 
-    vec3 irradiance = vec3(0.3);
-    LightingTerms lighting = Init();
+    // Alpha test
+#if (F_ALPHA_TEST == 1) || (defined(static_overlay) && (F_BLEND_MODE == 2))
+    mat.Opacity = AlphaTestAntiAliasing(mat.Opacity, vTexCoordOut);
+
+    if (mat.Opacity - 0.001 < g_flAlphaTestReference)   discard;
+#endif
 
 
-    // Define PBR parameters
-#if defined(csgo_character)
-    extraParams.xz = texture(g_tMetalness, texCoord).rb;
-    metalness = texture(g_tMetalness, texCoord).g;
-    // a = rimmask
-    occlusion = texture(g_tAmbientOcclusion, texCoord).r;
-#elif defined(csgo_weapon)
-    roughness = texture(g_tMetalness, texCoord).r;
-    metalness = texture(g_tMetalness, texCoord).g;
-    occlusion = texture(g_tAmbientOcclusion, texCoord).r;
-#elif defined(csgo_foliage)
-    occlusion = texture(g_tAmbientOcclusion, texCoord).r;
-#elif (hasUniformMetalness)
-    metalness = g_flMetalness;
-#elif (hasColorAlphaMetalness)
-    metalness = color.a;
-#elif (hasMetalnessTexture)
-    metalness = texture(g_tMetalness, texCoord).g;
-    #if (F_RETRO_REFLECTIVE == 1)
-        extraParams.x = texture(g_tMetalness, texCoord).r;
+    // Tinting
+#if (F_ENABLE_TINT_MASKS == 0)
+    vec3 tintFactor = vVertexColorOut.rgb;
+
+    #if (F_TINT_MASK == 1)
+        #if (F_SECONDARY_UV == 1)
+            vec2 tintMaskTexcoord = g_bUseSecondaryUvForTintMask ? vTexCoord2 : vTexCoordOut;
+        #else
+            vec2 tintMaskTexcoord = vTexCoordOut;
+        #endif
+        float tintStrength = texture(g_tTintMask, tintMaskTexcoord).x;
+        tintFactor = 1.0 - tintStrength * (1.0 - tintFactor.rgb);
     #endif
-#elif (defined(simple_2way_blend))
-    metalness = mix(g_flMetalnessA, g_flMetalnessB, blendFactor);
-    #if F_ENABLE_AMBIENT_OCCLUSION == 1
-        occlusion = color.a;
-    #endif
+
+    mat.Albedo = color.rgb * tintFactor;
+#else
+    mat.Albedo = color.rgb;
 #endif
 
-#if defined(vr_complex) && (F_METALNESS_TEXTURE == 0) && (F_RETRO_REFLECTIVE == 1)
-    extraParams.x = g_flRetroReflectivity;
-#endif
-#if defined(vr_complex) && (F_CLOTH_SHADING == 1)
-    extraParams.z = 1.0;
-#endif
+
+    // Normals and Roughness
+    mat.NormalMap = unpackHemiOctNormal(normalTexture);
 
 #if hasAnisoGloss
-    vec2 anisoGloss = texture(g_tAnisoGloss, texCoord).rg;
+    vec2 anisoGloss = texture(g_tAnisoGloss, vTexCoordOut).rg;
     // convert to iso roughness. temp solution
-    roughness = (anisoGloss.r + anisoGloss.g) / 2.0;
-#endif
-
-#if defined(vr_simple) && (F_AMBIENT_OCCLUSION_TEXTURE == 1)
-    #if (F_METALNESS_TEXTURE == 0)
-        occlusion = color.a;
-    #else
-        occlusion = texture(g_tAmbientOcclusion, texCoord).r;
-    #endif
-#endif
-
-#if defined(complex)
-    #if (F_SECONDARY_UV == 1)
-        occlusion = texture(g_tAmbientOcclusion, g_bUseSecondaryUvForAmbientOcclusion ? vTexCoord2 : texCoord).r;
-    #else
-        occlusion = texture(g_tAmbientOcclusion, texCoord).r;
-    #endif
-#endif
-
-    roughness = AdjustRoughnessByGeometricNormal(roughness, vertexNormal);
-
-    roughness = clamp(roughness, 0.005, 1.0); // <- inaccurate?
-
-    // Get the world normal for this fragment
-    vec3 N = calculateWorldNormal(normal, vertexNormal, vTangentOut, vBitangentOut);
-
-
-#if unlit == 1
-    outputColor = vec4(albedo, color.a);
+    mat.RoughnessTex = (anisoGloss.r + anisoGloss.g) * 0.5;
 #else
+    mat.RoughnessTex = normalTexture.b;
+#endif
+
+
+#if (F_SCALE_NORMAL_MAP == 1)
+    mat.NormalMap = normalize(mix(vec3(0, 0, 1), mat.NormalMap, g_flNormalMapScaleFactor));
+#else
+    mat.NormalMap = normalize(mix(vec3(0, 0, 1), mat.NormalMap, g_flBumpStrength));
+#endif
+
+    // Detail texture
+#if (F_DETAIL_TEXTURE > 0)
+    #if F_SECONDARY_UV == 1
+        applyDetailTexture(mat.Albedo, mat.NormalMap, g_bUseSecondaryUvForDetailMask ? vTexCoord2 : vTexCoordOut);
+    #else
+        applyDetailTexture(mat.Albedo, mat.NormalMap, vTexCoordOut);
+    #endif
+#endif
+
+    // Apply normal map
+    mat.Normal = calculateWorldNormal(mat.NormalMap, mat.GeometricNormal, mat.Tangent, mat.Bitangent);
+
+
+
+    // Various PBR parameters
+#if defined(csgo_character)
+    // a = rimmask
+    vec4 metalnessTexture = texture(g_tMetalness, vTexCoordOut);
+
+    mat.ExtraParams.xz = metalnessTexture.rb;
+    mat.Metalness = metalnessTexture.g;
+    mat.AmbientOcclusion = texture(g_tAmbientOcclusion, vTexCoordOut).r;
+
+#elif defined(csgo_weapon)
+    vec4 metalnessTexture = texture(g_tMetalness, vTexCoordOut);
+
+    mat.Roughness = metalnessTexture.r;
+    mat.Metalness = metalnessTexture.g;
+    mat.AmbientOcclusion = texture(g_tAmbientOcclusion, vTexCoordOut).r;
+
+#elif defined(csgo_foliage)
+    mat.AmbientOcclusion = texture(g_tAmbientOcclusion, vTexCoordOut).r;
+#elif (hasMetalnessTexture)
+    mat.Metalness = texture(g_tMetalness, vTexCoordOut).g;
+    #if (F_RETRO_REFLECTIVE == 1)
+        mat.ExtraParams.x = texture(g_tMetalness, vTexCoordOut).r;
+    #endif
+#elif (hasUniformMetalness)
+    mat.Metalness = g_flMetalness;
+#elif (hasColorAlphaMetalness)
+    mat.Metalness = color.a;
+#elif (defined(simple_2way_blend))
+    mat.Metalness = mix(g_flMetalnessA, g_flMetalnessB, blendFactor);
+#endif
+
+#if (hasColorAlphaAO)
+    mat.AmbientOcclusion = color.a;
+#elif defined(vr_simple) && (F_AMBIENT_OCCLUSION_TEXTURE == 1) && (F_METALNESS_TEXTURE == 1)
+    mat.AmbientOcclusion = texture(g_tAmbientOcclusion, vTexCoordOut).r;
+#elif defined(complex)
+    #if (F_SECONDARY_UV == 1)
+        mat.AmbientOcclusion = texture(g_tAmbientOcclusion, g_bUseSecondaryUvForAmbientOcclusion ? vTexCoord2 : vTexCoordOut).r;
+    #else
+        mat.AmbientOcclusion = texture(g_tAmbientOcclusion, vTexCoordOut).r;
+    #endif
+#endif
+
+
+
+    mat.Roughness = AdjustRoughnessByGeometricNormal(mat.RoughnessTex, mat.GeometricNormal);
+
+    mat.Roughness = clamp(mat.Roughness, 0.005, 1.0); // <- inaccurate?
+
+
+    #if defined(vr_complex) && (F_METALNESS_TEXTURE == 0) && (F_RETRO_REFLECTIVE == 1)
+        mat.ExtraParams.x = g_flRetroReflectivity;
+    #endif
+    #if defined(vr_complex) && (F_CLOTH_SHADING == 1)
+        mat.ExtraParams.z = 1.0;
+    #endif
+
+
+    mat.DiffuseColor = mat.Albedo - mat.Albedo * mat.Metalness;
+	mat.SpecularColor = mix(vec3(0.04), mat.Albedo, mat.Metalness);
+
+    // Self illum
+    #if (F_SELF_ILLUM == 1) && !defined(vr_xen_foliage) // xen foliage has really complicated selfillum and is wrong with this code
+        #if (F_SECONDARY_UV == 1)
+            vec2 selfIllumCoords = g_bUseSecondaryUvForSelfIllum ? vTexCoord2 : vTexCoordOut;
+        #else
+            vec2 selfIllumCoords = vTexCoordOut;
+        #endif
+
+        selfIllumCoords += fract(g_vSelfIllumScrollSpeed.xy * g_flTime);
+
+        float selfIllumTexture = texture(g_tSelfIllumMask, selfIllumCoords).r; // is this float or rgb?
+
+        vec3 selfIllumScale = (exp2(g_flSelfIllumBrightness) * g_flSelfIllumScale) * SRGBtoLinear(g_vSelfIllumTint.rgb);
+        mat.IllumColor = selfIllumScale * selfIllumTexture * mix(vec3(1.0), mat.Albedo, g_flSelfIllumAlbedoFactor);
+    #endif
+
+    mat.DiffuseAO = vec3(mat.AmbientOcclusion);
+    mat.SpecularAO = mat.AmbientOcclusion;
+
+    return mat;
+}
+
+
+
+
+
+// MAIN
+
+void main()
+{
+    vec3 vertexNormal = SwitchCentroidNormal(vNormalOut, vCentroidNormalOut);
+
+    // Get the view direction vector for this fragment
+    vec3 V = normalize(vEyePosition - vFragPosition);
+
+    MaterialProperties mat = GetMaterial(vertexNormal);
+
+    LightingTerms lighting = InitLighting();
+
+
     #if (F_GLASS == 1) || defined(glass)
-        float viewDotNormalInv = saturate(1.0 - (dot(V, N) - g_flEdgeColorThickness));
+        float viewDotNormalInv = saturate(1.0 - (dot(mat.ViewDir, mat.Normal) - g_flEdgeColorThickness));
         float fresnel = saturate(pow(viewDotNormalInv, g_flEdgeColorFalloff)) * g_flEdgeColorMaxOpacity;
         vec4 fresnelColor = vec4(g_vEdgeColor.xyz, g_bFresnel ? fresnel : 0.0);
 
-        vec4 glassResult = mix(vec4(albedo, opacity), fresnelColor, g_flOpacityScale);
-        albedo = glassResult.rgb;
-        opacity = glassResult.a;
+        vec4 glassResult = mix(vec4(mat.Albedo, mat.Opacity), fresnelColor, g_flOpacityScale);
+        mat.Albedo = glassResult.rgb; // todo: is this right?
+        mat.Opacity = glassResult.a;
     #endif
 
-    outputColor = vec4(albedo, opacity);
+    outputColor = vec4(mat.Albedo, mat.Opacity);
 
+
+#if (unlit == 0)
 
     vec3 L = normalize(-getSunDir());
-    vec3 H = normalize(V + L);
-
-    vec3 F0 = vec3(0.04);
-
-    vec3 diffuseColor = albedo - albedo * metalness;
-	vec3 specularColor = mix(F0, albedo, metalness);
+    vec3 H = normalize(mat.ViewDir + L);
 
 
-    // Direct Lighting
+
+    // Lighting
     float visibility = 1.0;
+    lighting.DiffuseIndirect = vec3(0.3);
 
 #if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1)
     #if (LightmapGameVersionNumber == 1)
         vec4 vLightStrengths = texture(g_tDirectLightStrengths, vLightmapUVScaled);
-        vec4 strengthSquared = vLightStrengths * vLightStrengths;
+        vec4 strengthSquared = pow2(vLightStrengths);
         vec4 vLightIndices = texture(g_tDirectLightIndices, vLightmapUVScaled) * 255;
         // TODO: figure this out, it's barely working
         float index = 0.0;
@@ -459,8 +514,8 @@ void main()
 
     if (visibility > 0.0)
     {
-        vec3 specularLight = specularLighting(L, V, N, F0, specularColor, roughness, extraParams);
-        float diffuseLight = diffuseLobe(max(dot(N, L), 0.0), roughness);
+        vec3 specularLight = specularLighting(L, mat.ViewDir, mat.Normal, mat.SpecularColor, mat.Roughness, mat.ExtraParams);
+        float diffuseLight = diffuseLobe(max(dot(mat.Normal, L), 0.0), mat.Roughness);
 
        lighting.SpecularDirect += specularLight * visibility * getSunColor();
        lighting.DiffuseDirect += diffuseLight * visibility * getSunColor();
@@ -469,101 +524,108 @@ void main()
 
     // Indirect Lighting
     #if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1) && (LightmapGameVersionNumber > 0)
-        irradiance = texture(g_tIrradiance, vLightmapUVScaled).rgb;
+        vec3 irradiance = texture(g_tIrradiance, vLightmapUVScaled).rgb;
         vec4 vAHDData = texture(g_tDirectionalIrradiance, vLightmapUVScaled);
 
-        irradiance = ComputeLightmapShading(irradiance, vAHDData, normal);
+        lighting.DiffuseIndirect = ComputeLightmapShading(irradiance, vAHDData, mat.NormalMap);
 
-        occlusion = min(occlusion, vAHDData.a);
+        // In non-lightmap shaders, SpecularAO always does a min(1.0, specularAO) in the same place where lightmap
+        // shaders does min(bakedAO, specularAO). That means that bakedAO exists and is a constant 1.0 in those shaders!
+        mat.SpecularAO = min(mat.SpecularAO, vAHDData.a);
     #elif (D_BAKED_LIGHTING_FROM_VERTEX_STREAM == 1)
-        irradiance = vPerVertexLightingOut.rgb;
+        lighting.DiffuseIndirect = vPerVertexLightingOut.rgb;
     #endif
 
-
-    lighting.DiffuseIndirect = irradiance;
-
-    // Environment Map
+    // Environment Maps
     #if (S_SPECULAR == 1)
-        vec3 specular = GetEnvironment(N, V, roughness, specularColor, irradiance, extraParams);
-        lighting.SpecularIndirect += specular * occlusion;
+        vec3 envMap = GetEnvironment(mat.Normal, mat.ViewDir, mat.Roughness, mat.SpecularColor, lighting.DiffuseIndirect, mat.ExtraParams);
+        lighting.SpecularIndirect += envMap;
     #endif
 
-    lighting.DiffuseDirect *= mix(1.0, occlusion, g_flAmbientOcclusionDirectDiffuse);
-    lighting.SpecularDirect *= mix(1.0, occlusion, g_flAmbientOcclusionDirectSpecular);
+    // Apply AO
+    ApplyAmbientOcclusion(lighting, mat);
 
-    vec3 diffuseLighting = lighting.DiffuseDirect + lighting.DiffuseIndirect * occlusion;
-    vec3 specularLighting = lighting.SpecularDirect + lighting.SpecularIndirect * occlusion;
+    vec3 diffuseLighting = lighting.DiffuseDirect + lighting.DiffuseIndirect;
+    vec3 specularLighting = lighting.SpecularDirect + lighting.SpecularIndirect;
 
     #if F_NO_SPECULAR_AT_FULL_ROUGHNESS == 1
-        specularLighting = (roughness == 1.0) ? vec3(0) : specularLighting;
+        specularLighting = (mat.Roughness == 1.0) ? vec3(0) : specularLighting;
     #endif
 
-    vec3 combinedLighting = diffuseColor * diffuseLighting + specularLighting;
+    // wip
+    #if defined(hasTransmission)
+        vec3 transmissiveLighting = o.TransmissiveDirect * mat.TransmissiveColor;
+    #else
+        vec3 transmissiveLighting = vec3(0.0);
+    #endif
+
+    // Unique HLA blend mode: specular unaffected by opacity
+    #if blendMembrane
+        vec3 combinedLighting = specularLighting + (mat.DiffuseColor * diffuseLighting + transmissiveLighting + mat.IllumColor) * mat.Opacity;
+        outputColor.a = 1.0;
+    #else
+        vec3 combinedLighting = mat.DiffuseColor * diffuseLighting + specularLighting + transmissiveLighting + mat.IllumColor;
+    #endif
 
     outputColor.rgb = combinedLighting;
-
-    #if F_SELF_ILLUM == 1
-        vec3 SelfIllumScaled = pow2(g_flSelfIllumBrightness) * g_flSelfIllumScale * SRGBtoLinear(g_vSelfIllumTint.rgb);
-        outputColor.rgb *= max(vec3(1.0), texture(g_tSelfIllumMask, texCoord).r * SelfIllumScaled);
-    #endif
-
 #endif
+
 #if F_DISABLE_TONE_MAPPING == 0
-    outputColor.rgb = pow(outputColor.rgb, vec3(invGamma));
+    outputColor.rgb = pow(outputColor.rgb, invGamma);
     //outputColor.rgb = SRGBtoLinear(outputColor.rgb);
 #endif
 
     // Rendermodes
 
 #if renderMode_FullBright == 1
-    vec3 fullbrightLighting = CalculateFullbrightLighting(albedo, N, V);
-    outputColor = vec4(pow(fullbrightLighting, vec3(invGamma)), opacity);
+    vec3 fullbrightLighting = CalculateFullbrightLighting(mat.Albedo, mat.Normal, mat.ViewDir);
+    outputColor = vec4(pow(fullbrightLighting, invGamma), mat.Opacity);
 #endif
 
 #if renderMode_Color == 1
-    outputColor = vec4(color.rgb, 1.0);
+    outputColor = vec4(pow(mat.Albedo, invGamma), 1.0);
 #endif
 
 #if renderMode_BumpMap == 1
-    outputColor = vec4(PackToColor(normal), 1.0);
+    outputColor = vec4(PackToColor(mat.NormalMap), 1.0);
 #endif
 
 #if renderMode_Tangents == 1
-    outputColor = vec4(PackToColor(vTangentOut), 1.0);
+    outputColor = vec4(PackToColor(mat.Tangent), 1.0);
 #endif
 
 #if renderMode_Normals == 1
-    outputColor = vec4(PackToColor(vertexNormal), 1.0);
+    outputColor = vec4(PackToColor(mat.GeometricNormal), 1.0);
 #endif
 
 #if renderMode_BumpNormals == 1
-    outputColor = vec4(PackToColor(N), 1.0);
+    outputColor = vec4(PackToColor(mat.Normal), 1.0);
 #endif
 
 #if (renderMode_Diffuse == 1) && (unlit != 1)
-    outputColor.rgb = pow(diffuseLighting * 0.5, vec3(invGamma));
+    outputColor.rgb = pow(diffuseLighting * 0.5, invGamma);
 #endif
 
 #if (renderMode_Specular == 1) && (unlit != 1)
-    outputColor.rgb = pow(specularLighting, vec3(invGamma));
+    outputColor.rgb = pow(specularLighting, invGamma);
 #endif
 
 #if renderMode_PBR == 1
-    outputColor = vec4(occlusion, roughness, metalness, 1.0);
+    outputColor = vec4(mat.AmbientOcclusion, GetIsoRoughness(mat.Roughness), mat.Metalness, 1.0);
 #endif
 
 #if (renderMode_Cubemaps == 1)
     // No bumpmaps, full reflectivity
-    vec3 EnvMap = GetEnvironment(vertexNormal, V, 0.0, vec3(1.0), vec3(0.0), vec4(0)).rgb;
-    outputColor.rgb = pow(EnvMap, vec3(invGamma));
+    vec3 viewmodeEnvMap = GetEnvironment(mat.GeometricNormal, mat.ViewDir, 0.0, vec3(1.0), vec3(0.0), vec4(0)).rgb;
+    outputColor.rgb = pow(viewmodeEnvMap, invGamma);
 #endif
 
 #if renderMode_Illumination == 1
-    outputColor = vec4(pow(0.5 * lighting.DiffuseDirect + lighting.SpecularDirect, vec3(invGamma)), 1.0);
+    outputColor = vec4(pow(lighting.DiffuseDirect + lighting.SpecularDirect, invGamma), 1.0);
 #endif
 
 #if renderMode_Irradiance == 1 && (F_GLASS == 0)
-    outputColor = vec4(pow(irradiance, vec3(invGamma)), 1.0);
+    outputColor = vec4(pow(lighting.DiffuseIndirect, invGamma), 1.0);
 #endif
 
 #if renderMode_VertexColor == 1
@@ -575,6 +637,6 @@ void main()
 #endif
 
 #if renderMode_ExtraParams == 1
-    outputColor.rgb = extraParams.rgb;
+    outputColor.rgb = mat.ExtraParams.rgb;
 #endif
 }

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -81,12 +81,12 @@
 in vec3 vFragPosition;
 
 in vec3 vNormalOut;
-centroid in vec3 vCentroidNormalOut;
 in vec3 vTangentOut;
 in vec3 vBitangentOut;
 in vec2 vTexCoordOut;
 in vec4 vVertexColorOut;
 
+centroid in vec3 vCentroidNormalOut;
 
 #if F_SECONDARY_UV == 1
     in vec2 vTexCoord2;
@@ -455,12 +455,12 @@ MaterialProperties_t GetMaterial(vec3 vertexNormals)
             float selfIllumMask = combinedMasks.b;
         #endif
 
-        vec3 selfIllumScale = (exp2(g_flSelfIllumBrightness) * g_flSelfIllumScale) * SRGBtoLinear(g_vSelfIllumTint.rgb);
+        vec3 selfIllumScale = (exp2(g_flSelfIllumBrightness) * g_flSelfIllumScale) * SrgbGammaToLinear(g_vSelfIllumTint.rgb);
         mat.IllumColor = selfIllumScale * selfIllumMask * mix(vec3(1.0), mat.Albedo, g_flSelfIllumAlbedoFactor);
     #endif
 
     #if defined(vr_skin)
-        mat.TransmissiveColor = SRGBtoLinear(g_vTransmissionColor.rgb) * color.a;
+        mat.TransmissiveColor = SrgbGammaToLinear(g_vTransmissionColor.rgb) * color.a;
 
         float mouthOcclusion = mix(1.0, g_flMouthInteriorBrightnessScale, mat.ExtraParams.a);
         mat.TransmissiveColor *= mouthOcclusion;
@@ -536,7 +536,7 @@ void main()
 
 #if (F_DISABLE_TONE_MAPPING == 0)
     outputColor.rgb = pow(outputColor.rgb, invGamma);
-    //outputColor.rgb = SRGBtoLinear(outputColor.rgb);
+    //outputColor.rgb = SrgbGammaToLinear(outputColor.rgb);
 #endif
 
     // Rendermodes

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -32,6 +32,7 @@
 #endif
 
 //Parameter defines - These are default values and can be overwritten based on material/model parameters
+// BLENDING
 #define F_FULLBRIGHT 0
 #define F_LIT 0
 #define F_UNLIT 0

--- a/GUI/Types/Renderer/Shaders/simple.frag
+++ b/GUI/Types/Renderer/Shaders/simple.frag
@@ -177,9 +177,21 @@ uniform float g_flOpacityScale = 1.0;
     uniform sampler2D g_tMetalness;
 #endif
 
+uniform vec4 g_vTexCoordScale2 = vec4(1.0);
+
 #if (F_FANCY_BLENDING > 0)
     uniform sampler2D g_tBlendModulation;
     uniform float g_flBlendSoftness;
+#endif
+
+#if defined(simple_2way_blend)
+    uniform sampler2D g_tMask;
+    uniform float g_flMetalnessA = 0.0;
+    uniform float g_flMetalnessB = 0.0;
+#if defined(steampal_2way_blend_mask)
+    uniform float g_BlendFalloff = 0.0;
+    uniform float g_BlendHeight = 0.0;
+#endif
 #endif
 
 #if (F_RETRO_REFLECTIVE == 1)
@@ -191,16 +203,6 @@ uniform float g_flOpacityScale = 1.0;
 #endif
 uniform float g_flBumpStrength = 1.0;
 
-#if defined(simple_2way_blend)
-    uniform sampler2D g_tMask;
-    uniform float g_flMetalnessA = 0.0;
-    uniform float g_flMetalnessB = 0.0;
-    uniform vec4 g_vTexCoordScale2 = vec4(1.0);
-#if defined(steampal_2way_blend_mask)
-    uniform float g_BlendFalloff = 0.0;
-    uniform float g_BlendHeight = 0.0;
-#endif
-#endif
 
 #if (hasAmbientOcclusionTexture)
     uniform sampler2D g_tAmbientOcclusion;
@@ -274,6 +276,8 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
         float softnessPaint = vColorBlendValues.g;
 
         blendFactor = applyBlendModulation(blendFactor, blendModTexel.r, softnessPaint);
+    #else
+        float blendFactor = vColorBlendValues.r;
     #endif
 
     #if (F_ENABLE_TINT_MASKS == 1)

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -134,26 +134,28 @@ vec4 GetTintColor()
 }
 
 #if (F_DETAIL_TEXTURE > 0)
-    uniform float g_flDetailTexCoordRotation = 0.0;
-    uniform vec4 g_vDetailTexCoordOffset = vec4(0.0);
-    uniform vec4 g_vDetailTexCoordScale = vec4(1.0);
-    out vec2 vDetailTexCoords;
 
-    #if (F_SECONDARY_UV == 1)
-        uniform bool g_bUseSecondaryUvForDetailTexture = false; // this doesn't always show up
-    #endif
+uniform float g_flDetailTexCoordRotation = 0.0;
+uniform vec4 g_vDetailTexCoordOffset = vec4(0.0);
+uniform vec4 g_vDetailTexCoordScale = vec4(1.0);
+out vec2 vDetailTexCoords;
 
-    vec2 getDetailCoords(vec2 texCoords)
-    {
-        // in S2 most of these values are precomputed into the globals buffer
-        float rotation = radians(g_flDetailTexCoordRotation);
-        float sinRot = sin(rotation);
-        float cosRot = cos(rotation);
-        vec2 offset = (g_vDetailTexCoordScale.xy * -0.5) * vec2(cosRot - sinRot, sinRot - cosRot) + g_vDetailTexCoordOffset.xy + 0.5;
-        vec4 xform = g_vDetailTexCoordScale.xxyy * vec4(cosRot, -sinRot, sinRot, cosRot);
+#if (F_SECONDARY_UV == 1)
+    uniform bool g_bUseSecondaryUvForDetailTexture = false; // this doesn't always show up
+#endif
 
-        return vec2(dot(xform.xy, texCoords.xy), dot(xform.zw, texCoords.xy)) + offset;
-    }
+vec2 getDetailCoords(vec2 texCoords)
+{
+    // in S2 most of these values are precomputed into the globals buffer
+    float rotation = radians(g_flDetailTexCoordRotation);
+    float sinRot = sin(rotation);
+    float cosRot = cos(rotation);
+    vec2 offset = (g_vDetailTexCoordScale.xy * -0.5) * vec2(cosRot - sinRot, sinRot - cosRot) + g_vDetailTexCoordOffset.xy + 0.5;
+    vec4 xform = g_vDetailTexCoordScale.xxyy * vec4(cosRot, -sinRot, sinRot, cosRot);
+
+    return vec2(dot(xform.xy, texCoords.xy), dot(xform.zw, texCoords.xy)) + offset;
+}
+
 #endif
 
 

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -99,7 +99,7 @@ uniform vec4 g_vTexCoordOffset;
 uniform vec4 g_vTexCoordScale = vec4(1.0);
 uniform vec4 g_vTexCoordScrollSpeed;
 uniform float g_flTime;
-uniform vec4 g_vTexCoordCenter = vec4(0.0);
+uniform vec4 g_vTexCoordCenter = vec4(0.5);
 uniform float g_flTexCoordRotation = 0.0;
 
 #if F_TEXTURE_ANIMATION == 1

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -122,7 +122,7 @@ vec3 GetSphericalProjectedAnisoBitangent(vec3 normal, vec3 tangent)
 
     vec3 vAnisoTangent = cross(g_vSphericalAnisotropyPole.xyz, normal);
     // Prevent length of 0
-    vAnisoTangent = mix(vAnisoTangent, tangent.xyz, bvec3(length(vec3(equal(vAnisoTangent, vec3(0.0)))) != 0.0));
+    vAnisoTangent = mix(vAnisoTangent, tangent, bvec3(length(vec3(equal(vAnisoTangent, vec3(0.0)))) != 0.0));
 
     if (g_vSphericalAnisotropyAngle != 0.0)
     {

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -17,6 +17,7 @@
 #define F_LAYERS 0
 #define F_SECONDARY_UV 0
 #define F_DETAIL_TEXTURE 0
+#define F_FOLIAGE_ANIMATION 0
 #define F_TEXTURE_ANIMATION 0
 #define F_TEXTURE_ANIMATION_MODE 0
 //End of parameter defines
@@ -63,8 +64,12 @@ in vec2 vTEXCOORD;
     in vec4 vCOLOR;
 #endif
 #if F_SECONDARY_UV
-    in vec2 vTEXCOORD2;
+    in vec4 vTEXCOORD2;
     out vec2 vTexCoord2;
+#endif
+#if (F_FOLIAGE_ANIMATION > 0)
+    in vec4 vTEXCOORD1;
+    in vec4 vTEXCOORD2;
 #endif
 
 out vec4 vVertexColorOut;
@@ -180,7 +185,12 @@ void main()
     vBitangentOut = tangent.w * cross( vNormalOut, vTangentOut );
 #endif
 
-	vTexCoordOut = GetAnimatedUVs(vTEXCOORD);
+#if (F_FOLIAGE_ANIMATION > 0)
+    // TODO: this should always be texcoord semanticindex 0
+	vTexCoordOut = GetAnimatedUVs(vTEXCOORD2.xy);
+#else
+	vTexCoordOut = GetAnimatedUVs(vTEXCOORD.xy);
+#endif
 
 #if D_BAKED_LIGHTING_FROM_LIGHTMAP == 1
     vLightmapUVScaled = vec3(vLightmapUV * g_vLightmapUvScale.xy, 0);
@@ -197,7 +207,7 @@ void main()
 #endif
 
 #if F_SECONDARY_UV == 1
-    vTexCoord2 = vTEXCOORD2;
+    vTexCoord2 = vTEXCOORD2.xy;
 #endif
 
 #if F_DETAIL_TEXTURE > 0

--- a/GUI/Types/Renderer/Shaders/simple.vert
+++ b/GUI/Types/Renderer/Shaders/simple.vert
@@ -208,7 +208,7 @@ void main()
 
 #if (F_LAYERS > 0) || defined(simple_2way_blend)
     vColorBlendValues = vBLEND_COLOR / 255.0f;
-    // After HLA they presumably realized this was dumb as hell
+    // todo: check csgo
     #if defined(vr_blend)
         vColorBlendValues.y = max(0.5 * vBLEND_ALPHA.x, 0.1);
     #endif

--- a/GUI/Types/Renderer/Shaders/sky.frag
+++ b/GUI/Types/Renderer/Shaders/sky.frag
@@ -1,5 +1,7 @@
 #version 460
 
+#include "common/utils.glsl"
+
 in vec3 vSkyLookupInterpolant;
 out vec4 vColor;
 
@@ -37,15 +39,7 @@ vec3 DecodeYCoCg(vec4 YCoCg)
 
     vec3 color = vec3(R, G, B);
 
-    vec3 vLinearSegment =  color / vec3(12.92);
-    vec3 vExpSegment = pow((color / vec3(1.055)) + vec3(0.0521327), vec3(2.4));
-
-    const float cap = 0.04045;
-	float select = R > cap ? vExpSegment.x : vLinearSegment.x;
-	float select1 = G > cap ? vExpSegment.y : vLinearSegment.y;
-	float select2 = B > cap ? vExpSegment.z : vLinearSegment.z;
-
-    return vec3(select, select1, select2);
+    return SrgbGammaToLinear(color);
 }
 
 void main()
@@ -66,10 +60,11 @@ void main()
     //vColor.rgb *= (1.0 + g_flBrightnessExposureBias);
     //vColor.rgb *= (1.0 + g_flRenderOnlyExposureBias);
     vColor.rgb *= g_vTint;
-    vColor.rgb = max(vColor.rgb, vec3(0.0));
+    vColor.rgb = ClampToPositive(vColor.rgb);
     vColor.rgb *= g_flToneMapScalarLinear;
 
-    vColor.a = dot(vColor.rgb, vec3(0.3, 0.59, 0.11));
+    // Why do we do this?
+    vColor.a = GetLuma(vColor.rgb);
 
     //vColor.rgb += (vSkyLookupInterpolant*0.5);
 }

--- a/GUI/Types/Renderer/Shaders/vr_unlit.frag
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.frag
@@ -7,6 +7,7 @@
 in vec3 vFragPosition;
 
 in vec2 vTexCoordOut;
+in vec4 vTintColorFadeOut;
 
 out vec4 outputColor;
 
@@ -14,17 +15,12 @@ uniform float g_flAlphaTestReference;
 uniform sampler2D g_tColor2;
 uniform sampler2D g_tTintMask;
 
-uniform vec4 m_vTintColorSceneObject;
-uniform vec3 m_vTintColorDrawCall;
-
-uniform vec4 g_vTexCoordOffset;
-uniform vec4 g_vTexCoordScale;
 
 //Main entry point
 void main()
 {
     //Get the ambient color from the color texture
-    vec4 color = texture(g_tColor2, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy) * vec4(m_vTintColorDrawCall.xyz, 1);
+    vec4 color = texture(g_tColor2, vTexCoordOut);
 
 #if F_ALPHA_TEST == 1
     if (color.a < g_flAlphaTestReference)
@@ -34,12 +30,10 @@ void main()
 #endif
 
     //Calculate tint color
-    float tintStrength = texture(g_tTintMask, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordScale.xy).y;
-    vec3 tintColor = m_vTintColorSceneObject.xyz * m_vTintColorDrawCall;
-    vec3 tintFactor = tintStrength * tintColor + (1 - tintStrength) * vec3(1);
+    float tintStrength = texture(g_tTintMask, vTexCoordOut).y;
+    vec3 tintFactor = mix(vec3(1.0), vTintColorFadeOut.rgb, tintStrength);
 
     //Simply multiply the color from the color texture with the illumination
-    //outputColor = vec4(color.rgb * tintFactor, color.a);
-    vec2 tc = vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy;
-    outputColor = vec4( texture(g_tColor2, vTexCoordOut * g_vTexCoordScale.xy + g_vTexCoordOffset.xy).xyz, 1);
+    //outputColor = vec4(color.rgb * tintFactor, color.a * vTintColorFadeOut.a);
+    outputColor = vec4(color.rgb, 1.0);
 }

--- a/GUI/Types/Renderer/Shaders/vr_unlit.vert
+++ b/GUI/Types/Renderer/Shaders/vr_unlit.vert
@@ -8,9 +8,16 @@ in vec2 vTEXCOORD;
 out vec3 vFragPosition;
 
 out vec2 vTexCoordOut;
+out vec4 vTintColorFadeOut;
 
 uniform mat4 uProjectionViewMatrix;
 uniform mat4 transform;
+
+uniform vec4 g_vTexCoordOffset;
+uniform vec4 g_vTexCoordScale;
+
+uniform vec4 m_vTintColorSceneObject;
+uniform vec3 m_vTintColorDrawCall;
 
 void main()
 {
@@ -18,5 +25,8 @@ void main()
     gl_Position = uProjectionViewMatrix * fragPosition;
     vFragPosition = fragPosition.xyz / fragPosition.w;
 
-    vTexCoordOut = vTEXCOORD;
+    vTexCoordOut = vTEXCOORD * g_vTexCoordScale.xy + g_vTexCoordOffset.xy;
+
+    vTintColorFadeOut.rgb = m_vTintColorSceneObject.rgb * m_vTintColorDrawCall;
+    vTintColorFadeOut.a = m_vTintColorSceneObject.a;
 }


### PR DESCRIPTION
- Implement material struct, hopefully providing a major boost to code quality
- Moved entire material pass to GetMaterial
- Further compartmentalize lighting passes, making unified lighting more achievable
- Add anisotropic gloss support
- Add bent normals support
- Improve support for vr_skin
- Implement diffuse wrap lighting
- Update cloth shading code to CS2 code
- Improve multiblend.frag/vert blending to be accurate to valve's code (yeah, the dota 2 shader)
- Improve code quality on various old shaders