### PR TITLE
Allow trailing bytes in file-size validation (fix #1119)

### DIFF
--- a/ValveResourceFormat/Resource/Resource.cs
+++ b/ValveResourceFormat/Resource/Resource.cs
@@ -318,23 +318,11 @@ namespace ValveResourceFormat
             {
                 if (ResourceType == ResourceType.Texture)
                 {
-                    var data = (Texture?)DataBlock;
-
-                    // TODO: We do not currently have a way of calculating buffer size for these types
-                    // Texture.GenerateBitmap also just reads until end of the buffer
-                    if (data == null || data.IsRawJpeg)
+                    // Some workshop and generated texture resources contain harmless trailing bytes.
+                    // Accept textures when the stream is at least as large as the computed payload.
+                    if (Reader.BaseStream.Length >= fullFileSize)
                     {
                         return;
-                    }
-
-                    // TODO: Valve added null bytes after the png for whatever reason,
-                    // so assume we have the full file if the buffer is bigger than the size we calculated
-                    if (data.IsRawPng)
-                    {
-                        if (Reader.BaseStream.Length > fullFileSize)
-                        {
-                            return;
-                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #1119 by relaxing texture size validation to allow trailing bytes for all textures while still rejecting truncated textures. This should be safe, because the texture decoders only read the payload length, so any trailing bytes can be ignored. I think weakening the validation to remove such edge cases is worth it.

The map from the ticket does not reproduce the issue anymore, but I could reproduce it using this map: [Workshop Link](https://steamcommunity.com/sharedfiles/filedetails/?id=3369117065)