### PR TITLE
Fix off by one error in MurmurHashMatcher and add 2 missing keys

### DIFF
--- a/Misc/MurmurHashMatcher/Program.cs
+++ b/Misc/MurmurHashMatcher/Program.cs
@@ -88,7 +88,7 @@ if (args?.Length > 0 && Directory.Exists(args![0]))
 
             var asciiStart = position;
 
-            for (var i = position - 1; i > 0; i--)
+            for (var i = position - 1; i >= 0; i--)
             {
                 if (bytes[i] < 32 || bytes[i] > 126 || position - i > 50)
                 {

--- a/ValveResourceFormat/Utils/EntityLumpKnownKeys.cs
+++ b/ValveResourceFormat/Utils/EntityLumpKnownKeys.cs
@@ -644,6 +644,8 @@ class EntityLumpKnownKeys
         "box_size",
         "box_world_aligned",
         "box",
+        "boxproject_maxs",
+        "boxproject_mins",
         "brace_attachment_up",
         "brace_up_flipped",
         "brackets_a",


### PR DESCRIPTION
Fix the off by one error in MurmurHashMatcher that drops the first character of strings starting right after a `\0`. Since binary files pack strings with null bytes it happens when scanning binary files.