### PR TITLE
Hide first person player model when not in walk mode

### DIFF
--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -1568,6 +1568,17 @@ namespace ValveResourceFormat.Renderer
             }
         }
 
+        internal void DeactivateLayer(string layerName)
+        {
+            foreach (var node in AllNodes)
+            {
+                if (node.LayerName == layerName)
+                {
+                    node.LayerEnabled = false;
+                }
+            }
+        }
+
         /// <summary>
         /// Enables or disables scene nodes based on whether their layer name is present in the given set.
         /// </summary>

--- a/Renderer/Renderer/SceneNodes/ViewmodelSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ViewmodelSceneNode.cs
@@ -410,6 +410,10 @@ public class ViewmodelSceneNode : ModelSceneNode
         scene.RendererContext.Logger.LogInformation($"Loaded first person model.");
 
         scene.Add(viewmodel, true);
+
+        // don't render player model in noclip mode
+        scene.DeactivateLayer(WorldLayerName);
+
         return viewmodel;
     }
 
@@ -429,6 +433,12 @@ public class ViewmodelSceneNode : ModelSceneNode
 
         if (!attachViewmodelDistance)
         {
+            // don't render player model in noclip mode
+            if (LayerEnabled)
+            {
+                Scene.DeactivateLayer(WorldLayerName);
+            }
+
             return;
         }
 


### PR DESCRIPTION
I noticed that the player model used for the first person rendering in walk mode is also visible during noclip (and orbit) mode.

<img width="500" alt="player_model_bug" src="https://github.com/user-attachments/assets/1517b5fe-9e06-46fa-9753-d64b9317f815" />
<img width="500" alt="player_model_bug_2" src="https://github.com/user-attachments/assets/b1d9b848-415c-4b4a-9117-7e2216fc58b6" />

This PR disables the rendering of the player model when not in walk mode. Walk mode still works the exact same as before.

<img width="500" alt="player_model_fix" src="https://github.com/user-attachments/assets/114611c8-ab91-4e80-9354-802f5210393c" />
