### PR TITLE
Fix NRE when opening modern s&box materials

### DIFF
--- a/ValveResourceFormat/Resource/ResourceTypes/Material.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Material.cs
@@ -144,7 +144,10 @@ namespace ValveResourceFormat.ResourceTypes
 
             var renderAttributesUsed = Data.GetArray<string>("m_renderAttributesUsed");
 
-            foreach (var kvp in Data.GetArray("m_dynamicParams"))
+            // s&box removed m_dynamicParams + m_dynamicTextureParams from the material schema
+            // so guard against nulls here
+
+            foreach (var kvp in Data.GetArray("m_dynamicParams") ?? [])
             {
                 var dynamicParamName = kvp.GetStringProperty("m_name");
                 var dynamicParamBytes = kvp.GetArray<byte>("m_value");
@@ -152,7 +155,7 @@ namespace ValveResourceFormat.ResourceTypes
                 DynamicExpressions.Add(dynamicParamName, vfxEval.DynamicExpressionResult.Replace("\n", "\\n", StringComparison.Ordinal));
             }
 
-            foreach (var kvp in Data.GetArray("m_dynamicTextureParams"))
+            foreach (var kvp in Data.GetArray("m_dynamicTextureParams") ?? [])
             {
                 var dynamicTextureParamName = kvp.GetStringProperty("m_name");
                 var dynamicTextureParamBytes = kvp.GetArray<byte>("m_value");


### PR DESCRIPTION
s&box removed m_dynamicParams + m_dynamicTextureParams from the material schema

https://cdn.sbox.game/asset/237e579dcbc93c42374f947232e7499c.8a8d3b1ec7f465f3.vmat_c