### PR TITLE
attempt to fix vnmskel decomp

### DIFF
--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -91,7 +91,8 @@ partial class ModelExtract
             }
         };
 
-        dmx.Save(stream, "keyvalues2", 4);
+        //dmx.Save(stream, "keyvalues2", 4);
+        dmx.Save(stream, "binary", 9); //Fixes vnmskel decomp
 
         return stream.ToArray();
     }


### PR DESCRIPTION
Saving dmx files as binary 9 instead of keyvalues 4 fixes vnmskel decomp.
<img width="1920" height="1050" alt="blender_z2gzLsxCrp" src="https://github.com/user-attachments/assets/42441668-cbda-4ef4-9ea3-c8792ba60d12" />
