### PR TITLE
Fix YCoCg texture colors when exporting and previewing

### DIFF
--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -385,8 +385,7 @@ namespace GUI.Types.GLViewers
                 SetInitialDecodeFlagsState,
                 checkedItemNames =>
                 {
-                    // Preserve the auto-detected YCoCgSrgb flag, which is not shown as a checkbox.
-                    decodeFlags &= TextureCodec.YCoCgSrgb;
+                    decodeFlags = TextureCodec.None;
 
                     foreach (var itemName in checkedItemNames)
                     {
@@ -571,8 +570,7 @@ namespace GUI.Types.GLViewers
                 var name = Enum.GetName(value)!;
 
                 var isCombinedFlag = (value & value - 1) != 0;
-                // YCoCgSrgb is auto-detected, not a user-facing checkbox.
-                var skipFlags = TextureCodec.None | TextureCodec.Auto | TextureCodec.YCoCgSrgb;
+                var skipFlags = TextureCodec.None | TextureCodec.Auto;
 
                 if (isCombinedFlag || skipFlags.HasFlag(value))
                 {

--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -385,12 +385,15 @@ namespace GUI.Types.GLViewers
                 SetInitialDecodeFlagsState,
                 checkedItemNames =>
                 {
-                    decodeFlags = TextureCodec.None;
+                    // Preserve the auto-detected YCoCgSrgb flag, which is not shown as a checkbox.
+                    decodeFlags &= TextureCodec.YCoCgSrgb;
 
                     foreach (var itemName in checkedItemNames)
                     {
                         decodeFlags |= Enum.Parse<TextureCodec>(itemName);
                     }
+
+                    SetupTextureFromUi(softwareDecodeCheckBox != null && softwareDecodeCheckBox.Checked);
                 }
             );
 
@@ -399,17 +402,21 @@ namespace GUI.Types.GLViewers
                 AddChannelsComboBox();
 
                 var forceSoftwareDecode = textureData.IsRawAnyImage;
+                var projectionBeforeSoftwareDecode = (int)CubemapProjection.Equirectangular;
                 softwareDecodeCheckBox = UiControl.AddCheckBox("Software decode", forceSoftwareDecode, (state) =>
                 {
                     if (cubemapProjectionComboBox != null)
                     {
                         if (state)
                         {
+                            // Software decode can't project cubemaps; force a single face, remembering the projection.
+                            projectionBeforeSoftwareDecode = cubemapProjectionComboBox.SelectedIndex;
                             cubemapProjectionComboBox.SelectedIndex = (int)CubemapProjection.None;
                             cubemapProjectionComboBox.Enabled = false;
                         }
                         else
                         {
+                            cubemapProjectionComboBox.SelectedIndex = projectionBeforeSoftwareDecode;
                             cubemapProjectionComboBox.Enabled = true;
                         }
                     }
@@ -564,7 +571,8 @@ namespace GUI.Types.GLViewers
                 var name = Enum.GetName(value)!;
 
                 var isCombinedFlag = (value & value - 1) != 0;
-                var skipFlags = TextureCodec.None | TextureCodec.Auto;
+                // YCoCgSrgb is auto-detected, not a user-facing checkbox.
+                var skipFlags = TextureCodec.None | TextureCodec.Auto | TextureCodec.YCoCgSrgb;
 
                 if (isCombinedFlag || skipFlags.HasFlag(value))
                 {

--- a/Renderer/Shaders/texture_decode.frag.slang
+++ b/Renderer/Shaders/texture_decode.frag.slang
@@ -32,7 +32,6 @@ uniform vec4 g_vInputTextureSize;
 #define Dxt5nm_AlphaGreen (1 << 4)
 #define ColorSpace_Linear (1 << 5)
 #define ColorSpace_Srgb (1 << 6)
-#define YCoCg_Srgb (1 << 8)
 
 uniform int g_nSelectedMip;
 uniform int g_nSelectedDepth;
@@ -244,12 +243,13 @@ void main()
         vColor.rgb = PackToColor(vec3(normalXy.xy, derivedZ));
     }
 
+    if ((g_nDecodeFlags & ColorSpace_Srgb) != 0)
+    {
+        vColor.rgb = SrgbGammaToLinear(vColor.rgb);
+    }
+
     if ((g_nDecodeFlags & YCoCg_Conversion) != 0)
     {
-        if ((g_nDecodeFlags & YCoCg_Srgb) != 0)
-        {
-            vColor.rgb = SrgbGammaToLinear(vColor.rgb);
-        }
         vColor.rgb = DecodeYCoCg(vColor);
         vColor.a = 1.0;
     }
@@ -257,11 +257,6 @@ void main()
     if ((g_nDecodeFlags & RGBM) != 0)
     {
         vColor.rgb = DecodeRGBM(vColor);
-    }
-
-    if ((g_nDecodeFlags & ColorSpace_Srgb) != 0)
-    {
-        vColor.rgb = SrgbGammaToLinear(vColor.rgb);
     }
 
     if ((g_nDecodeFlags & ColorSpace_Linear) != 0)

--- a/Renderer/Shaders/texture_decode.frag.slang
+++ b/Renderer/Shaders/texture_decode.frag.slang
@@ -32,6 +32,7 @@ uniform vec4 g_vInputTextureSize;
 #define Dxt5nm_AlphaGreen (1 << 4)
 #define ColorSpace_Linear (1 << 5)
 #define ColorSpace_Srgb (1 << 6)
+#define YCoCg_Srgb (1 << 8)
 
 uniform int g_nSelectedMip;
 uniform int g_nSelectedDepth;
@@ -245,8 +246,10 @@ void main()
 
     if ((g_nDecodeFlags & YCoCg_Conversion) != 0)
     {
-        // Linearize rgb to match the sky render's sRGB texture read; this viewer samples linearly (issue #1127).
-        vColor.rgb = SrgbGammaToLinear(vColor.rgb);
+        if ((g_nDecodeFlags & YCoCg_Srgb) != 0)
+        {
+            vColor.rgb = SrgbGammaToLinear(vColor.rgb);
+        }
         vColor.rgb = DecodeYCoCg(vColor);
         vColor.a = 1.0;
     }

--- a/Renderer/Shaders/texture_decode.frag.slang
+++ b/Renderer/Shaders/texture_decode.frag.slang
@@ -245,6 +245,8 @@ void main()
 
     if ((g_nDecodeFlags & YCoCg_Conversion) != 0)
     {
+        // Linearize rgb to match the sky render's sRGB texture read; this viewer samples linearly (issue #1127).
+        vColor.rgb = SrgbGammaToLinear(vColor.rgb);
         vColor.rgb = DecodeYCoCg(vColor);
         vColor.a = 1.0;
     }

--- a/Tests/TextureTests.cs
+++ b/Tests/TextureTests.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
+using SkiaSharp;
 using ValveResourceFormat;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.TextureDecoders;
@@ -36,16 +37,33 @@ namespace Tests
         [Test]
         public void Undo_YCoCg_TransformsColorCorrectly()
         {
-            var color = new Color { r = 128, g = 128, b = 8, a = 128 };
-
-            Common.Decode_YCoCg(ref color);
+            // Pure matrix: neutral chroma (Co == Cg == 128) reconstructs to neutral grey. The sRGB
+            // linearization of the inputs is the caller's job (ApplyTextureConversions), see issue #1127.
+            var rgb = Common.Decode_YCoCg(new Vector4(128, 128, 8, 128) / 255f);
 
             using (Assert.EnterMultipleScope())
             {
-                Assert.That(color.r, Is.EqualTo(128));
-                Assert.That(color.g, Is.EqualTo(128));
-                Assert.That(color.b, Is.EqualTo(128));
-                Assert.That(color.a, Is.EqualTo(255));
+                Assert.That(Common.ToClampedLdrColor(rgb.X), Is.EqualTo(128));
+                Assert.That(Common.ToClampedLdrColor(rgb.Y), Is.EqualTo(128));
+                Assert.That(Common.ToClampedLdrColor(rgb.Z), Is.EqualTo(128));
+            }
+        }
+
+        [Test]
+        public void ApplyTextureConversions_YCoCg_LinearizesInputsBeforeMatrix()
+        {
+            using var bitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+            bitmap.SetPixel(0, 0, new SKColor(red: 128, green: 128, blue: 8, alpha: 128)); // Co, Cg, scale, Y
+
+            Common.ApplyTextureConversions(bitmap, TextureCodec.YCoCg);
+
+            var result = bitmap.GetPixel(0, 0);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.Red, Is.EqualTo(128));
+                Assert.That(result.Green, Is.EqualTo(60));
+                Assert.That(result.Blue, Is.EqualTo(255));
+                Assert.That(result.Alpha, Is.EqualTo(255));
             }
         }
 

--- a/Tests/TextureTests.cs
+++ b/Tests/TextureTests.cs
@@ -50,12 +50,12 @@ namespace Tests
         }
 
         [Test]
-        public void ApplyTextureConversions_YCoCgSrgb_LinearizesInputsBeforeMatrix()
+        public void ApplyTextureConversions_YCoCg_WithColorSpaceSrgb_LinearizesInputsBeforeMatrix()
         {
             using var bitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul);
             bitmap.SetPixel(0, 0, new SKColor(red: 128, green: 128, blue: 8, alpha: 128)); // Co, Cg, scale, Y
 
-            Common.ApplyTextureConversions(bitmap, TextureCodec.YCoCg | TextureCodec.YCoCgSrgb);
+            Common.ApplyTextureConversions(bitmap, TextureCodec.YCoCg | TextureCodec.ColorSpaceSrgb);
 
             var result = bitmap.GetPixel(0, 0);
             using (Assert.EnterMultipleScope())

--- a/Tests/TextureTests.cs
+++ b/Tests/TextureTests.cs
@@ -50,7 +50,25 @@ namespace Tests
         }
 
         [Test]
-        public void ApplyTextureConversions_YCoCg_LinearizesInputsBeforeMatrix()
+        public void ApplyTextureConversions_YCoCgSrgb_LinearizesInputsBeforeMatrix()
+        {
+            using var bitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+            bitmap.SetPixel(0, 0, new SKColor(red: 128, green: 128, blue: 8, alpha: 128)); // Co, Cg, scale, Y
+
+            Common.ApplyTextureConversions(bitmap, TextureCodec.YCoCg | TextureCodec.YCoCgSrgb);
+
+            var result = bitmap.GetPixel(0, 0);
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.Red, Is.EqualTo(128));
+                Assert.That(result.Green, Is.EqualTo(60));
+                Assert.That(result.Blue, Is.EqualTo(255));
+                Assert.That(result.Alpha, Is.EqualTo(255));
+            }
+        }
+
+        [Test]
+        public void ApplyTextureConversions_YCoCg_AppliesRawMatrixWithoutSrgbFlag()
         {
             using var bitmap = new SKBitmap(1, 1, SKColorType.Bgra8888, SKAlphaType.Unpremul);
             bitmap.SetPixel(0, 0, new SKColor(red: 128, green: 128, blue: 8, alpha: 128)); // Co, Cg, scale, Y
@@ -61,8 +79,8 @@ namespace Tests
             using (Assert.EnterMultipleScope())
             {
                 Assert.That(result.Red, Is.EqualTo(128));
-                Assert.That(result.Green, Is.EqualTo(60));
-                Assert.That(result.Blue, Is.EqualTo(255));
+                Assert.That(result.Green, Is.EqualTo(128));
+                Assert.That(result.Blue, Is.EqualTo(128));
                 Assert.That(result.Alpha, Is.EqualTo(255));
             }
         }

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -1097,7 +1097,7 @@ namespace ValveResourceFormat.ResourceTypes
             if (codec.HasFlag(TextureCodec.YCoCg) && (Flags & VTexFlags.CUBE_TEXTURE) != 0)
             {
                 // Skybox cubemaps store YCoCg in sRGB gamma space; flat panorama textures are raw (issue #1127).
-                codec |= TextureCodec.YCoCgSrgb;
+                codec |= TextureCodec.ColorSpaceSrgb;
             }
 
             if (Format == VTexFormat.DXT5 && codec.HasFlag(TextureCodec.NormalizeNormals))

--- a/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Texture.cs
@@ -1094,6 +1094,12 @@ namespace ValveResourceFormat.ResourceTypes
                 };
             }
 
+            if (codec.HasFlag(TextureCodec.YCoCg) && (Flags & VTexFlags.CUBE_TEXTURE) != 0)
+            {
+                // Skybox cubemaps store YCoCg in sRGB gamma space; flat panorama textures are raw (issue #1127).
+                codec |= TextureCodec.YCoCgSrgb;
+            }
+
             if (Format == VTexFormat.DXT5 && codec.HasFlag(TextureCodec.NormalizeNormals))
             {
                 codec |= TextureCodec.Dxt5nm;

--- a/ValveResourceFormat/TextureDecoders/Common.cs
+++ b/ValveResourceFormat/TextureDecoders/Common.cs
@@ -73,6 +73,12 @@ namespace ValveResourceFormat.TextureDecoders
         ForceLDR = 1 << 7,
 
         /// <summary>
+        /// YCoCg Co/Cg/scale are stored in sRGB gamma space; linearize before the <see cref="YCoCg"/>
+        /// matrix. Set for skybox cubemaps, off for flat panorama textures. See issue #1127.
+        /// </summary>
+        YCoCgSrgb = 1 << 8,
+
+        /// <summary>
         /// Automatically determine codec flags.
         /// </summary>
         Auto = 1 << 30,
@@ -84,6 +90,7 @@ namespace ValveResourceFormat.TextureDecoders
         {
             var swapRA = decodeFlags.HasFlag(TextureCodec.Dxt5nm);
             var decodeYCoCg = decodeFlags.HasFlag(TextureCodec.YCoCg);
+            var linearizeYCoCg = decodeFlags.HasFlag(TextureCodec.YCoCgSrgb);
             var decodeHemiOct = decodeFlags.HasFlag(TextureCodec.HemiOctRB);
             var reconstructZ = decodeFlags.HasFlag(TextureCodec.NormalizeNormals);
 
@@ -107,11 +114,14 @@ namespace ValveResourceFormat.TextureDecoders
                 {
                     ref var pixel = ref pixels[i];
 
-                    // Co/Cg/scale are stored in sRGB gamma space; linearize them before the matrix, the
-                    // same way the engine samples these textures (sRGB texture read). The Y luma in alpha
-                    // stays linear. Without this the result is desaturated with a green cast (issue #1127).
-                    var lin = ColorSpace.SrgbGammaToLinear(new Vector3(pixel.r, pixel.g, pixel.b) / 255f);
-                    var rgb = Decode_YCoCg(new Vector4(lin, pixel.a / 255f));
+                    var input = new Vector3(pixel.r, pixel.g, pixel.b) / 255f;
+
+                    if (linearizeYCoCg)
+                    {
+                        input = ColorSpace.SrgbGammaToLinear(input);
+                    }
+
+                    var rgb = Decode_YCoCg(new Vector4(input, pixel.a / 255f));
 
                     pixel.r = ToClampedLdrColor(rgb.X);
                     pixel.g = ToClampedLdrColor(rgb.Y);

--- a/ValveResourceFormat/TextureDecoders/Common.cs
+++ b/ValveResourceFormat/TextureDecoders/Common.cs
@@ -73,12 +73,6 @@ namespace ValveResourceFormat.TextureDecoders
         ForceLDR = 1 << 7,
 
         /// <summary>
-        /// YCoCg Co/Cg/scale are stored in sRGB gamma space; linearize before the <see cref="YCoCg"/>
-        /// matrix. Set for skybox cubemaps, off for flat panorama textures. See issue #1127.
-        /// </summary>
-        YCoCgSrgb = 1 << 8,
-
-        /// <summary>
         /// Automatically determine codec flags.
         /// </summary>
         Auto = 1 << 30,
@@ -90,7 +84,7 @@ namespace ValveResourceFormat.TextureDecoders
         {
             var swapRA = decodeFlags.HasFlag(TextureCodec.Dxt5nm);
             var decodeYCoCg = decodeFlags.HasFlag(TextureCodec.YCoCg);
-            var linearizeYCoCg = decodeFlags.HasFlag(TextureCodec.YCoCgSrgb);
+            var linearizeYCoCg = decodeYCoCg && decodeFlags.HasFlag(TextureCodec.ColorSpaceSrgb);
             var decodeHemiOct = decodeFlags.HasFlag(TextureCodec.HemiOctRB);
             var reconstructZ = decodeFlags.HasFlag(TextureCodec.NormalizeNormals);
 

--- a/ValveResourceFormat/TextureDecoders/Common.cs
+++ b/ValveResourceFormat/TextureDecoders/Common.cs
@@ -105,7 +105,18 @@ namespace ValveResourceFormat.TextureDecoders
             {
                 if (decodeYCoCg)
                 {
-                    Decode_YCoCg(ref pixels[i]);
+                    ref var pixel = ref pixels[i];
+
+                    // Co/Cg/scale are stored in sRGB gamma space; linearize them before the matrix, the
+                    // same way the engine samples these textures (sRGB texture read). The Y luma in alpha
+                    // stays linear. Without this the result is desaturated with a green cast (issue #1127).
+                    var lin = ColorSpace.SrgbGammaToLinear(new Vector3(pixel.r, pixel.g, pixel.b) / 255f);
+                    var rgb = Decode_YCoCg(new Vector4(lin, pixel.a / 255f));
+
+                    pixel.r = ToClampedLdrColor(rgb.X);
+                    pixel.g = ToClampedLdrColor(rgb.Y);
+                    pixel.b = ToClampedLdrColor(rgb.Z);
+                    pixel.a = 255;
                 }
 
                 if (decodeHemiOct)
@@ -120,18 +131,19 @@ namespace ValveResourceFormat.TextureDecoders
             }
         }
 
-        public static void Decode_YCoCg(ref Color color)
+        /// <summary>
+        /// Reconstructs normalized RGB from the YCoCg encoding (Co, Cg, scale, Y in X, Y, Z, W). Pure
+        /// matrix with no color space handling; the caller linearizes the inputs. Mirrors DecodeYCoCg in utils.slang.
+        /// </summary>
+        public static Vector3 Decode_YCoCg(Vector4 color)
         {
-            var scale = (color.b >> 3) + 1;
-            var co = (color.r - 128) / scale;
-            var cg = (color.g - 128) / scale;
+            var scale = (color.Z * (255f / 8f)) + 1f;
+            var co = (color.X - (128f / 255f)) / scale;
+            var cg = (color.Y - (128f / 255f)) / scale;
 
-            var y = color.a;
+            var y = color.W;
 
-            color.r = ClampColor(y + co - cg);
-            color.g = ClampColor(y + cg);
-            color.b = ClampColor(y - co - cg);
-            color.a = 255;
+            return new Vector3(y + co - cg, y + cg, y - co - cg);
         }
 
         public static void ReconstructNormals(ref Color color)


### PR DESCRIPTION
YCoCg textures come out desaturated with a green tint when exported to PNG or viewed in the texture inspector (#1127).

The Co/Cg/scale channels are stored in sRGB gamma space, and the engine samples these textures as sRGB, so they get linearized before the YCoCg matrix. The sky render was already fixed this way in #866 (`f3a943ec`, adding `SrgbRead(true)`), but the CPU export path and the texture-viewer shader still decode the raw gamma values directly.

I switched Decode_YCoCg from Color to Vector4 so the conversion happens in normalized float space instead of the byte-based Color, which would lead to losing precision.

Reproducible with `C:\Program Files (x86)\Steam\steamapps\common\SteamVR\tools\steamvr_environments\game\steamtours\pak02_dir\materials\skyboxes\vesper_peak_png_fbeb5735.vtex_c`

The sky shader is unchanged, since it already worked. If you want changes let me know.

Before:
<img width="500"  alt="broken" src="https://github.com/user-attachments/assets/9d89cf6d-18da-45f2-ad03-a8fcfc2e677d" />

After:
<img width="500" alt="fixed" src="https://github.com/user-attachments/assets/c66ff5db-1e4a-42e9-9cfa-ed8d6617b35f" />