### PR TITLE
Skip per-block compressed sizes metadata in BinaryKV3 version 5+

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/BinaryKV3.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/BinaryKV3.cs
@@ -630,9 +630,14 @@ namespace ValveResourceFormat.ResourceTypes
                     {
                         if (version >= 5)
                         {
-                            UnexpectedMagicException.Assert(sizeBlockCompressedSizesBytes == 0, sizeBlockCompressedSizesBytes);
+                            // sizeBlockCompressedSizesBytes contains per-block compressed sizes metadata
+                            // that is not needed for bulk ZSTD decompression - skip it
+                            if (sizeBlockCompressedSizesBytes > 0)
+                            {
+                                reader.BaseStream.Position += sizeBlockCompressedSizesBytes;
+                            }
 
-                            var sizeCompressedBinaryBlobs = sizeCompressedTotal - sizeCompressedBuffer1 - sizeCompressedBuffer2;
+                            var sizeCompressedBinaryBlobs = sizeCompressedTotal - sizeCompressedBuffer1 - sizeCompressedBuffer2 - sizeBlockCompressedSizesBytes;
 
                             binaryBlobsRaw = ArrayPool<byte>.Shared.Rent(sizeBinaryBlobsBytes);
                             context.BinaryBlobs = new ArraySegment<byte>(binaryBlobsRaw, 0, sizeBinaryBlobsBytes);


### PR DESCRIPTION
# Fix BinaryKV3: Handle non-zero sizeBlockCompressedSizesBytes in ZSTD v5 blocks decompression

## Problem

When parsing KV3 v5 binary data with ZSTD compression (compressionMethod == 2) that has `sizeBlockCompressedSizesBytes > 0`, the parser throws `UnexpectedMagicException` at line 633 of `BinaryKV3.cs`:

```csharp
UnexpectedMagicException.Assert(sizeBlockCompressedSizesBytes == 0, sizeBlockCompressedSizesBytes);
```

This occurs when loading large physics data blocks (e.g., `world_physics.vmdl_c` from Deadlock's `dl_midtown` map, where the PHYS block is ~104MB compressed / ~286MB uncompressed and has `sizeBlockCompressedSizesBytes = 4`).

The `sizeBlockCompressedSizesBytes` field represents per-block compressed sizes metadata embedded in the stream. These bytes need to be skipped before reading the actual compressed binary blobs data, and their size must be subtracted from the total compressed size calculation.

## Fix

In `BinaryKV3.cs`, lines 631-642:

**Before:**
```csharp
if (version >= 5)
{
    UnexpectedMagicException.Assert(sizeBlockCompressedSizesBytes == 0, sizeBlockCompressedSizesBytes);

    var sizeCompressedBinaryBlobs = sizeCompressedTotal - sizeCompressedBuffer1 - sizeCompressedBuffer2;

    binaryBlobsRaw = ArrayPool<byte>.Shared.Rent(sizeBinaryBlobsBytes);
    context.BinaryBlobs = new ArraySegment<byte>(binaryBlobsRaw, 0, sizeBinaryBlobsBytes);

    zstdDecompressor ??= new ZstdSharp.Decompressor();

    DecompressZSTD(zstdDecompressor, reader, context.BinaryBlobs, sizeCompressedBinaryBlobs);
}
```

**After:**
```csharp
if (version >= 5)
{
    // sizeBlockCompressedSizesBytes contains per-block compressed sizes metadata
    // that is not needed for bulk ZSTD decompression — skip it
    if (sizeBlockCompressedSizesBytes > 0)
    {
        reader.BaseStream.Position += sizeBlockCompressedSizesBytes;
    }

    var sizeCompressedBinaryBlobs = sizeCompressedTotal - sizeCompressedBuffer1 - sizeCompressedBuffer2 - sizeBlockCompressedSizesBytes;

    binaryBlobsRaw = ArrayPool<byte>.Shared.Rent(sizeBinaryBlobsBytes);
    context.BinaryBlobs = new ArraySegment<byte>(binaryBlobsRaw, 0, sizeBinaryBlobsBytes);

    zstdDecompressor ??= new ZstdSharp.Decompressor();

    DecompressZSTD(zstdDecompressor, reader, context.BinaryBlobs, sizeCompressedBinaryBlobs);
}
```

## Changes

1. **Remove the assert** — `sizeBlockCompressedSizesBytes` can legitimately be non-zero
2. **Skip the bytes** in the reader stream (`reader.BaseStream.Position += sizeBlockCompressedSizesBytes`)
3. **Subtract from compressed size** — `sizeCompressedBinaryBlobs` must exclude the skipped metadata bytes

## Reproduction

Open `maps/dl_midtown/world_physics.vmdl_c` from Deadlock game files in Source 2 Viewer — it will crash with `UnexpectedMagicException` on the PHYS block because `sizeBlockCompressedSizesBytes = 4`.

## Tested

Verified that after this fix, the PHYS block (KV3 v5, ZSTD, 104MB compressed, 286MB uncompressed, `sizeBlockCompressedSizesBytes=4`) decompresses correctly and yields valid physics KV data with 17 top-level keys including `m_parts`, `m_collisionAttributes`, `m_surfacePropertyHashes`, etc.
