### PR TITLE
Fix fog in SteamVR Home and Robot Repair

### DIFF
--- a/Renderer/Renderer/SceneEnvironment/SceneGradientFog.cs
+++ b/Renderer/Renderer/SceneEnvironment/SceneGradientFog.cs
@@ -46,6 +46,7 @@ public class SceneGradientFog(Scene scene) : SceneNode(scene)
         var distBias = -(startDist * distScale);
 
         // this might be same as cubemap fog height calculations
+        // Doesn't seem to be the case for SteamVR, it cuts off too early at the top
         var heightScale = 1f / (HeightStart - HeightEnd);
         var heightBias = -(HeightEnd * heightScale);
 

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -583,24 +583,37 @@ namespace ValveResourceFormat.Renderer.World
                         var endDist = entity.GetFloatProperty("fogend");
 
                         // Some maps don't have these properties.
-                        var useHeightFog = entity.ContainsKey("fogverticalexponent"); // the oldest versions have these values missing, so disable it there
+                        var useHeightFog = entity.ContainsKey("fogverticalexponent"); // The oldest versions lack these values, so disable it there
+                        var useHeightFog2 = entity.ContainsKey("fogstartheight"); // Robot Repair lack these values, so disable it there
                         useHeightFog = entity.GetBooleanProperty("heightfog", useHeightFog); // New in CS2
 
                         // TODO: find the correct behavior under this condition
-                        var startHeight = float.NegativeInfinity;
-                        var endHeight = float.NegativeInfinity;
-                        var heightExponent = 1.0f;
-
-                        if (useHeightFog)
-                        {
-                            heightExponent = entity.GetFloatProperty("fogverticalexponent");
-                            startHeight = entity.GetFloatProperty("fogstartheight");
-                            endHeight = entity.GetFloatProperty("fogendheight");
-                        }
+                        var startHeight = entity.GetFloatProperty("fogstartheight");
+                        var endHeight = entity.GetFloatProperty("fogendheight");
+                        var heightExponent = entity.GetFloatProperty("fogverticalexponent");
 
                         var strength = entity.GetFloatProperty("fogstrength");
                         var color = entity.GetColor32Property("fogcolor");
                         var maxOpacity = entity.GetFloatProperty("fogmaxopacity");
+
+                        if (!useHeightFog && !useHeightFog2)
+                        {
+                            heightExponent = 1.0f; // Need the value for Robot Repair
+                            startHeight = startDist; // Assuming it's similar to the horizontal distances
+                            endHeight = endDist; // Assuming it's similar to the horizontal distances
+                            strength = 1.0f; // Need the value for Robot Repair
+                            //color = entity.GetColor32Property("fogcolor"); // Need to get from `gradientfogtexture` key value and combine with `color` keyvalue
+                            maxOpacity = 0.5f; // Need the value for Robot Repair
+                            distExponent = 2.0f;
+                        }
+                        else if(!useHeightFog && useHeightFog2)
+                        {
+                            heightExponent = 1.0f; // Need the value for SteamVR
+                            strength = 1.0f; // Need the value for SteamVR
+                            //color = entity.GetColor32Property("fogcolor"); // Need to get from `gradientfogtexture` key value
+                            maxOpacity = 0.5f; // Need the value for SteamVR
+                            distExponent = 2.0f; // Need the value for SteamVR
+                        }
 
                         scene.FogInfo.GradientFog = new SceneGradientFog(scene)
                         {


### PR DESCRIPTION
Fixed the rendering of fog in both Robot Repair and SteamVR Home. The appearance doesn't match the games perfectly but it's better than lacking the fog or having a pure white sphere render around the camera in some maps. This PR fixes the issue in #922 