### PR TITLE
Fix VfxEval float formatting on de-AT locale

### DIFF
--- a/ValveResourceFormat/Serialization/VfxEval.cs
+++ b/ValveResourceFormat/Serialization/VfxEval.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.IO;
 using System.Text;
 
@@ -356,7 +357,7 @@ namespace ValveResourceFormat.Serialization.VfxEval
                     return;
                 }
 
-                var floatLiteral = $"{floatVal:g}";
+                var floatLiteral = floatVal.ToString("g", CultureInfo.InvariantCulture);
 
                 // if a float leads with "0." remove the 0 (as how Valve likes it)
                 if (floatLiteral.Length > 1 && floatLiteral[..2] == "0.")


### PR DESCRIPTION
Float literals in dynamic expressions are formatted using the current culture, so on regional formats with a comma decimal separator they come out as e.g. 0,8 instead of .8. Switched to invariant culture. This fixes the VfxEval tests failing on my locale.