### PR TITLE
Fix vr_standard in robot repair

### DIFF
--- a/Renderer/Shaders/vr_standard.vert.slang
+++ b/Renderer/Shaders/vr_standard.vert.slang
@@ -78,7 +78,9 @@ void main()
     ObjectData_t object = GetObjectData();
 
     mat4 skinTransform = object.transform * getSkinMatrix();
-    vFragPosition = (skinTransform * vec4(vPOSITION + getMorphOffset(), 1.0)).xyz;
+    vec4 fragPosition = skinTransform * vec4(vPOSITION + getMorphOffset(), 1.0);
+    gl_Position = g_matWorldToProjection * fragPosition;
+    vFragPosition = fragPosition.xyz / fragPosition.w;
 
     vec3 normal;
     vec4 tangent;

--- a/Renderer/Shaders/vr_standard.vert.slang
+++ b/Renderer/Shaders/vr_standard.vert.slang
@@ -91,8 +91,6 @@ void main()
     vTangentOut = normalize(normalTransform * tangent.xyz);
     vBitangentOut = tangent.w * cross(vNormalOut, vTangentOut);
 
-    gl_Position = g_matWorldToProjection * vec4(vFragPosition, 1.0);
-
     vTexCoordOut = GetAnimatedUVs(vTEXCOORD.xy);
 
 #if (D_BAKED_LIGHTING_FROM_LIGHTMAP == 1)


### PR DESCRIPTION
Fixes the vr_standard shader causing some models in Robot Repair appearing much larger than they should.