### PR TITLE
Fix procedural cloth bone duplication on compile round-trips

### DIFF
--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -136,6 +136,12 @@ partial class ModelExtract
 
     private static Quaternion NmSkelRotationFixup = new(-0.5f, -0.5f, -0.5f, 0.5f);
 
+    /// <summary>Emits cloth bones with the '_' prefix the compiler sanitizes '$' to, so round-trips don't duplicate them.</summary>
+    internal static string GetExportBoneName(Bone bone)
+        => bone.IsProceduralCloth && bone.Name.StartsWith('$')
+            ? string.Concat("_", bone.Name.AsSpan(1))
+            : bone.Name;
+
     private static DmeModel BuildDmeDagSkeleton(Skeleton skeleton, out DmeTransform[] transforms, bool nmSkelAxisFixup = false)
     {
         var dmeSkeleton = new DmeModel();
@@ -146,12 +152,13 @@ partial class ModelExtract
 
         foreach (var bone in skeleton.Bones)
         {
+            var boneName = GetExportBoneName(bone);
             var dag = new DmeJoint
             {
-                Name = bone.Name
+                Name = boneName
             };
 
-            dag.Transform.Name = bone.Name;
+            dag.Transform.Name = boneName;
             dag.Transform.Position = bone.Position;
             dag.Transform.Orientation = bone.Angle;
 
@@ -300,9 +307,10 @@ partial class ModelExtract
         foreach (var bone in skeleton.Bones)
         {
             var transform = transforms[bone.Index];
+            var boneName = GetExportBoneName(bone);
 
-            var positionChannel = BuildDmeChannel<Vector3>($"{bone.Name}_p", transform, "position", out var positionLog);
-            var orientationChannel = BuildDmeChannel<Quaternion>($"{bone.Name}_o", transform, "orientation", out var orientationLog);
+            var positionChannel = BuildDmeChannel<Vector3>($"{boneName}_p", transform, "position", out var positionLog);
+            var orientationChannel = BuildDmeChannel<Quaternion>($"{boneName}_o", transform, "orientation", out var orientationLog);
 
             var positionLogLayer = positionLog.GetLayer(0);
             var orientationLogLayer = orientationLog.GetLayer(0);

--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -139,7 +139,7 @@ partial class ModelExtract
     /// <summary>Emits cloth bones with the '_' prefix the compiler sanitizes '$' to, so round-trips don't duplicate them.</summary>
     internal static string GetExportBoneName(Bone bone)
         => bone.IsProceduralCloth && bone.Name.StartsWith('$')
-            ? string.Concat("_", bone.Name.AsSpan(1))
+            ? $"_{bone.Name[1..]}"
             : bone.Name;
 
     private static DmeModel BuildDmeDagSkeleton(Skeleton skeleton, out DmeTransform[] transforms, bool nmSkelAxisFixup = false)

--- a/ValveResourceFormat/IO/ModelExtract.ValveModel.cs
+++ b/ValveResourceFormat/IO/ModelExtract.ValveModel.cs
@@ -258,7 +258,7 @@ partial class ModelExtract
         {
             var boneDefinitionNode = MakeNode(
                 "Bone",
-                ("name", bone.Name),
+                ("name", GetExportBoneName(bone)),
                 ("origin", ToKVArray(bone.Position)),
                 ("angles", ToKVArray(ToEulerAngles(bone.Angle))),
                 ("do_not_discard", true)


### PR DESCRIPTION
Procedural cloth bones (`$cloth_mXpY`) were exported with their raw `$` prefix. The compiler keeps that name on the skeleton but renames it to `_cloth_mXpY` on the mesh/anim/bindpose, so each cloth bone turned into two on compile (36 -> 72). A second decompile -> recompile then hit a duplicate-bone error. It doesn't always error, sometimes it just doubles without an error.

Can e.g. be checked with `models/heroes_staging/nano/nano_v2/nano.vmdl` (deadlock).

Closes #1187 