### PR TITLE
Fix lag in pulse graph viewer

### DIFF
--- a/GUI/Types/GLViewers/GLNodeGraphViewer.cs
+++ b/GUI/Types/GLViewers/GLNodeGraphViewer.cs
@@ -203,7 +203,6 @@ namespace GUI.Types.GLViewers
             var screenPoint = new SKPoint(e.Location.X, e.Location.Y);
             var graphPoint = ScreenToGraph(screenPoint);
 
-            using var lockedGl = MakeCurrent();
             nodeGraph.HandleMouseDown(graphPoint, e.Button, Control.ModifierKeys);
 
             if (e.Button == MouseButtons.Left && Control.ModifierKeys == Keys.None)
@@ -228,7 +227,6 @@ namespace GUI.Types.GLViewers
                 return;
             }
 
-            using var lockedGl = MakeCurrent();
             nodeGraph.HandleMouseMove(graphPoint, Control.ModifierKeys);
         }
 
@@ -241,7 +239,6 @@ namespace GUI.Types.GLViewers
             var screenPoint = new SKPoint(e.Location.X, e.Location.Y);
             var graphPoint = ScreenToGraph(screenPoint);
 
-            using var lockedGl = MakeCurrent();
             nodeGraph.HandleMouseUp(graphPoint);
         }
 

--- a/GUI/Types/GLViewers/GLNodeGraphViewer.cs
+++ b/GUI/Types/GLViewers/GLNodeGraphViewer.cs
@@ -255,6 +255,38 @@ namespace GUI.Types.GLViewers
             return new SKPoint(graphX, graphY);
         }
 
+        // The graph is drawn through Skia, not the texture/shader pipeline the base capture
+        // path assumes, so render the whole graph into a raster bitmap for Ctrl+C / saving.
+        protected override SKBitmap ReadPixelsToBitmap()
+        {
+            var bounds = nodeGraph.GetGraphBounds();
+
+            const float maxDimension = 8192f;
+            var scale = Math.Min(1f, maxDimension / Math.Max(bounds.Width, bounds.Height));
+
+            var width = Math.Max(1, (int)(bounds.Width * scale));
+            var height = Math.Max(1, (int)(bounds.Height * scale));
+
+            var bitmap = new SKBitmap(new SKImageInfo(width, height, SKColorType.Bgra8888, SKAlphaType.Premul));
+
+            try
+            {
+                using var canvas = new SKCanvas(bitmap);
+                canvas.Scale(scale, scale);
+                canvas.Translate(-bounds.Left, -bounds.Top);
+
+                nodeGraph.RenderToCanvas(canvas, bounds.Location, new SKPoint(bounds.Right, bounds.Bottom));
+
+                var bitmapToReturn = bitmap;
+                bitmap = null;
+                return bitmapToReturn;
+            }
+            finally
+            {
+                bitmap?.Dispose();
+            }
+        }
+
         public override void Dispose()
         {
             nodeGraph.GraphChanged -= OnGraphChanged;

--- a/GUI/Types/Graphs/NodeGraphControl/NodeGraphControl.cs
+++ b/GUI/Types/Graphs/NodeGraphControl/NodeGraphControl.cs
@@ -169,8 +169,13 @@ namespace GUI.Types.Graphs
         public bool IsMoving { get; private set; }
         SKPoint lastLocation;
 
+        // Synchronizes graph state between the render thread and UI mouse handlers.
+        private readonly System.Threading.Lock stateLock = new();
+
         public void RenderToCanvas(SKCanvas canvas, SKPoint topLeft, SKPoint bottomRight)
         {
+            using var _ = stateLock.EnterScope();
+
             canvas.Clear(_canvasBackgroundColor);
 
             OnDrawBackground(canvas, topLeft, bottomRight);
@@ -222,6 +227,8 @@ namespace GUI.Types.Graphs
         // Get the bounds of the entire graph in graph space
         public SKRect GetGraphBounds()
         {
+            using var _ = stateLock.EnterScope();
+
             if (_graphNodes.Count == 0)
             {
                 return new SKRect(-1000, -1000, 1000, 1000); // Default large area
@@ -248,6 +255,8 @@ namespace GUI.Types.Graphs
 
         public void HandleMouseDown(SKPoint graphPoint, MouseButtons button, Keys modifiers)
         {
+            using var _ = stateLock.EnterScope();
+
             UpdateOriginalLocation(graphPoint);
 
             var element = FindElementAt(lastLocation);
@@ -284,6 +293,8 @@ namespace GUI.Types.Graphs
 
         public void HandleMouseMove(SKPoint graphPoint, Keys modifiers = Keys.None)
         {
+            using var _ = stateLock.EnterScope();
+
             if (IsMoving)
             {
                 var delta = new SKPoint(
@@ -329,6 +340,8 @@ namespace GUI.Types.Graphs
 
         public void HandleMouseUp(SKPoint graphPoint)
         {
+            using var _ = stateLock.EnterScope();
+
             UpdateOriginalLocation(graphPoint);
 
             IsMoving = false;
@@ -424,6 +437,8 @@ namespace GUI.Types.Graphs
         // Find element at graph-space point
         public NodeUIElement? FindElementAt(SKPoint point)
         {
+            using var _ = stateLock.EnterScope();
+
             // Iterate in reverse order to find topmost (frontmost) nodes first
             for (var i = _graphNodes.Count - 1; i >= 0; i--)
             {


### PR DESCRIPTION
The node graph ran the hit-testing inside MakeCurrent() -> every mouse move switched the GL context lock held by the vsync render thread. This stalled input by switching this lock constantly between threads. I replaced it with a lock that only guards the shared state without touching the GL context.