### PR TITLE
Render skybox materials into thumbnails and rotate cubemap thumbnails

### DIFF
--- a/GUI/Types/PackageViewer/ThumbnailRenderers/ThumbnailMaterialRenderer.cs
+++ b/GUI/Types/PackageViewer/ThumbnailRenderers/ThumbnailMaterialRenderer.cs
@@ -1,11 +1,15 @@
 using System.Diagnostics;
 using ValveResourceFormat;
+using ValveResourceFormat.Renderer.SceneEnvironment;
 using ValveResourceFormat.Renderer.SceneNodes;
+using ValveResourceFormat.ResourceTypes;
 
 namespace GUI.Types.PackageViewer.ThumbnailRenderers;
 
 internal class ThumbnailMaterialRenderer : ThumbnailRenderer
 {
+    private SceneSkybox2D? skybox;
+
     public override void SetResource(Resource resource)
     {
         Debug.Assert(SceneRenderer != null);
@@ -14,6 +18,20 @@ internal class ThumbnailMaterialRenderer : ThumbnailRenderer
         var renderMat = SceneRenderer.RendererContext.MaterialLoader.LoadMaterial(resource);
         renderMat.Shader.EnsureLoaded();
         renderMat.IsOverlay = false;
+
+        // Render sky materials as a full-screen sky, like the skybox viewer.
+        if (resource.DataBlock is Material { ShaderName: "sky.vfx" })
+        {
+            skybox ??= new SceneSkybox2D(renderMat);
+            skybox.Material = renderMat;
+            SceneRenderer.Skybox2D = skybox;
+            SceneRenderer.Camera.Pitch = float.DegreesToRadians(20);
+            SceneRenderer.Camera.Yaw = float.DegreesToRadians(180);
+            return;
+        }
+
+        // Reset the skybox; it isn't cleared between reused thumbnails.
+        SceneRenderer.Skybox2D = SceneRenderer.BaseBackground;
 
         var planeMesh = MeshSceneNode.CreateMaterialPreviewQuad(SceneRenderer.Scene, renderMat, new Vector2(32));
 

--- a/GUI/Types/PackageViewer/ThumbnailRenderers/ThumbnailTextureRenderer.cs
+++ b/GUI/Types/PackageViewer/ThumbnailRenderers/ThumbnailTextureRenderer.cs
@@ -24,6 +24,8 @@ internal class ThumbnailTextureRenderer : ThumbnailRenderer
         var textureData = (Texture)(resource.DataBlock!);
         var size = (int)Size;
 
+        var isCubemap = (textureData.Flags & VTexFlags.CUBE_TEXTURE) != 0;
+
         // Find the highest mip level that is still higher than the thumbnail size
         var mipLevel = 0;
 
@@ -37,7 +39,11 @@ internal class ThumbnailTextureRenderer : ThumbnailRenderer
             mipLevel = i;
         }
 
-        using var bitmap = textureData.GenerateBitmap(mipLevel: (uint)mipLevel);
+        using var decoded = textureData.GenerateBitmap(mipLevel: (uint)mipLevel);
+
+        // A raw cubemap face decodes 90° counter-clockwise, so rotate it upright.
+        using var rotated = isCubemap ? RotateClockwise90(decoded) : null;
+        var bitmap = rotated ?? decoded;
 
         var originalWidth = bitmap.Width;
         var originalHeight = bitmap.Height;
@@ -72,5 +78,17 @@ internal class ThumbnailTextureRenderer : ThumbnailRenderer
         using var snapshot = surface.Snapshot();
         using var finalBitmap = SKBitmap.FromImage(snapshot);
         return finalBitmap.ToBitmap();
+    }
+
+    private static SKBitmap RotateClockwise90(SKBitmap source)
+    {
+        var rotated = new SKBitmap(source.Height, source.Width, source.ColorType, source.AlphaType);
+
+        using var canvas = new SKCanvas(rotated);
+        canvas.Translate(rotated.Width, 0);
+        canvas.RotateDegrees(90);
+        canvas.DrawBitmap(source, 0, 0);
+
+        return rotated;
     }
 }

--- a/Renderer/Renderer/SceneEnvironment/SceneSkybox2D.cs
+++ b/Renderer/Renderer/SceneEnvironment/SceneSkybox2D.cs
@@ -13,8 +13,8 @@ namespace ValveResourceFormat.Renderer.SceneEnvironment
         /// <summary>Gets the rotation transform applied to the skybox cube.</summary>
         public Matrix4x4 Transform { get; init; } = Matrix4x4.Identity;
 
-        /// <summary>Gets the material used to render the skybox.</summary>
-        public RenderMaterial Material { get; }
+        /// <summary>Gets or sets the material used to render the skybox.</summary>
+        public RenderMaterial Material { get; set; }
         private readonly int vao;
 
         /// <summary>


### PR DESCRIPTION
Addressing #1166

Skies (sky.vfx) now render properly in the thumbnails:

Old:
<img width="1000"  alt="old" src="https://github.com/user-attachments/assets/3fdd7cee-8dbc-4429-9603-8e2e5a39c33e" />
New:
<img width="1000" alt="new" src="https://github.com/user-attachments/assets/32c2609d-8aa4-436f-9f1f-d9e81e3202f5" />

I also thought it makes sense to rotate the cubemap texture thumbnails by 90 degrees clockwise, so they are rotated upright in the thumbnail. If you don't like this change it can be easily removed, I think it makes more sense for them to be upright, even if they're technically not upright in the bitmap texture.

Old:
<img width="750" alt="old2" src="https://github.com/user-attachments/assets/334a1426-733c-4cab-96fa-605620c719a2" />
New:
<img width="750" alt="new2" src="https://github.com/user-attachments/assets/3556ef3e-d946-44cf-bca1-644ab4920a2b" />
