### PR TITLE
Fix envmap render mode in vr_standard

### DIFF
--- a/Renderer/Shaders/vr_standard.frag.slang
+++ b/Renderer/Shaders/vr_standard.frag.slang
@@ -274,8 +274,7 @@ void main()
     }
     else if (g_iRenderMode == renderMode_Cubemaps)
     {
-        vec3 viewmodeEnvMap = GetEnvironment(mat).rgb;
-        outputColor.rgb = SrgbLinearToGamma(viewmodeEnvMap);
+        outputColor.rgb = GetEnvironment(mat).rgb;
     }
     else if (g_iRenderMode == renderMode_Tint)
     {

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -1108,6 +1108,10 @@ namespace ValveResourceFormat.ResourceTypes
             {
                 codec |= TextureCodec.ColorSpaceLinear;
             }
+            else
+            {
+                codec |= TextureCodec.ColorSpaceSrgb;
+            }
 
             return codec;
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -1108,10 +1108,6 @@ namespace ValveResourceFormat.ResourceTypes
             {
                 codec |= TextureCodec.ColorSpaceLinear;
             }
-            else
-            {
-                codec |= TextureCodec.ColorSpaceSrgb;
-            }
 
             return codec;
         }


### PR DESCRIPTION
After the envmap rendering was fixed for the standard rendering mode with the vr_standard shader, it was still not fixed for the cubemap rendering mode. This removes the forced color space conversion when using said rendering mode so SteamVR Home cubemaps aren't blown out.
I only changed it for the vr_standard shader but should I also change the other shaders to mimic this behavior as well?