### PR TITLE
Fix mesh list filtering

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -707,7 +707,7 @@ namespace ValveResourceFormat.IO
                 var meshName = m.Name;
 
                 // Apply mesh filter if specified
-                if (MeshFilter.Count > 0 && !MeshFilter.Contains(name.Split('.')[^1]))
+                if (MeshFilter.Count > 0 && !MeshFilter.Contains(meshName.Split('.')[^1]))
                 {
                     continue;
                 }


### PR DESCRIPTION
The current mesh filtering filters it based only on the file extension, since `split` is called using the file name instead of the mesh name.
This doesn't seem to be the intended behavior.