### PR TITLE
Fix UV export for decal/overlay meshes

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -308,13 +308,32 @@ public partial class GltfModelExporter
 
         var vertexBuffers = drawCall.GetArray("m_vertexBuffers");
 
+        // Each vertex buffer names its TEXCOORDs/COLORs from 0 independently, so remap to a
+        // global counter here to avoid later buffers overwriting earlier ones on the primitive.
+        var texcoordCounter = 0;
+        var colorCounter = 0;
+
         foreach (var vertexBufferInfo in vertexBuffers)
         {
             var vertexBufferIndex = vertexBufferInfo.GetInt32Property("m_hBuffer");
 
             foreach (var (attributeKey, accessor) in vertexBufferAccessors[vertexBufferIndex])
             {
-                primitive.SetVertexAccessor(attributeKey, accessor);
+                string key;
+                if (attributeKey.StartsWith("TEXCOORD_", StringComparison.Ordinal))
+                {
+                    key = $"TEXCOORD_{texcoordCounter++}";
+                }
+                else if (attributeKey.StartsWith("COLOR_", StringComparison.Ordinal))
+                {
+                    key = $"COLOR_{colorCounter++}";
+                }
+                else
+                {
+                    key = attributeKey;
+                }
+
+                primitive.SetVertexAccessor(key, accessor);
 
                 DebugValidateGLTF();
             }


### PR DESCRIPTION
CreateVertexBufferAccessors numbers TEXCOORD/COLOR accessors locally per vertex buffer, so each buffer starts from TEXCOORD_0.

When a draw call uses multiple vertex buffers (geometry + a separate lightmap UV buffer) the second buffer's TEXCOORD_0 would silently overwrite the first's on the primitive which would replace the primary UV with the lightmap UV.

Before:
![blender_m2te5s4RJg](https://github.com/user-attachments/assets/12aa776f-9b3b-4bae-b66c-bec028d08914)

After:
![blender_M29IUyEUrJ](https://github.com/user-attachments/assets/0dcafc5c-f0c9-4efb-837d-636bcdbd4579)
