### PR TITLE
Fix exception when double-clicking output target without targetname

### DIFF
--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -357,8 +357,7 @@ namespace ValveResourceFormat.Renderer
                     return false;
                 }
 
-                var value = node.EntityData[keyToFind];
-                return value != null
+                return node.EntityData.TryGetValue(keyToFind, out var value)
                     && value.ValueType == ValveKeyValue.KVValueType.String
                     && valueToFind.Equals((string)value, StringComparison.OrdinalIgnoreCase);
             }


### PR DESCRIPTION
Fixes #1150 

Currently double clicking a cell in the Target Entity Column of the Outputs tab throws an exception.

<img width="500" alt="exception" src="https://github.com/user-attachments/assets/32240c46-ff82-46fc-bce7-6300f9d93aec" />

With this fix, the navigation works properly: 

<img width="500" alt="no_exception" src="https://github.com/user-attachments/assets/106ee946-66bd-4174-81e9-e515269ff182" />
