### PR TITLE
Add native Linux Source 2 Viewer GUI

### DIFF
--- a/Renderer/Renderer/Framebuffer.cs
+++ b/Renderer/Renderer/Framebuffer.cs
@@ -133,6 +133,21 @@ public class Framebuffer
     /// </summary>
     public static Framebuffer GLDefaultFramebuffer => new(fboHandle: 0);
 
+    /// <summary>
+    /// Creates a <see cref="Framebuffer"/> instance wrapping an existing OpenGL framebuffer owned by another UI toolkit.
+    /// </summary>
+    /// <param name="fboHandle">Existing OpenGL framebuffer handle.</param>
+    /// <param name="width">Framebuffer width in pixels.</param>
+    /// <param name="height">Framebuffer height in pixels.</param>
+    public static Framebuffer WrapExisting(int fboHandle, int width, int height)
+    {
+        return new Framebuffer(fboHandle)
+        {
+            Width = width,
+            Height = height,
+        };
+    }
+
     /// <inheritdoc/>
     public override bool Equals(object? obj) => obj is Framebuffer other && other.FboHandle == FboHandle;
 

--- a/Renderer/Renderer/GPUMeshBufferCache.cs
+++ b/Renderer/Renderer/GPUMeshBufferCache.cs
@@ -19,7 +19,7 @@ namespace ValveResourceFormat.Renderer
         private readonly Dictionary<string, GPUMeshBuffers> gpuBuffers = [];
         private readonly Dictionary<VAOKey, int> vertexArrayObjects = [];
 
-        private record struct VAOKey(string MeshName, int Shader, int VertexIndex, int IndexIndex);
+        private record struct VAOKey(string MeshName, int Shader, string VertexBuffers, int IndexIndex);
 
         /// <summary>Initializes a new GPU mesh buffer cache.</summary>
         /// <param name="rendererContext">The renderer context owning this cache.</param>
@@ -104,7 +104,7 @@ namespace ValveResourceFormat.Renderer
             {
                 MeshName = meshName,
                 Shader = material.Shader.Program,
-                VertexIndex = vertexBuffers[0].Handle, // Probably good enough since every draw call will be creating new buffers
+                VertexBuffers = GetVertexBufferKey(vertexBuffers),
                 IndexIndex = idxIndex,
             };
 
@@ -122,11 +122,11 @@ namespace ValveResourceFormat.Renderer
             GL.BindVertexArray(newVaoHandle);
 
             var bindingIndex = 0;
-            vertexBuffers = AddMissingAttributes(vertexBuffers, material.Shader);
+            SetMissingAttributes(vertexBuffers, material.Shader);
 
             foreach (var curVertexBuffer in vertexBuffers)
             {
-                GL.VertexArrayVertexBuffer(newVaoHandle, bindingIndex, curVertexBuffer.Handle, 0, (int)curVertexBuffer.ElementSizeInBytes);
+                GL.VertexArrayVertexBuffer(newVaoHandle, bindingIndex, curVertexBuffer.Handle, (nint)curVertexBuffer.Offset, (int)curVertexBuffer.ElementSizeInBytes);
 
                 foreach (var attribute in curVertexBuffer.InputLayoutFields)
                 {
@@ -189,29 +189,17 @@ namespace ValveResourceFormat.Renderer
             return newVaoHandle;
         }
 
-        private VertexDrawBuffer[] AddMissingAttributes(VertexDrawBuffer[] vertexBuffers, Shader shader)
+        private static string GetVertexBufferKey(VertexDrawBuffer[] vertexBuffers)
+            => string.Join(';', vertexBuffers.Select(static vertexBuffer =>
+                $"{vertexBuffer.Handle}:{vertexBuffer.Offset}:{vertexBuffer.ElementSizeInBytes}"));
+
+        private static void SetMissingAttributes(VertexDrawBuffer[] vertexBuffers, Shader shader)
         {
             if (shader.Attributes.TryGetValue("vCOLOR", out var colorAttributeLocation)
                         && !vertexBuffers.Any(vb => vb.InputLayoutFields.Any(f => f.SemanticName == "COLOR")))
             {
-                var defaultColor = new VertexDrawBuffer
-                {
-                    Handle = VectorOneVertexBuffer,
-                    ElementSizeInBytes = 0, // required for the singular attribute to apply to all vertices
-                    InputLayoutFields =
-                    [
-                        new VBIB.RenderInputLayoutField
-                        {
-                            SemanticName = "COLOR",
-                            Format = DXGI_FORMAT.R32G32B32A32_FLOAT,
-                        },
-                    ],
-                };
-
-                vertexBuffers = [.. vertexBuffers, defaultColor];
+                GL.VertexAttrib4(colorAttributeLocation, 1f, 1f, 1f, 1f);
             }
-
-            return vertexBuffers;
         }
 
         private static void BindVertexAttrib(int vao, VBIB.RenderInputLayoutField attribute, int attributeLocation, int offset, int bindingIndex)

--- a/Renderer/Renderer/RenderableMesh.cs
+++ b/Renderer/Renderer/RenderableMesh.cs
@@ -379,7 +379,7 @@ namespace ValveResourceFormat.Renderer
                 drawCall.IndexBuffer = indexBuffer;
 
                 var indexElementSize = vbib.IndexBuffers[(int)bufferIndex].ElementSizeInBytes;
-                drawCall.StartIndex = (nint)(objectDrawCall.GetUInt32Property("m_nStartIndex") * indexElementSize);
+                drawCall.StartIndex = (nint)(indexBuffer.Offset + (objectDrawCall.GetUInt32Property("m_nStartIndex") * indexElementSize));
                 drawCall.IndexCount = objectDrawCall.GetInt32Property("m_nIndexCount");
 
                 drawCall.IndexType = indexElementSize switch

--- a/Renderer/Renderer/SceneNodes/HitboxSetSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/HitboxSetSceneNode.cs
@@ -87,6 +87,9 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             currentSet = hitboxSets[set];
         }
 
+        /// <summary>Gets all hitbox set names available on this node.</summary>
+        public IEnumerable<string> HitboxSets => hitboxSets.Keys;
+
         private static void UpdateHitboxSet(HitboxSetData hitboxSetData, Span<Matrix4x4> boneMatrices)
         {
             var hitboxSet = hitboxSetData.HitboxSet;

--- a/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
@@ -589,6 +589,10 @@ namespace ValveResourceFormat.Renderer.SceneNodes
         public IEnumerable<string> GetMeshGroups()
             => meshGroups;
 
+        /// <summary>Returns all material group names defined by this model.</summary>
+        public IEnumerable<string> GetMaterialGroups()
+            => materialGroups.Select(static group => group.Name);
+
         /// <summary>Returns the set of currently active mesh group names.</summary>
         public ICollection<string> GetActiveMeshGroups()
             => activeMeshGroups;
@@ -608,6 +612,9 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
         /// <summary>Gets whether the LoD level is being chosen automatically by distance, rather than forced.</summary>
         public bool IsAutoLod => lodOverride == null;
+
+        /// <summary>Gets the model LoD metadata used for automatic and forced LoD selection.</summary>
+        public ModelLodInfo LodInfo => lodInfo;
 
         /// <summary>
         /// Sets the LoD level to display, rebuilding the renderable mesh list accordingly.

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -109,17 +109,24 @@ namespace ValveResourceFormat.Renderer.Shaders
         private unsafe void StoreUniformLocations()
         {
             Span<float> floatVal = stackalloc float[16];
+            var nextTextureSlot = (int)ReservedTextureSlots.Last + 1;
 
             // Stores uniform types and locations
             var uniforms = GetAllUniformNames();
 
             // Stores uniform values
-            foreach (var uniform in uniforms)
+            foreach (var activeUniform in uniforms)
             {
-                var name = uniform.Name;
-                var type = uniform.Type;
-                var index = uniform.Index;
-                var size = uniform.Size;
+                var name = activeUniform.Name;
+                var type = activeUniform.Type;
+                var index = activeUniform.Index;
+                var size = activeUniform.Size;
+                var isTexture = IsSamplerType(type);
+
+                if (isTexture && Uniforms.TryGetValue(name, out var cachedUniform))
+                {
+                    SetInitialTextureSlots(name, cachedUniform.Location, size, ref nextTextureSlot);
+                }
 
                 if (!name.StartsWith("g_", StringComparison.Ordinal) && !name.StartsWith("F_", StringComparison.Ordinal))
                 {
@@ -131,7 +138,6 @@ namespace ValveResourceFormat.Renderer.Shaders
                     continue;
                 }
 
-                var isTexture = type is >= ActiveUniformType.Sampler2D and <= ActiveUniformType.SamplerCube;
                 var isVector = type is >= ActiveUniformType.FloatVec2 and <= ActiveUniformType.IntVec4;
                 var isScalar = type == ActiveUniformType.Float;
                 var isBoolean = type == ActiveUniformType.Bool;
@@ -199,6 +205,95 @@ namespace ValveResourceFormat.Renderer.Shaders
                     );
                 }
             }
+        }
+
+        private static bool IsSamplerType(ActiveUniformType type) => type.ToString().Contains("Sampler", StringComparison.Ordinal);
+
+        private void SetInitialTextureSlots(string name, int location, int size, ref int nextTextureSlot)
+        {
+            if (size <= 1)
+            {
+                GL.ProgramUniform1(Program, location, GetInitialTextureSlot(name, ref nextTextureSlot));
+                return;
+            }
+
+            var slots = new int[size];
+            for (var i = 0; i < slots.Length; i++)
+            {
+                slots[i] = GetInitialTextureSlot($"{name}[{i}]", ref nextTextureSlot);
+            }
+
+            GL.ProgramUniform1(Program, location, slots.Length, slots);
+        }
+
+        private static int GetInitialTextureSlot(string name, ref int nextTextureSlot)
+        {
+            if (name.Contains("BRDFLookup", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BRDFLookup;
+            }
+            if (name.Contains("BlueNoise", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BlueNoise;
+            }
+            if (name.Contains("FogCubeTexture", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.FogCubeTexture;
+            }
+            if (name.Contains("ShadowDepthBufferDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.ShadowDepthBufferDepth;
+            }
+            if (name.Contains("BarnLightShadowDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BarnLightShadowDepth;
+            }
+            if (name.Contains("EnvironmentMap", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.EnvironmentMap;
+            }
+            if (name.Contains("LPV_Irradiance", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe1;
+            }
+            if (name.Contains("LPV_Indices", StringComparison.OrdinalIgnoreCase) || name.Contains("LPV_Shadows", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe2;
+            }
+            if (name.Contains("LPV_Scalars", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe3;
+            }
+            if (name.Contains("LightCookieTextureWrap", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.LightCookieTextureWrap;
+            }
+            if (name.Contains("LightCookieTexture", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.LightCookieTexture;
+            }
+            if (name.Contains("SceneColor", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneColor;
+            }
+            if (name.Contains("SceneDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneDepth;
+            }
+            if (name.Contains("SceneStencil", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneStencil;
+            }
+            if (name.Contains("DepthPyramid", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.DepthPyramid;
+            }
+            if (name.Contains("Morph", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.MorphCompositeTexture;
+            }
+
+            return nextTextureSlot++;
         }
 
         /// <summary>Installs this shader program as part of the current rendering state.</summary>

--- a/Source2Viewer.App/App.axaml
+++ b/Source2Viewer.App/App.axaml
@@ -1,0 +1,10 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Source2Viewer.App.App"
+             RequestedThemeVariant="Dark">
+             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/Source2Viewer.App/App.axaml.cs
+++ b/Source2Viewer.App/App.axaml.cs
@@ -1,0 +1,23 @@
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace Source2Viewer.App;
+
+public partial class App : Application
+{
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            desktop.MainWindow = new MainWindow();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+}

--- a/Source2Viewer.App/MainWindow.axaml
+++ b/Source2Viewer.App/MainWindow.axaml
@@ -1,0 +1,255 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="using:Source2Viewer.App"
+        mc:Ignorable="d" d:DesignWidth="1280" d:DesignHeight="800"
+        x:Class="Source2Viewer.App.MainWindow"
+        Width="1280" Height="800" MinWidth="1000" MinHeight="620"
+        Background="#111721"
+        Title="Source 2 Viewer - Linux Native">
+    <Window.Styles>
+        <Style Selector="Button">
+            <Setter Property="Background" Value="#2A3140" />
+            <Setter Property="Foreground" Value="#E6EDF3" />
+            <Setter Property="BorderBrush" Value="#4A5263" />
+            <Setter Property="Padding" Value="8,5" />
+        </Style>
+        <Style Selector="TextBox">
+            <Setter Property="Background" Value="#151B26" />
+            <Setter Property="Foreground" Value="#E6EDF3" />
+            <Setter Property="BorderBrush" Value="#4A5263" />
+        </Style>
+        <Style Selector="ComboBox">
+            <Setter Property="Background" Value="#151B26" />
+            <Setter Property="Foreground" Value="#E6EDF3" />
+            <Setter Property="BorderBrush" Value="#4A5263" />
+        </Style>
+        <Style Selector="ListBox">
+            <Setter Property="Background" Value="#111722" />
+            <Setter Property="Foreground" Value="#E6EDF3" />
+            <Setter Property="BorderBrush" Value="#313948" />
+        </Style>
+        <Style Selector="TreeView">
+            <Setter Property="Background" Value="#111722" />
+            <Setter Property="Foreground" Value="#E6EDF3" />
+        </Style>
+        <Style Selector="CheckBox">
+            <Setter Property="Foreground" Value="#E6EDF3" />
+        </Style>
+    </Window.Styles>
+
+    <Grid RowDefinitions="42,*">
+        <Border Grid.Row="0" Padding="8,0" Background="#10151F" BorderBrush="#222B3A" BorderThickness="0,0,0,1">
+            <DockPanel LastChildFill="True">
+                <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Border Width="24" Height="24" CornerRadius="12" Background="#1D3351" BorderBrush="#5C8FD6" BorderThickness="1">
+                        <TextBlock Text="S²" Foreground="#EAF3FF" FontWeight="Bold" FontSize="12" HorizontalAlignment="Center" VerticalAlignment="Center" />
+                    </Border>
+                    <Menu Background="#10151F" Foreground="#E6EDF3">
+                        <MenuItem Header="📁 File">
+                            <MenuItem x:Name="OpenPackageButton" Header="Open..." />
+                            <MenuItem x:Name="ReopenLastButton" Header="Reopen last" IsEnabled="False" />
+                            <Separator />
+                            <MenuItem x:Name="ClearButton" Header="Clear" />
+                        </MenuItem>
+                        <MenuItem Header="🧭 Explorer">
+                            <MenuItem x:Name="BackButton" Header="Back" IsEnabled="False" />
+                            <MenuItem x:Name="ForwardButton" Header="Forward" IsEnabled="False" />
+                            <Separator />
+                            <MenuItem x:Name="ExportSelectedButton" Header="Export selected raw" />
+                            <MenuItem x:Name="ExportVisibleButton" Header="Export shown raw" />
+                            <MenuItem x:Name="ExportVisibleDecompiledButton" Header="Export shown decompiled" />
+                            <MenuItem x:Name="PreviewDecompiledButton" Header="Preview decompiled" />
+                            <MenuItem x:Name="ExportDecompiledButton" Header="Export decompiled" />
+                        </MenuItem>
+                        <MenuItem x:Name="FindMenuItem" Header="🔎 Find" />
+                        <MenuItem Header="⚙ Settings">
+                            <MenuItem x:Name="SaveScreenshotButton" Header="Save screenshot" />
+                            <MenuItem x:Name="PlaySoundButton" Header="Play sound" IsVisible="False" />
+                            <MenuItem x:Name="StopSoundButton" Header="Stop sound" IsVisible="False" />
+                        </MenuItem>
+                        <MenuItem x:Name="AboutMenuItem" Header="ℹ About" />
+                    </Menu>
+                </StackPanel>
+                <TextBlock x:Name="StatusText" Margin="12,0,8,0" VerticalAlignment="Center" Foreground="#AEB8C7" Text="Open a .vpk to browse package entries." TextTrimming="CharacterEllipsis" />
+            </DockPanel>
+        </Border>
+
+        <TabControl x:Name="MainTabs" Grid.Row="1" Background="#111721" Foreground="#E6EDF3">
+            <TabItem x:Name="ExplorerTab" Header="🧭 Explorer">
+                <Grid RowDefinitions="36,*" Background="#111721">
+                    <Border Grid.Row="0" Padding="10,0" Background="#1B2230" BorderBrush="#2A3446" BorderThickness="0,0,0,1">
+                        <DockPanel LastChildFill="True">
+                            <TextBlock DockPanel.Dock="Left" Text="PACKAGE" Foreground="#7FA3D7" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,12,0" />
+                            <TextBlock x:Name="PackagePathText" TextWrapping="NoWrap" TextTrimming="CharacterEllipsis" Foreground="#C6D0DE" VerticalAlignment="Center" />
+                        </DockPanel>
+                    </Border>
+
+                    <Grid Grid.Row="1" ColumnDefinitions="380,5,*" Background="#111721">
+                        <Border Grid.Column="0" Padding="10" Background="#19202B" BorderBrush="#2A3446" BorderThickness="0,0,1,0">
+                            <Grid RowDefinitions="Auto,*,Auto,2*" RowSpacing="8">
+                                <Grid ColumnDefinitions="*,118,100,90" ColumnSpacing="8">
+                                    <TextBox x:Name="SearchTextBox" PlaceholderText="Search package entries" />
+                                    <ComboBox x:Name="SearchModeComboBox" Grid.Column="1" />
+                                    <ComboBox x:Name="EntryFilterComboBox" Grid.Column="2" />
+                                    <ComboBox x:Name="SortModeComboBox" Grid.Column="3" />
+                                </Grid>
+                                <TreeView x:Name="FolderTree" Grid.Row="1" />
+                                <Border Grid.Row="2" Padding="6,3" Background="#252C39" BorderBrush="#313948" BorderThickness="1">
+                                    <Grid ColumnDefinitions="*,90,90">
+                                        <TextBlock Text="Path" Foreground="#AEB8C7" />
+                                        <TextBlock Grid.Column="1" Text="Type" Foreground="#AEB8C7" />
+                                        <TextBlock Grid.Column="2" Text="Size" Foreground="#AEB8C7" HorizontalAlignment="Right" />
+                                    </Grid>
+                                </Border>
+                                <ListBox x:Name="EntryList" Grid.Row="3">
+                                    <ListBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding}" FontFamily="monospace" TextTrimming="CharacterEllipsis" Margin="2" />
+                                        </DataTemplate>
+                                    </ListBox.ItemTemplate>
+                                    <ListBox.ContextMenu>
+                                        <ContextMenu>
+                                            <MenuItem x:Name="CopyEntryPathMenuItem" Header="Copy name" />
+                                            <MenuItem x:Name="ExportSelectedMenuItem" Header="Export as is" />
+                                            <MenuItem x:Name="PreviewDecompiledMenuItem" Header="Preview decompiled" />
+                                            <MenuItem x:Name="ExportDecompiledMenuItem" Header="Decompile and export" />
+                                        </ContextMenu>
+                                    </ListBox.ContextMenu>
+                                </ListBox>
+                            </Grid>
+                        </Border>
+                        <GridSplitter Grid.Column="1" Background="#2A3446" ResizeDirection="Columns" />
+                        <Border Grid.Column="2" Margin="10" Padding="12" Background="#151B26" BorderBrush="#313948" BorderThickness="1" CornerRadius="3">
+                            <Grid ColumnDefinitions="280,*" ColumnSpacing="14">
+                                <Border x:Name="PreviewImageBorder" Background="#0D1117" BorderBrush="#313948" BorderThickness="1" Padding="8" IsVisible="False">
+                                    <Image x:Name="PreviewImage" Stretch="Uniform" />
+                                </Border>
+                                <ScrollViewer Grid.Column="1">
+                                    <TextBlock x:Name="DetailsText" TextWrapping="Wrap" Foreground="#DDE7F3" FontFamily="monospace" />
+                                </ScrollViewer>
+                            </Grid>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </TabItem>
+
+            <TabItem x:Name="ViewportTab" Header="Viewport">
+                <Grid RowDefinitions="36,*" Background="#111721">
+                    <Border Grid.Row="0" Background="#1B2230" BorderBrush="#2A3446" BorderThickness="0,0,0,1">
+                        <StackPanel Orientation="Horizontal" Spacing="0">
+                            <Border Padding="18,8,18,6" BorderBrush="#66A7FF" BorderThickness="0,0,0,3">
+                                <TextBlock Text="MAP" Foreground="#E6EDF3" FontWeight="Bold" />
+                            </Border>
+                            <Border Padding="16,8,16,6">
+                                <TextBlock Text="World Data" Foreground="#AEB8C7" />
+                            </Border>
+                            <Border Padding="16,8,16,6">
+                                <TextBlock Text="Node Data" Foreground="#AEB8C7" />
+                            </Border>
+                            <Border Padding="16,8,16,6">
+                                <TextBlock Text="Entity List" Foreground="#AEB8C7" />
+                            </Border>
+                            <Border Padding="16,8,16,6">
+                                <TextBlock Text="External Refs" Foreground="#AEB8C7" />
+                            </Border>
+                            <Border Padding="16,8,16,6">
+                                <TextBlock Text="RED2" Foreground="#AEB8C7" />
+                            </Border>
+                        </StackPanel>
+                    </Border>
+
+                    <Grid Grid.Row="1" ColumnDefinitions="220,5,*" Background="#111721">
+                        <Border Grid.Column="0" Padding="8" Background="#1A2230" BorderBrush="#2A3446" BorderThickness="0,0,1,0">
+                            <ScrollViewer>
+                                <StackPanel Spacing="10">
+                                    <Button x:Name="ResetCameraButton" Content="Reset camera / focus" />
+
+                                    <StackPanel Spacing="5">
+                                        <TextBlock Text="Render Mode" Foreground="#C6D0DE" />
+                                        <ComboBox x:Name="RenderModeComboBox" PlaceholderText="Render mode" />
+                                    </StackPanel>
+
+                                    <StackPanel x:Name="WorldSection" Spacing="8" IsVisible="False">
+                                        <Border Height="1" Background="#313948" />
+                                        <TextBlock x:Name="WorldLayerLabel" Text="World Layers" Foreground="#C6D0DE" FontWeight="SemiBold" IsVisible="False" />
+                                        <ListBox x:Name="WorldLayerListBox" Height="118" SelectionMode="Multiple" IsVisible="False" />
+                                        <TextBlock x:Name="PhysicsGroupLabel" Text="Physics Groups" Foreground="#C6D0DE" FontWeight="SemiBold" IsVisible="False" />
+                                        <ListBox x:Name="PhysicsGroupListBox" Height="130" SelectionMode="Multiple" IsVisible="False" />
+                                        <TextBlock x:Name="EntityLabel" Text="Entities" Foreground="#C6D0DE" FontWeight="SemiBold" IsVisible="False" />
+                                        <ListBox x:Name="EntityListBox" Height="116" IsVisible="False" />
+                                        <StackPanel Spacing="5">
+                                            <TextBlock Text="Map Camera" Foreground="#C6D0DE" />
+                                            <ComboBox x:Name="MapCameraComboBox" PlaceholderText="Map camera" IsVisible="False" />
+                                        </StackPanel>
+                                    </StackPanel>
+
+                                    <StackPanel x:Name="ModelSection" Spacing="8" IsVisible="False">
+                                        <Border Height="1" Background="#313948" />
+                                        <TextBlock x:Name="MeshGroupLabel" Text="Mesh groups" Foreground="#C6D0DE" FontWeight="SemiBold" IsVisible="False" />
+                                        <ListBox x:Name="MeshGroupListBox" Height="90" SelectionMode="Multiple" IsVisible="False" />
+                                        <TextBlock x:Name="MaterialGroupLabel" Text="Material group" Foreground="#C6D0DE" IsVisible="False" />
+                                        <ComboBox x:Name="MaterialGroupComboBox" PlaceholderText="Material group" IsVisible="False" />
+                                        <TextBlock x:Name="LodLabel" Text="Level of detail" Foreground="#C6D0DE" IsVisible="False" />
+                                        <ComboBox x:Name="LodComboBox" PlaceholderText="Level of detail" IsVisible="False" />
+                                        <TextBlock x:Name="HitboxSetLabel" Text="Hitbox set" Foreground="#C6D0DE" IsVisible="False" />
+                                        <ComboBox x:Name="HitboxSetComboBox" PlaceholderText="Hitbox set" IsVisible="False" />
+                                        <CheckBox x:Name="SkeletonCheckBox" Content="Show skeleton" IsVisible="False" />
+                                    </StackPanel>
+
+                                    <StackPanel x:Name="AnimationSection" Spacing="8" IsVisible="False">
+                                        <Border Height="1" Background="#313948" />
+                                        <TextBlock x:Name="AnimationLabel" Text="Animation" Foreground="#C6D0DE" FontWeight="SemiBold" IsVisible="False" />
+                                        <ComboBox x:Name="AnimationComboBox" PlaceholderText="Animation" IsVisible="False" />
+                                        <CheckBox x:Name="AnimationAutoplayCheckBox" Content="Autoplay" IsVisible="False" />
+                                        <CheckBox x:Name="RootMotionCheckBox" Content="Root motion" IsVisible="False" />
+                                        <TextBlock x:Name="AnimationFrameLabel" Text="Animation frame" Foreground="#C6D0DE" IsVisible="False" />
+                                        <Slider x:Name="AnimationFrameSlider" Minimum="0" Maximum="1" Value="0" IsVisible="False" />
+                                        <TextBlock x:Name="AnimationSpeedLabel" Text="Animation speed" Foreground="#C6D0DE" IsVisible="False" />
+                                        <Slider x:Name="AnimationSpeedSlider" Minimum="0.1" Maximum="2" Value="1" IsVisible="False" />
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="6">
+                                        <Border Height="1" Background="#313948" />
+                                        <TextBlock Text="Scene" Foreground="#C6D0DE" FontWeight="SemiBold" />
+                                        <CheckBox x:Name="GridCheckBox" Content="Show grid" />
+                                        <CheckBox x:Name="SkyboxCheckBox" Content="Show skybox" />
+                                        <CheckBox x:Name="FogCheckBox" Content="Show fog" />
+                                        <CheckBox x:Name="ColorCorrectionCheckBox" Content="Color correction" />
+                                        <CheckBox x:Name="ToolMaterialsCheckBox" Content="Show tool materials" />
+                                    </StackPanel>
+
+                                    <StackPanel Spacing="6">
+                                        <Border Height="1" Background="#313948" />
+                                        <TextBlock Text="Debug" Foreground="#C6D0DE" FontWeight="SemiBold" />
+                                        <CheckBox x:Name="WireframeCheckBox" Content="Wireframe" />
+                                        <CheckBox x:Name="OcclusionCullingCheckBox" Content="Occlusion culling" />
+                                        <CheckBox x:Name="GpuCullingCheckBox" Content="GPU culling" />
+                                        <CheckBox x:Name="DepthPrepassCheckBox" Content="Depth prepass" />
+                                        <CheckBox x:Name="ExperimentalLightsCheckBox" Content="Experimental lights" />
+                                        <CheckBox x:Name="OccludedBoundsCheckBox" Content="Show occluded bounds" />
+                                        <CheckBox x:Name="StaticOctreeCheckBox" Content="Show static octree" />
+                                        <CheckBox x:Name="DynamicOctreeCheckBox" Content="Show dynamic octree" />
+                                        <CheckBox x:Name="ModelStatsCheckBox" Content="Model stats" IsVisible="False" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </ScrollViewer>
+                        </Border>
+                        <GridSplitter Grid.Column="1" Background="#2A3446" ResizeDirection="Columns" />
+                        <Grid Grid.Column="2">
+                            <local:NativeRenderControl x:Name="RenderControl" />
+                            <Border x:Name="ViewportInputLayer" Background="Transparent" Focusable="True" />
+                            <Border HorizontalAlignment="Left" VerticalAlignment="Top" Margin="16" Padding="10,6" Background="#AA000000" CornerRadius="4" IsHitTestVisible="False">
+                                <TextBlock x:Name="ViewportMessageText" Text="Native OpenGL renderer viewport" Foreground="#F2F2F2" TextWrapping="Wrap" MaxWidth="720" />
+                            </Border>
+                            <Border HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="16" Padding="10,6" Background="#AA000000" CornerRadius="4" IsHitTestVisible="False">
+                                <TextBlock x:Name="ModelStatsText" Foreground="#F2F2F2" FontFamily="monospace" TextWrapping="Wrap" MaxWidth="720" IsVisible="False" />
+                            </Border>
+                        </Grid>
+                    </Grid>
+                </Grid>
+            </TabItem>
+        </TabControl>
+    </Grid>
+</Window>

--- a/Source2Viewer.App/MainWindow.axaml.cs
+++ b/Source2Viewer.App/MainWindow.axaml.cs
@@ -1,0 +1,2063 @@
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Avalonia.Media.Imaging;
+using Avalonia.Platform.Storage;
+using SteamDatabase.ValvePak;
+using ValveResourceFormat;
+using ValveResourceFormat.IO;
+using ValveResourceFormat.Renderer.Materials;
+
+namespace Source2Viewer.App;
+
+#pragma warning disable CA2007 // Avalonia UI event handlers intentionally resume on the UI thread.
+
+public partial class MainWindow : Window
+{
+    private readonly List<PackageEntryItem> allEntries = [];
+    private static readonly string LastPathFile = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Source2Viewer",
+        "last-path.txt");
+
+    private readonly ObservableCollection<PackageEntryItem> visibleEntries = [];
+    private Package? currentPackage;
+    private string? currentPath;
+    private string currentFolderPrefix = string.Empty;
+    private bool ignoreMapCameraChange;
+    private bool ignoreAnimationChange;
+    private bool ignoreAnimationFrameChange;
+    private bool ignoreMeshGroupChange;
+    private bool ignoreMaterialGroupChange;
+    private bool ignoreRenderModeChange;
+    private bool ignoreLodChange;
+    private bool ignoreHitboxSetChange;
+    private bool ignoreLayerChange;
+    private bool ignorePhysicsGroupChange;
+    private bool ignoreEntrySelectionChange;
+    private bool ignoreFolderSelection;
+    private readonly List<string> navigationHistory = [];
+    private int navigationHistoryIndex = -1;
+    private int selectionVersion;
+    private string? pendingStartupEntryPath;
+    private string viewportStatus = "Native OpenGL renderer viewport";
+    private WindowState previousWindowState = WindowState.Normal;
+    private Process? soundProcess;
+    private string? soundTempPath;
+    private string? clipboardScreenshotPath;
+
+    public MainWindow() : this(Program.StartupArgs)
+    {
+    }
+
+    public MainWindow(string[] args)
+    {
+        InitializeComponent();
+
+        EntryList.ItemsSource = visibleEntries;
+        SearchModeComboBox.ItemsSource = new[] { "File contains", "Full path", "Exact file", "Regex" };
+        SearchModeComboBox.SelectedIndex = 0;
+        EntryFilterComboBox.ItemsSource = new[] { "All", "Compiled", "Renderable", "Images", "Audio" };
+        EntryFilterComboBox.SelectedIndex = 0;
+        SortModeComboBox.ItemsSource = new[] { "Path", "Name", "Type", "Size" };
+        SortModeComboBox.SelectedIndex = 0;
+        RenderModeComboBox.ItemsSource = GetRenderModeNames(RenderModes.Items.Select(static mode => mode.Name));
+        RenderModeComboBox.SelectedIndex = 0;
+
+        OpenPackageButton.Click += OnOpenPackage;
+        ReopenLastButton.IsEnabled = GetLastPath() != null;
+        ReopenLastButton.Click += async (_, _) => await ReopenLastPathAsync();
+        BackButton.Click += (_, _) => NavigateHistory(-1);
+        ForwardButton.Click += (_, _) => NavigateHistory(1);
+        ClearButton.Click += (_, _) => ClearPackage();
+        ExportSelectedButton.Click += OnExportSelected;
+        ExportVisibleButton.Click += OnExportVisible;
+        ExportVisibleDecompiledButton.Click += OnExportVisibleDecompiled;
+        PreviewDecompiledButton.Click += OnPreviewDecompiled;
+        ExportDecompiledButton.Click += OnExportDecompiled;
+        PlaySoundButton.Click += OnPlaySound;
+        StopSoundButton.Click += (_, _) => StopSound();
+        SaveScreenshotButton.Click += OnSaveScreenshot;
+        FindMenuItem.Click += (_, _) => FocusSearch();
+        AboutMenuItem.Click += (_, _) => ShowAbout();
+        CopyEntryPathMenuItem.Click += OnCopyEntryPath;
+        ExportSelectedMenuItem.Click += OnExportSelected;
+        PreviewDecompiledMenuItem.Click += OnPreviewDecompiled;
+        ExportDecompiledMenuItem.Click += OnExportDecompiled;
+        ResetCameraButton.Click += (_, _) => RenderControl.ResetCamera();
+        WireframeCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetWireframe(WireframeCheckBox.IsChecked == true);
+        GridCheckBox.IsChecked = true;
+        GridCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetGridVisible(GridCheckBox.IsChecked == true);
+        SkyboxCheckBox.IsChecked = true;
+        SkyboxCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetSkyboxVisible(SkyboxCheckBox.IsChecked == true);
+        FogCheckBox.IsChecked = true;
+        FogCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetFogVisible(FogCheckBox.IsChecked == true);
+        ColorCorrectionCheckBox.IsChecked = true;
+        ColorCorrectionCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetColorCorrectionEnabled(ColorCorrectionCheckBox.IsChecked == true);
+        OcclusionCullingCheckBox.IsChecked = true;
+        OcclusionCullingCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetOcclusionCullingEnabled(OcclusionCullingCheckBox.IsChecked == true);
+        GpuCullingCheckBox.IsChecked = true;
+        GpuCullingCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetGpuCullingEnabled(GpuCullingCheckBox.IsChecked == true);
+        DepthPrepassCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetDepthPrepassEnabled(DepthPrepassCheckBox.IsChecked == true);
+        ExperimentalLightsCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetExperimentalLightsEnabled(ExperimentalLightsCheckBox.IsChecked == true);
+        ToolMaterialsCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetToolMaterialsVisible(ToolMaterialsCheckBox.IsChecked == true);
+        OccludedBoundsCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetOccludedBoundsVisible(OccludedBoundsCheckBox.IsChecked == true);
+        StaticOctreeCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetStaticOctreeVisible(StaticOctreeCheckBox.IsChecked == true);
+        DynamicOctreeCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetDynamicOctreeVisible(DynamicOctreeCheckBox.IsChecked == true);
+        RenderControl.MapCamerasChanged += OnMapCamerasChanged;
+        RenderControl.AnimationsChanged += OnAnimationsChanged;
+        RenderControl.MeshGroupsChanged += OnMeshGroupsChanged;
+        RenderControl.MaterialGroupsChanged += OnMaterialGroupsChanged;
+        RenderControl.LodsChanged += OnLodsChanged;
+        RenderControl.HitboxSetsChanged += OnHitboxSetsChanged;
+        RenderControl.SkeletonChanged += OnSkeletonChanged;
+        RenderControl.WorldLayersChanged += OnWorldLayersChanged;
+        RenderControl.PhysicsGroupsChanged += OnPhysicsGroupsChanged;
+        RenderControl.EntitiesChanged += OnEntitiesChanged;
+        RenderControl.RenderModesChanged += OnRenderModesChanged;
+        RenderControl.ModelStatsChanged += OnModelStatsChanged;
+        RenderControl.ViewportErrorChanged += OnViewportErrorChanged;
+        RenderControl.ViewportStatusChanged += OnViewportStatusChanged;
+        RenderControl.ScreenshotSaved += OnScreenshotSaved;
+        RenderModeComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreRenderModeChange && RenderModeComboBox.SelectedItem is string mode)
+            {
+                RenderControl.SetRenderMode(mode);
+            }
+        };
+        MapCameraComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreMapCameraChange && MapCameraComboBox.SelectedIndex >= 0)
+            {
+                RenderControl.SetMapCamera(MapCameraComboBox.SelectedIndex);
+            }
+        };
+        AnimationComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreAnimationChange)
+            {
+                RenderControl.SetAnimation(AnimationComboBox.SelectedIndex <= 0 ? null : AnimationComboBox.SelectedItem as string);
+            }
+        };
+        AnimationAutoplayCheckBox.IsChecked = true;
+        AnimationAutoplayCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetAnimationPaused(AnimationAutoplayCheckBox.IsChecked != true);
+        RootMotionCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetRootMotionEnabled(RootMotionCheckBox.IsChecked == true);
+        AnimationFrameSlider.PropertyChanged += (_, e) =>
+        {
+            if (!ignoreAnimationFrameChange && e.Property == Slider.ValueProperty)
+            {
+                RenderControl.SetAnimationFrame((float)AnimationFrameSlider.Value);
+            }
+        };
+        AnimationSpeedSlider.PropertyChanged += (_, e) =>
+        {
+            if (e.Property == Slider.ValueProperty)
+            {
+                RenderControl.SetAnimationSpeed((float)AnimationSpeedSlider.Value);
+            }
+        };
+        MeshGroupListBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreMeshGroupChange)
+            {
+                RenderControl.SetMeshGroups(MeshGroupListBox.SelectedItems?.Cast<string>().ToArray() ?? []);
+            }
+        };
+        MaterialGroupComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreMaterialGroupChange && MaterialGroupComboBox.SelectedItem is string group)
+            {
+                RenderControl.SetMaterialGroup(group);
+            }
+        };
+        LodComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreLodChange)
+            {
+                RenderControl.SetLod(LodComboBox.SelectedIndex - 1);
+            }
+        };
+        HitboxSetComboBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreHitboxSetChange)
+            {
+                RenderControl.SetHitboxSet(HitboxSetComboBox.SelectedIndex <= 0 ? null : HitboxSetComboBox.SelectedItem as string);
+            }
+        };
+        SkeletonCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetSkeletonVisible(SkeletonCheckBox.IsChecked == true);
+        ModelStatsCheckBox.IsCheckedChanged += (_, _) => RenderControl.SetModelStatsVisible(ModelStatsCheckBox.IsChecked == true);
+        WorldLayerListBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignoreLayerChange)
+            {
+                RenderControl.SetWorldLayers(WorldLayerListBox.SelectedItems?.Cast<string>().ToArray() ?? []);
+            }
+        };
+        PhysicsGroupListBox.SelectionChanged += (_, _) =>
+        {
+            if (!ignorePhysicsGroupChange)
+            {
+                RenderControl.SetPhysicsGroups(PhysicsGroupListBox.SelectedItems?.Cast<string>().ToArray() ?? []);
+            }
+        };
+        SearchModeComboBox.SelectionChanged += (_, _) => ApplyFilter();
+        EntryFilterComboBox.SelectionChanged += (_, _) => ApplyFilter();
+        SortModeComboBox.SelectionChanged += (_, _) => ApplyFilter();
+        SearchTextBox.TextChanged += (_, _) => ApplyFilter();
+        SearchTextBox.KeyDown += OnSearchKeyDown;
+        FolderTree.SelectionChanged += OnFolderSelected;
+        EntryList.SelectionChanged += OnEntrySelected;
+        EntryList.DoubleTapped += (_, _) => _ = LoadSelectedEntryAsync();
+        EntityListBox.SelectionChanged += (_, _) => ShowSelectedEntityDetails();
+        EntityListBox.DoubleTapped += (_, _) => RenderControl.FocusEntity(EntityListBox.SelectedIndex);
+        EntityListBox.KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Enter)
+            {
+                RenderControl.FocusEntity(EntityListBox.SelectedIndex);
+                e.Handled = true;
+            }
+        };
+        ViewportInputLayer.PointerPressed += OnViewportPointerPressed;
+        ViewportInputLayer.PointerReleased += OnViewportPointerReleased;
+        ViewportInputLayer.PointerMoved += OnViewportPointerMoved;
+        ViewportInputLayer.PointerWheelChanged += OnViewportPointerWheelChanged;
+        ViewportInputLayer.KeyDown += OnViewportKeyDown;
+        ViewportInputLayer.KeyUp += OnViewportKeyUp;
+        KeyDown += OnWindowKeyDown;
+        DragDrop.SetAllowDrop(this, true);
+        DragDrop.AddDragOverHandler(this, OnDragOver);
+        DragDrop.AddDropHandler(this, OnDrop);
+
+        if (args.Length > 0)
+        {
+            pendingStartupEntryPath = args.Length > 1 ? args[1] : null;
+            _ = LoadPathAsync(args[0]);
+        }
+        else
+        {
+            PackagePathText.Text = "No package loaded.";
+            DetailsText.Text = "Open a VPK to browse entries, preview, export, or render Source 2 resources.";
+        }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        StopSound();
+        RenderControl.ClearResource();
+        SetPreviewImage(null);
+        currentPackage?.Dispose();
+        base.OnClosed(e);
+    }
+
+    private async void OnOpenPackage(object? sender, RoutedEventArgs e)
+        => await OpenPackageAsync();
+
+    private void FocusSearch()
+    {
+        MainTabs.SelectedItem = ExplorerTab;
+        SearchTextBox.Focus();
+        SearchTextBox.SelectAll();
+    }
+
+    private void ShowAbout()
+    {
+        MainTabs.SelectedItem = ExplorerTab;
+        DetailsText.Text = "Source 2 Viewer - Linux Native" + Environment.NewLine
+            + "Native Avalonia/OpenGL port in progress." + Environment.NewLine
+            + "Shortcuts: Ctrl+O open, Ctrl+F find, F focus viewport, F11 fullscreen.";
+    }
+
+    private async Task OpenPackageAsync()
+    {
+        var topLevel = GetTopLevel(this);
+        if (topLevel == null)
+        {
+            return;
+        }
+
+        var files = await topLevel.StorageProvider.OpenFilePickerAsync(new FilePickerOpenOptions
+        {
+            Title = "Open VPK or Source 2 resource",
+            AllowMultiple = false,
+            FileTypeFilter =
+            [
+                new FilePickerFileType("Valve packages and resources")
+                {
+                    Patterns = ["*.vpk", "*_c"],
+                },
+                FilePickerFileTypes.All,
+            ],
+        });
+
+        var path = files.Count == 0 ? null : files[0].TryGetLocalPath();
+        if (path != null)
+        {
+            await LoadPathAsync(path);
+        }
+    }
+
+    private async Task LoadPathAsync(string path)
+    {
+        if (string.Equals(Path.GetExtension(path), ".vpk", StringComparison.OrdinalIgnoreCase))
+        {
+            await LoadPackageAsync(path);
+            SaveLastPath(path);
+            return;
+        }
+
+        ClearPackage();
+        currentPath = path;
+        SaveLastPath(path);
+        PackagePathText.Text = path;
+        StatusText.Text = "Opened loose file.";
+        var (details, previewImage) = await Task.Run(() => (DescribeLooseFile(path), TryExtractLooseFilePreviewImageBytes(path)));
+        DetailsText.Text = details;
+        SetPreviewImage(CreatePreviewBitmap(previewImage));
+
+        if (path.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase)
+            && IsRenderableCompiledType(Path.GetExtension(path).TrimStart('.')))
+        {
+            RenderControl.LoadLooseFile(path);
+            SetViewportTabHeader(path);
+            MainTabs.SelectedItem = ViewportTab;
+        }
+        else
+        {
+            RenderControl.ClearResource();
+        }
+    }
+
+    private async Task ReopenLastPathAsync()
+    {
+        var path = GetLastPath();
+        if (path == null)
+        {
+            ReopenLastButton.IsEnabled = false;
+            StatusText.Text = "No last path saved.";
+            return;
+        }
+
+        await LoadPathAsync(path);
+    }
+
+    private static string? GetLastPath()
+    {
+        if (!File.Exists(LastPathFile))
+        {
+            return null;
+        }
+
+        var path = File.ReadAllText(LastPathFile).Trim();
+        return File.Exists(path) ? path : null;
+    }
+
+    private void SaveLastPath(string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(LastPathFile)!);
+        File.WriteAllText(LastPathFile, path);
+        ReopenLastButton.IsEnabled = true;
+    }
+
+    private void OnDragOver(object? sender, DragEventArgs e)
+    {
+        e.DragEffects = GetDroppedPath(e) == null ? DragDropEffects.None : DragDropEffects.Copy;
+        e.Handled = true;
+    }
+
+    private async void OnDrop(object? sender, DragEventArgs e)
+    {
+        var path = GetDroppedPath(e);
+        if (path != null)
+        {
+            await LoadPathAsync(path);
+        }
+
+        e.Handled = true;
+    }
+
+    private static string? GetDroppedPath(DragEventArgs e)
+    {
+        var file = e.DataTransfer.TryGetFiles()?.FirstOrDefault();
+        return file?.TryGetLocalPath();
+    }
+
+    private async Task LoadPackageAsync(string path)
+    {
+        StatusText.Text = "Loading package...";
+        DetailsText.Text = string.Empty;
+        selectionVersion++;
+        EntryList.SelectedItem = null;
+
+        var package = await Task.Run(() =>
+        {
+            var loadedPackage = new Package();
+            loadedPackage.OptimizeEntriesForBinarySearch(StringComparison.OrdinalIgnoreCase);
+            loadedPackage.Read(path);
+            return loadedPackage;
+        });
+
+        currentPackage?.Dispose();
+        currentPackage = package;
+        currentPath = path;
+        currentFolderPrefix = string.Empty;
+        navigationHistory.Clear();
+        navigationHistoryIndex = -1;
+
+        allEntries.Clear();
+
+        if (package.Entries != null)
+        {
+            allEntries.AddRange(package.Entries.Values
+                .SelectMany(static entries => entries)
+                .Select(static entry => new PackageEntryItem(entry))
+                .OrderBy(static entry => entry.Path, StringComparer.OrdinalIgnoreCase));
+        }
+
+        PackagePathText.Text = path;
+        BuildFolderTree();
+        SearchTextBox.Text = string.Empty;
+        SearchModeComboBox.SelectedIndex = 0;
+        EntryFilterComboBox.SelectedIndex = 0;
+        SortModeComboBox.SelectedIndex = 0;
+        ApplyFilter();
+        StatusText.Text = $"Loaded {allEntries.Count:N0} package entries.";
+        DetailsText.Text = "Select an entry to inspect it.";
+        SetPreviewImage(null);
+
+        if (!string.IsNullOrWhiteSpace(pendingStartupEntryPath))
+        {
+            var selectedEntryPath = pendingStartupEntryPath;
+            pendingStartupEntryPath = null;
+
+            ignoreEntrySelectionChange = true;
+            if (SelectPackageEntry(selectedEntryPath))
+            {
+                ignoreEntrySelectionChange = false;
+                await LoadSelectedEntryAsync();
+                StatusText.Text = $"Loaded entry {selectedEntryPath}.";
+                return;
+            }
+            ignoreEntrySelectionChange = false;
+
+            StatusText.Text = $"Loaded {allEntries.Count:N0} package entries. Entry not found: {selectedEntryPath}";
+        }
+
+        SelectDefaultMapEntry();
+    }
+
+    private void ClearPackage()
+    {
+        selectionVersion++;
+        StopSound();
+        RenderControl.ClearResource();
+        SetPreviewImage(null);
+        currentPackage?.Dispose();
+        currentPackage = null;
+        currentPath = null;
+        currentFolderPrefix = string.Empty;
+        navigationHistory.Clear();
+        navigationHistoryIndex = -1;
+        UpdateNavigationButtons();
+        allEntries.Clear();
+        visibleEntries.Clear();
+        FolderTree.Items.Clear();
+        EntryList.SelectedItem = null;
+        PackagePathText.Text = "No package loaded.";
+        StatusText.Text = "Open a .vpk to browse package entries.";
+        DetailsText.Text = string.Empty;
+        SetViewportTabHeader(null);
+        SetSoundButtonsVisible(false);
+    }
+
+    private void SetViewportTabHeader(string? path)
+        => ViewportTab.Header = string.IsNullOrWhiteSpace(path)
+            ? "Viewport"
+            : Path.GetFileName(path.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar));
+
+    private void ApplyFilter()
+    {
+        var filter = SearchTextBox.Text;
+        visibleEntries.Clear();
+
+        var entries = allEntries.AsEnumerable();
+
+        if (!string.IsNullOrEmpty(currentFolderPrefix))
+        {
+            var folderPrefix = currentFolderPrefix + SteamDatabase.ValvePak.Package.DirectorySeparatorChar;
+            entries = entries.Where(entry => entry.Path.StartsWith(folderPrefix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        entries = (EntryFilterComboBox.SelectedItem as string) switch
+        {
+            "Compiled" => entries.Where(static entry => entry.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase)),
+            "Renderable" => entries.Where(static entry => IsRenderableCompiledType(entry.Entry.TypeName)),
+            "Images" => entries.Where(static entry => IsSupportedImageFileName(entry.Path)),
+            "Audio" => entries.Where(static entry => IsAudioFileName(entry.Path) || entry.Entry.TypeName.Equals("vsnd_c", StringComparison.OrdinalIgnoreCase)),
+            _ => entries,
+        };
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            entries = ApplySearchMode(entries, filter);
+        }
+
+        entries = ApplySortMode(entries);
+
+        foreach (var entry in entries)
+        {
+            visibleEntries.Add(entry);
+        }
+
+        if (currentPackage != null)
+        {
+            StatusText.Text = $"Showing {visibleEntries.Count:N0} of {allEntries.Count:N0} package entries.";
+        }
+    }
+
+    private IEnumerable<PackageEntryItem> ApplySortMode(IEnumerable<PackageEntryItem> entries)
+        => (SortModeComboBox.SelectedItem as string) switch
+        {
+            "Name" => entries.OrderBy(static entry => entry.Entry.GetFileName(), StringComparer.OrdinalIgnoreCase),
+            "Type" => entries.OrderBy(static entry => entry.Entry.TypeName, StringComparer.OrdinalIgnoreCase).ThenBy(static entry => entry.Path, StringComparer.OrdinalIgnoreCase),
+            "Size" => entries.OrderByDescending(static entry => entry.Entry.TotalLength).ThenBy(static entry => entry.Path, StringComparer.OrdinalIgnoreCase),
+            _ => entries.OrderBy(static entry => entry.Path, StringComparer.OrdinalIgnoreCase),
+        };
+
+    private IEnumerable<PackageEntryItem> ApplySearchMode(IEnumerable<PackageEntryItem> entries, string filter)
+    {
+        var normalized = filter.Replace('\\', SteamDatabase.ValvePak.Package.DirectorySeparatorChar);
+        return (SearchModeComboBox.SelectedItem as string) switch
+        {
+            "Full path" => entries.Where(entry => entry.Path.Contains(normalized, StringComparison.OrdinalIgnoreCase)),
+            "Exact file" => entries.Where(entry => entry.Entry.GetFileName().Equals(filter, StringComparison.OrdinalIgnoreCase)),
+            "Regex" => ApplyRegexSearch(entries, filter),
+            _ when normalized.Contains(SteamDatabase.ValvePak.Package.DirectorySeparatorChar, StringComparison.Ordinal)
+                => entries.Where(entry => entry.Path.Contains(normalized, StringComparison.OrdinalIgnoreCase)),
+            _ => entries.Where(entry => entry.Entry.GetFileName().Contains(filter, StringComparison.OrdinalIgnoreCase)),
+        };
+    }
+
+    private static IEnumerable<PackageEntryItem> ApplyRegexSearch(IEnumerable<PackageEntryItem> entries, string filter)
+    {
+        Regex regex;
+        try
+        {
+            regex = new Regex(filter, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            return [];
+        }
+
+        return entries.Where(entry => regex.IsMatch(entry.Entry.GetFileName()));
+    }
+
+    private async void OnSearchKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter || visibleEntries.Count == 0)
+        {
+            return;
+        }
+
+        var filter = SearchTextBox.Text?.Trim();
+        var entry = string.IsNullOrEmpty(filter)
+            ? visibleEntries[0]
+            : visibleEntries.FirstOrDefault(entry => entry.Path.Equals(filter.Replace('\\', SteamDatabase.ValvePak.Package.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase))
+                ?? visibleEntries[0];
+
+        EntryList.SelectedItem = entry;
+        EntryList.ScrollIntoView(entry);
+        await LoadSelectedEntryAsync();
+        e.Handled = true;
+    }
+
+    private void SelectDefaultMapEntry()
+    {
+        var entry = allEntries.FirstOrDefault(static entry => entry.Path.EndsWith(".vmap_c", StringComparison.OrdinalIgnoreCase))
+            ?? allEntries.FirstOrDefault(static entry => entry.Path.EndsWith("/world.vwrld_c", StringComparison.OrdinalIgnoreCase))
+            ?? allEntries.FirstOrDefault(static entry => entry.Path.EndsWith("\\world.vwrld_c", StringComparison.OrdinalIgnoreCase));
+
+        if (entry == null)
+        {
+            return;
+        }
+
+        EntryList.SelectedItem = entry;
+        StatusText.Text = $"Loaded map entry {entry.Path}.";
+    }
+
+    private bool SelectPackageEntry(string path)
+    {
+        var normalizedPath = path
+            .Trim()
+            .TrimStart('/', '\\')
+            .Replace('\\', SteamDatabase.ValvePak.Package.DirectorySeparatorChar);
+
+        var entry = allEntries.FirstOrDefault(entry => entry.Path.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase));
+        entry ??= currentPackage?.FindEntry(normalizedPath) is { } packageEntry
+            ? new PackageEntryItem(packageEntry)
+            : null;
+
+        if (entry == null)
+        {
+            return false;
+        }
+
+        EntryList.SelectedItem = entry;
+        EntryList.ScrollIntoView(entry);
+        return true;
+    }
+
+    private static bool IsRenderableCompiledType(string typeName)
+        => typeName.Equals("vmap_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vwrld_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vwnod_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vmdl_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vmesh_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vmat_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vphys_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vpcf_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vsmart_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vnmclip_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vnmskel_c", StringComparison.OrdinalIgnoreCase)
+        || typeName.Equals("vvis_c", StringComparison.OrdinalIgnoreCase);
+
+    private void BuildFolderTree()
+    {
+        FolderTree.Items.Clear();
+
+        var root = new TreeViewItem
+        {
+            Header = $"root ({allEntries.Count:N0})",
+            Tag = string.Empty,
+            IsExpanded = true,
+        };
+
+        FolderTree.Items.Add(root);
+
+        var folders = new Dictionary<string, TreeViewItem>(StringComparer.OrdinalIgnoreCase)
+        {
+            [""] = root,
+        };
+
+        foreach (var entry in allEntries)
+        {
+            var parts = entry.Path.Split(SteamDatabase.ValvePak.Package.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries);
+            var prefix = string.Empty;
+
+            for (var i = 0; i < parts.Length - 1; i++)
+            {
+                var parentPrefix = prefix;
+                prefix = prefix.Length == 0
+                    ? parts[i]
+                    : string.Concat(prefix, SteamDatabase.ValvePak.Package.DirectorySeparatorChar, parts[i]);
+
+                if (folders.ContainsKey(prefix))
+                {
+                    continue;
+                }
+
+                var item = new TreeViewItem
+                {
+                    Header = parts[i],
+                    Tag = prefix,
+                };
+
+                folders[parentPrefix].Items.Add(item);
+                folders[prefix] = item;
+            }
+        }
+
+        SetCurrentFolder(string.Empty, record: true, updateSelection: true);
+    }
+
+    private void OnFolderSelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (ignoreFolderSelection || FolderTree.SelectedItem is not TreeViewItem { Tag: string prefix })
+        {
+            return;
+        }
+
+        SetCurrentFolder(prefix, record: true, updateSelection: false);
+    }
+
+    private void SetCurrentFolder(string prefix, bool record, bool updateSelection)
+    {
+        currentFolderPrefix = prefix;
+
+        if (updateSelection && FindFolderItem(prefix) is { } item)
+        {
+            ignoreFolderSelection = true;
+            item.IsSelected = true;
+            item.BringIntoView();
+            ignoreFolderSelection = false;
+        }
+
+        if (record)
+        {
+            RecordNavigation(prefix);
+        }
+
+        ApplyFilter();
+        UpdateNavigationButtons();
+    }
+
+    private void RecordNavigation(string prefix)
+    {
+        if (navigationHistoryIndex >= 0 && navigationHistory[navigationHistoryIndex] == prefix)
+        {
+            return;
+        }
+
+        if (navigationHistoryIndex < navigationHistory.Count - 1)
+        {
+            navigationHistory.RemoveRange(navigationHistoryIndex + 1, navigationHistory.Count - navigationHistoryIndex - 1);
+        }
+
+        navigationHistory.Add(prefix);
+        navigationHistoryIndex = navigationHistory.Count - 1;
+    }
+
+    private void NavigateHistory(int delta)
+    {
+        var index = navigationHistoryIndex + delta;
+        if (index < 0 || index >= navigationHistory.Count)
+        {
+            return;
+        }
+
+        navigationHistoryIndex = index;
+        SetCurrentFolder(navigationHistory[index], record: false, updateSelection: true);
+    }
+
+    private void UpdateNavigationButtons()
+    {
+        BackButton.IsEnabled = navigationHistoryIndex > 0;
+        ForwardButton.IsEnabled = navigationHistoryIndex >= 0 && navigationHistoryIndex < navigationHistory.Count - 1;
+    }
+
+    private TreeViewItem? FindFolderItem(string prefix)
+    {
+        foreach (var item in FolderTree.Items.OfType<TreeViewItem>())
+        {
+            if (FindFolderItem(item, prefix) is { } match)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private static TreeViewItem? FindFolderItem(TreeViewItem item, string prefix)
+    {
+        if (item.Tag is string itemPrefix && itemPrefix == prefix)
+        {
+            return item;
+        }
+
+        foreach (var child in item.Items.OfType<TreeViewItem>())
+        {
+            if (FindFolderItem(child, prefix) is { } match)
+            {
+                return match;
+            }
+        }
+
+        return null;
+    }
+
+    private void OnMapCamerasChanged(IReadOnlyList<string> cameras)
+    {
+        ignoreMapCameraChange = true;
+        MapCameraComboBox.ItemsSource = cameras;
+        MapCameraComboBox.SelectedIndex = -1;
+        MapCameraComboBox.IsVisible = cameras.Count > 0;
+        ignoreMapCameraChange = false;
+    }
+
+    private void OnAnimationsChanged(IReadOnlyList<string> animations)
+    {
+        ignoreAnimationChange = true;
+        ignoreAnimationFrameChange = true;
+        AnimationComboBox.ItemsSource = animations.Count == 0 ? [] : animations.Prepend("None").ToArray();
+        AnimationComboBox.SelectedIndex = animations.Count > 0 ? 0 : -1;
+        AnimationFrameSlider.Value = 0;
+        RootMotionCheckBox.IsChecked = false;
+        AnimationLabel.IsVisible = animations.Count > 0;
+        AnimationComboBox.IsVisible = animations.Count > 0;
+        AnimationAutoplayCheckBox.IsVisible = animations.Count > 0;
+        RootMotionCheckBox.IsVisible = animations.Count > 0;
+        AnimationFrameLabel.IsVisible = animations.Count > 0;
+        AnimationFrameSlider.IsVisible = animations.Count > 0;
+        AnimationSpeedLabel.IsVisible = animations.Count > 0;
+        AnimationSpeedSlider.IsVisible = animations.Count > 0;
+        AnimationSection.IsVisible = animations.Count > 0;
+        ignoreAnimationFrameChange = false;
+        ignoreAnimationChange = false;
+    }
+
+    private void OnMeshGroupsChanged(IReadOnlyList<string> groups, IReadOnlySet<string> activeGroups)
+    {
+        ignoreMeshGroupChange = true;
+        MeshGroupListBox.ItemsSource = groups;
+        MeshGroupListBox.SelectedItems?.Clear();
+
+        foreach (var group in groups.Where(activeGroups.Contains))
+        {
+            MeshGroupListBox.SelectedItems?.Add(group);
+        }
+
+        MeshGroupLabel.IsVisible = groups.Count > 1;
+        MeshGroupListBox.IsVisible = groups.Count > 1;
+        ModelStatsCheckBox.IsVisible = groups.Count > 0;
+        UpdateModelSectionVisibility();
+        ignoreMeshGroupChange = false;
+    }
+
+    private void OnMaterialGroupsChanged(IReadOnlyList<string> groups, string? activeGroup)
+    {
+        ignoreMaterialGroupChange = true;
+        MaterialGroupComboBox.ItemsSource = groups;
+        MaterialGroupComboBox.SelectedItem = activeGroup;
+        MaterialGroupLabel.IsVisible = groups.Count > 1;
+        MaterialGroupComboBox.IsVisible = groups.Count > 1;
+        UpdateModelSectionVisibility();
+        ignoreMaterialGroupChange = false;
+    }
+
+    private void OnLodsChanged(IReadOnlyList<string> lods)
+    {
+        ignoreLodChange = true;
+        LodComboBox.ItemsSource = lods;
+        LodComboBox.SelectedIndex = lods.Count > 0 ? 0 : -1;
+        LodLabel.IsVisible = lods.Count > 0;
+        LodComboBox.IsVisible = lods.Count > 0;
+        UpdateModelSectionVisibility();
+        ignoreLodChange = false;
+    }
+
+    private void OnHitboxSetsChanged(IReadOnlyList<string> hitboxSets)
+    {
+        ignoreHitboxSetChange = true;
+        HitboxSetComboBox.ItemsSource = hitboxSets.Count == 0 ? [] : hitboxSets.Prepend("None").ToArray();
+        HitboxSetComboBox.SelectedIndex = hitboxSets.Count == 0 ? -1 : 0;
+        HitboxSetLabel.IsVisible = hitboxSets.Count > 0;
+        HitboxSetComboBox.IsVisible = hitboxSets.Count > 0;
+        UpdateModelSectionVisibility();
+        ignoreHitboxSetChange = false;
+    }
+
+    private void OnSkeletonChanged(bool hasSkeleton)
+    {
+        SkeletonCheckBox.IsChecked = false;
+        SkeletonCheckBox.IsVisible = hasSkeleton;
+        UpdateModelSectionVisibility();
+    }
+
+    private void UpdateModelSectionVisibility()
+        => ModelSection.IsVisible = MeshGroupListBox.IsVisible
+            || MaterialGroupComboBox.IsVisible
+            || LodComboBox.IsVisible
+            || HitboxSetComboBox.IsVisible
+            || SkeletonCheckBox.IsVisible
+            || ModelStatsCheckBox.IsVisible;
+
+    private void UpdateWorldSectionVisibility()
+        => WorldSection.IsVisible = WorldLayerListBox.IsVisible
+            || PhysicsGroupListBox.IsVisible
+            || EntityListBox.IsVisible;
+
+    private void OnModelStatsChanged(string? stats)
+    {
+        ModelStatsText.Text = stats ?? string.Empty;
+        ModelStatsText.IsVisible = !string.IsNullOrEmpty(stats);
+    }
+
+    private void OnWorldLayersChanged(IReadOnlyList<string> layers, IReadOnlySet<string> enabledLayers)
+    {
+        ignoreLayerChange = true;
+        WorldLayerListBox.ItemsSource = layers;
+        WorldLayerListBox.SelectedItems?.Clear();
+
+        foreach (var layer in layers.Where(enabledLayers.Contains))
+        {
+            WorldLayerListBox.SelectedItems?.Add(layer);
+        }
+
+        WorldLayerLabel.IsVisible = layers.Count > 0;
+        WorldLayerListBox.IsVisible = layers.Count > 0;
+        UpdateWorldSectionVisibility();
+        ignoreLayerChange = false;
+    }
+
+    private void OnPhysicsGroupsChanged(IReadOnlyList<string> groups, IReadOnlySet<string> enabledGroups)
+    {
+        ignorePhysicsGroupChange = true;
+        PhysicsGroupListBox.ItemsSource = groups;
+        PhysicsGroupListBox.SelectedItems?.Clear();
+
+        foreach (var group in groups.Where(enabledGroups.Contains))
+        {
+            PhysicsGroupListBox.SelectedItems?.Add(group);
+        }
+
+        PhysicsGroupLabel.IsVisible = groups.Count > 0;
+        PhysicsGroupListBox.IsVisible = groups.Count > 0;
+        UpdateWorldSectionVisibility();
+        ignorePhysicsGroupChange = false;
+    }
+
+    private void OnEntitiesChanged(IReadOnlyList<string> entities)
+    {
+        EntityListBox.ItemsSource = entities;
+        EntityLabel.IsVisible = entities.Count > 0;
+        EntityListBox.IsVisible = entities.Count > 0;
+        UpdateWorldSectionVisibility();
+    }
+
+    private void ShowSelectedEntityDetails()
+    {
+        var details = RenderControl.GetEntityDetails(EntityListBox.SelectedIndex);
+        if (details != null)
+        {
+            DetailsText.Text = details;
+        }
+    }
+
+    private void OnRenderModesChanged(IReadOnlyList<string> modes)
+    {
+        ignoreRenderModeChange = true;
+        var current = RenderModeComboBox.SelectedItem as string ?? "Default";
+        var names = GetRenderModeNames(modes);
+        RenderModeComboBox.ItemsSource = names;
+        RenderModeComboBox.SelectedItem = names.Contains(current, StringComparer.Ordinal) ? current : "Default";
+        ignoreRenderModeChange = false;
+    }
+
+    private static string[] GetRenderModeNames(IEnumerable<string> supportedModes)
+    {
+        var supported = supportedModes.ToHashSet(StringComparer.Ordinal);
+        return RenderModes.Items
+            .Where(mode => !mode.IsHeader && (mode.Name == "Default" || supported.Contains(mode.Name)))
+            .Select(static mode => mode.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private void OnViewportErrorChanged(string? message)
+    {
+        ViewportMessageText.Text = message == null
+            ? viewportStatus
+            : $"Viewport error: {message}";
+
+        if (message != null)
+        {
+            StatusText.Text = $"Viewport error: {message}";
+        }
+    }
+
+    private void OnViewportStatusChanged(string message)
+    {
+        viewportStatus = $"Native OpenGL renderer viewport - {message}";
+        ViewportMessageText.Text = viewportStatus;
+    }
+
+    private void OnViewportPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        ViewportInputLayer.Focus();
+        var point = e.GetCurrentPoint(ViewportInputLayer);
+        RenderControl.BeginPointerInput(point.Position, IsLeftPressed(point), IsRightPressed(point), IsMiddlePressed(point));
+        e.Pointer.Capture(ViewportInputLayer);
+        e.Handled = true;
+    }
+
+    private void OnViewportPointerReleased(object? sender, PointerReleasedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(ViewportInputLayer);
+        RenderControl.EndPointerInput(point.Properties.IsLeftButtonPressed, point.Properties.IsRightButtonPressed, point.Properties.IsMiddleButtonPressed);
+        e.Pointer.Capture(null);
+        e.Handled = true;
+    }
+
+    private void OnViewportPointerMoved(object? sender, PointerEventArgs e)
+    {
+        RenderControl.MovePointerInput(e.GetPosition(ViewportInputLayer));
+        e.Handled = true;
+    }
+
+    private void OnViewportPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        RenderControl.WheelInput((float)e.Delta.Y);
+        e.Handled = true;
+    }
+
+    private async void OnWindowKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (await HandleAppShortcutAsync(e))
+        {
+            e.Handled = true;
+        }
+    }
+
+    private async void OnViewportKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (await HandleAppShortcutAsync(e))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        RenderControl.KeyInput(e.Key, pressed: true);
+        e.Handled = true;
+    }
+
+    private void OnViewportKeyUp(object? sender, KeyEventArgs e)
+    {
+        RenderControl.KeyInput(e.Key, pressed: false);
+        e.Handled = true;
+    }
+
+    private async Task<bool> HandleAppShortcutAsync(KeyEventArgs e)
+    {
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Alt))
+        {
+            if (e.Key == Key.Left)
+            {
+                NavigateHistory(-1);
+                return true;
+            }
+
+            if (e.Key == Key.Right)
+            {
+                NavigateHistory(1);
+                return true;
+            }
+        }
+
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            if (e.Key == Key.C && e.Source is not TextBox)
+            {
+                if (e.Source == ViewportInputLayer || e.Source == RenderControl)
+                {
+                    await CopyViewportScreenshotAsync();
+                }
+                else
+                {
+                    await CopySelectedEntryPathAsync();
+                }
+
+                return true;
+            }
+
+            if (e.Key == Key.O)
+            {
+                await OpenPackageAsync();
+                return true;
+            }
+
+            if (e.Key == Key.F)
+            {
+                FocusSearch();
+                return true;
+            }
+        }
+
+        return HandleWindowShortcut(e.Key);
+    }
+
+    private async Task CopyViewportScreenshotAsync()
+    {
+        var topLevel = GetTopLevel(this);
+        if (topLevel?.Clipboard == null)
+        {
+            return;
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"vrf-screenshot-{Guid.NewGuid():N}.png");
+        clipboardScreenshotPath = path;
+        RenderControl.SaveScreenshot(path);
+        StatusText.Text = "Copying viewport screenshot...";
+        await Task.CompletedTask;
+    }
+
+    private async void OnScreenshotSaved(string path)
+    {
+        if (!string.Equals(path, clipboardScreenshotPath, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        clipboardScreenshotPath = null;
+        try
+        {
+            var topLevel = GetTopLevel(this);
+            if (topLevel?.Clipboard == null)
+            {
+                return;
+            }
+
+            using var bitmap = new Bitmap(path);
+            await topLevel.Clipboard.SetBitmapAsync(bitmap);
+            StatusText.Text = "Copied viewport screenshot.";
+        }
+        catch (Exception exception)
+        {
+            StatusText.Text = $"Failed to copy screenshot: {exception.Message}";
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private async Task CopySelectedEntryPathAsync()
+    {
+        if (EntryList.SelectedItem is not PackageEntryItem item)
+        {
+            return;
+        }
+
+        var topLevel = GetTopLevel(this);
+        if (topLevel?.Clipboard == null)
+        {
+            return;
+        }
+
+        await topLevel.Clipboard.SetTextAsync(item.Path);
+        StatusText.Text = $"Copied {item.Path}.";
+    }
+
+    private bool HandleWindowShortcut(Key key)
+    {
+        if (key == Key.F11)
+        {
+            if (WindowState == WindowState.FullScreen)
+            {
+                WindowState = previousWindowState;
+            }
+            else
+            {
+                previousWindowState = WindowState == WindowState.Minimized ? WindowState.Normal : WindowState;
+                WindowState = WindowState.FullScreen;
+            }
+
+            ViewportInputLayer.Focus();
+            return true;
+        }
+
+        if (key == Key.Escape && WindowState == WindowState.FullScreen)
+        {
+            WindowState = previousWindowState;
+            ViewportInputLayer.Focus();
+            return true;
+        }
+
+        return false;
+    }
+
+    private static bool IsLeftPressed(PointerPoint point)
+        => point.Properties.IsLeftButtonPressed || point.Properties.PointerUpdateKind == PointerUpdateKind.LeftButtonPressed;
+
+    private static bool IsRightPressed(PointerPoint point)
+        => point.Properties.IsRightButtonPressed || point.Properties.PointerUpdateKind == PointerUpdateKind.RightButtonPressed;
+
+    private static bool IsMiddlePressed(PointerPoint point)
+        => point.Properties.IsMiddleButtonPressed || point.Properties.PointerUpdateKind == PointerUpdateKind.MiddleButtonPressed;
+
+    private async void OnEntrySelected(object? sender, SelectionChangedEventArgs e)
+    {
+        if (ignoreEntrySelectionChange)
+        {
+            return;
+        }
+
+        await LoadSelectedEntryAsync();
+    }
+
+    private async Task LoadSelectedEntryAsync()
+    {
+        if (EntryList.SelectedItem is not PackageEntryItem item || currentPackage == null)
+        {
+            return;
+        }
+
+        StopSound();
+        SetSoundButtonsVisible(item.Entry.TypeName.Equals("vsnd_c", StringComparison.OrdinalIgnoreCase));
+
+        var package = currentPackage;
+        var packagePath = currentPath;
+        var version = ++selectionVersion;
+        DetailsText.Text = "Reading entry...";
+        SetPreviewImage(null);
+
+        var canRender = packagePath != null
+            && item.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase)
+            && IsRenderableCompiledType(item.Entry.TypeName);
+        if (canRender)
+        {
+            RenderControl.LoadPackageEntry(package, packagePath!, item.Entry);
+            SetViewportTabHeader(item.Path);
+            MainTabs.SelectedItem = ViewportTab;
+        }
+
+        var (details, previewImage) = await Task.Run(() =>
+        {
+            var details = DescribePackageEntry(package, item.Entry);
+            var previewImage = TryExtractPackagePreviewImageBytes(package, packagePath, item.Entry);
+
+            if (!canRender && item.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                details += TryDescribeDecompiledPreview(package, packagePath, item.Entry);
+            }
+
+            return (details, previewImage);
+        });
+
+        if (version != selectionVersion || currentPackage != package || EntryList.SelectedItem is not PackageEntryItem selectedItem || selectedItem != item)
+        {
+            return;
+        }
+
+        DetailsText.Text = details;
+        SetPreviewImage(CreatePreviewBitmap(previewImage));
+
+        if (packagePath != null && item.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            if (!canRender)
+            {
+                StatusText.Text = $"No 3D viewport for {item.Entry.TypeName}; use preview/decompile/export.";
+            }
+        }
+    }
+
+    private async void OnSaveScreenshot(object? sender, RoutedEventArgs e)
+    {
+        var topLevel = GetTopLevel(this);
+        if (topLevel == null)
+        {
+            return;
+        }
+
+        var target = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Save viewport screenshot",
+            SuggestedFileName = "source2-viewer.png",
+            ShowOverwritePrompt = true,
+            FileTypeChoices = [new FilePickerFileType("PNG image") { Patterns = ["*.png"] }],
+        });
+
+        var path = target?.TryGetLocalPath();
+        if (path == null)
+        {
+            return;
+        }
+
+        RenderControl.SaveScreenshot(path);
+        StatusText.Text = $"Saving screenshot to {path}.";
+    }
+
+    private async void OnPlaySound(object? sender, RoutedEventArgs e)
+    {
+        if (currentPackage == null || EntryList.SelectedItem is not PackageEntryItem item)
+        {
+            return;
+        }
+
+        try
+        {
+            StopSound();
+            var (path, type) = await Task.Run(() => WriteSelectedSoundTempFile(currentPackage, item.Entry));
+            soundTempPath = path;
+            soundProcess = Process.Start(new ProcessStartInfo
+            {
+                FileName = "ffplay",
+                ArgumentList = { "-nodisp", "-autoexit", "-loglevel", "error", path },
+                UseShellExecute = false,
+            });
+            StatusText.Text = $"Playing {type} sound.";
+        }
+        catch (Exception exception)
+        {
+            StatusText.Text = $"Failed to play sound: {exception.Message}";
+        }
+    }
+
+    private void StopSound()
+    {
+        if (soundProcess is { HasExited: false })
+        {
+            soundProcess.Kill(entireProcessTree: true);
+        }
+
+        soundProcess?.Dispose();
+        soundProcess = null;
+
+        if (soundTempPath != null)
+        {
+            File.Delete(soundTempPath);
+            soundTempPath = null;
+        }
+    }
+
+    private void SetSoundButtonsVisible(bool visible)
+    {
+        PlaySoundButton.IsVisible = visible;
+        StopSoundButton.IsVisible = visible;
+    }
+
+    private static (string Path, string Type) WriteSelectedSoundTempFile(Package package, PackageEntry entry)
+    {
+        using var resource = new Resource { FileName = entry.GetFullPath() };
+        using var stream = GameFileLoader.GetPackageEntryStream(package, entry);
+        resource.Read(stream, verifyFileSize: false);
+
+        if (resource.DataBlock is not ValveResourceFormat.ResourceTypes.Sound sound || sound.StreamingDataSize == 0)
+        {
+            throw new InvalidOperationException("Selected resource has no playable sound data.");
+        }
+
+        var extension = sound.SoundType switch
+        {
+            ValveResourceFormat.ResourceTypes.Sound.AudioFileType.WAV => ".wav",
+            ValveResourceFormat.ResourceTypes.Sound.AudioFileType.MP3 => ".mp3",
+            ValveResourceFormat.ResourceTypes.Sound.AudioFileType.AAC => ".aac",
+            _ => ".bin",
+        };
+        var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"vrf-sound-{Guid.NewGuid():N}{extension}");
+        using var soundStream = sound.GetSoundStream();
+        using var output = File.Create(path);
+        soundStream.CopyTo(output);
+        return (path, sound.SoundType.ToString());
+    }
+
+    private async void OnExportSelected(object? sender, RoutedEventArgs e)
+    {
+        if (EntryList.SelectedItem is not PackageEntryItem item || currentPackage == null)
+        {
+            StatusText.Text = "Select a package entry to export.";
+            return;
+        }
+
+        var topLevel = GetTopLevel(this);
+        if (topLevel == null)
+        {
+            return;
+        }
+
+        var suggestedName = item.Path.Split(SteamDatabase.ValvePak.Package.DirectorySeparatorChar).LastOrDefault();
+        if (string.IsNullOrWhiteSpace(suggestedName))
+        {
+            suggestedName = "export.bin";
+        }
+
+        var target = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+        {
+            Title = "Export selected package entry",
+            SuggestedFileName = suggestedName,
+            ShowOverwritePrompt = true,
+        });
+
+        if (target == null)
+        {
+            return;
+        }
+
+        await using var output = await target.OpenWriteAsync();
+        using var input = GameFileLoader.GetPackageEntryStream(currentPackage, item.Entry);
+        await input.CopyToAsync(output);
+        StatusText.Text = $"Exported {item.Path}.";
+    }
+
+    private async void OnCopyEntryPath(object? sender, RoutedEventArgs e)
+        => await CopySelectedEntryPathAsync();
+
+    private async void OnExportVisible(object? sender, RoutedEventArgs e)
+        => await ExportVisibleAsync(decompile: false);
+
+    private async void OnExportVisibleDecompiled(object? sender, RoutedEventArgs e)
+        => await ExportVisibleAsync(decompile: true);
+
+    private async Task ExportVisibleAsync(bool decompile)
+    {
+        if (currentPackage == null || visibleEntries.Count == 0)
+        {
+            StatusText.Text = "No package entries are shown to export.";
+            return;
+        }
+
+        var topLevel = GetTopLevel(this);
+        if (topLevel == null)
+        {
+            return;
+        }
+
+        var folders = await topLevel.StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "Choose export folder",
+            AllowMultiple = false,
+        });
+
+        var root = folders.Count == 0 ? null : folders[0].TryGetLocalPath();
+        if (root == null)
+        {
+            return;
+        }
+
+        var package = currentPackage;
+        var packagePath = currentPath;
+        var entries = visibleEntries.ToArray();
+        StatusText.Text = $"Exporting {entries.Length:N0} entries...";
+
+        try
+        {
+            var exported = await Task.Run(() => ExportVisibleEntries(root, package, packagePath, entries, decompile));
+
+            StatusText.Text = $"Exported {exported:N0} entries.";
+        }
+        catch (Exception exception)
+        {
+            StatusText.Text = $"Export failed: {exception.Message}";
+        }
+    }
+
+    private async void OnPreviewDecompiled(object? sender, RoutedEventArgs e)
+    {
+        try
+        {
+            DetailsText.Text = "Decompiling selected resource...";
+            SetPreviewImage(null);
+            var (details, previewImage) = await Task.Run(() =>
+            {
+                using var loaded = LoadSelectedResource();
+                using var content = FileExtract.Extract(loaded.Resource, loaded.FileLoader);
+                return (DescribeContentFile(content), TryGetPreviewImageBytes(content));
+            });
+            DetailsText.Text = details;
+            SetPreviewImage(CreatePreviewBitmap(previewImage));
+        }
+        catch (Exception exception)
+        {
+            DetailsText.Text = $"Failed to decompile: {exception.Message}";
+        }
+    }
+
+    private async void OnExportDecompiled(object? sender, RoutedEventArgs e)
+    {
+        ContentFile? content = null;
+        try
+        {
+            using var loaded = LoadSelectedResource();
+            content = await Task.Run(() => FileExtract.Extract(loaded.Resource, loaded.FileLoader));
+        }
+        catch (Exception exception)
+        {
+            StatusText.Text = $"Failed to decompile: {exception.Message}";
+            return;
+        }
+
+        using (content)
+        {
+            if (content.Data == null)
+            {
+                StatusText.Text = "Decompiled resource has no primary file to export.";
+                return;
+            }
+
+            var topLevel = GetTopLevel(this);
+            if (topLevel == null)
+            {
+                return;
+            }
+
+            var suggestedName = Path.GetFileName(content.FileName);
+            if (string.IsNullOrWhiteSpace(suggestedName))
+            {
+                suggestedName = "decompiled.dat";
+            }
+
+            var target = await topLevel.StorageProvider.SaveFilePickerAsync(new FilePickerSaveOptions
+            {
+                Title = "Export decompiled resource",
+                SuggestedFileName = suggestedName,
+                ShowOverwritePrompt = true,
+            });
+
+            if (target == null)
+            {
+                return;
+            }
+
+            await using var output = await target.OpenWriteAsync();
+            await output.WriteAsync(content.Data);
+            StatusText.Text = $"Exported decompiled {suggestedName}.";
+        }
+    }
+
+    private static string DescribeLooseFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return $"File not found: {path}";
+        }
+
+        if (!path.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return $"Path: {path}{Environment.NewLine}Size: {new FileInfo(path).Length:N0} bytes";
+        }
+
+        using var resource = new Resource();
+        resource.Read(path);
+        return DescribeResource(path, resource);
+    }
+
+    private static string TryDescribeRawTextPreview(Package package, PackageEntry entry)
+    {
+        const int MaxRawPreviewBytes = 256 * 1024;
+        if (entry.TotalLength <= 0 || entry.TotalLength > MaxRawPreviewBytes)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            using var stream = GameFileLoader.GetPackageEntryStream(package, entry);
+            using var memory = new MemoryStream();
+            stream.CopyTo(memory);
+            var data = memory.ToArray();
+            if (!LooksText(data))
+            {
+                return string.Empty;
+            }
+
+            var text = Encoding.UTF8.GetString(data);
+            return string.Concat(Environment.NewLine, "Raw text preview:", Environment.NewLine, text);
+        }
+        catch (Exception exception)
+        {
+            return string.Concat(Environment.NewLine, "Raw text preview failed: ", exception.Message, Environment.NewLine);
+        }
+    }
+
+    private static string TryDescribeDecompiledPreview(Package package, string? packagePath, PackageEntry entry)
+    {
+        try
+        {
+            using var fileLoader = new GameFileLoader(package, packagePath);
+            using var stream = GameFileLoader.GetPackageEntryStream(package, entry);
+            using var resource = new Resource { FileName = entry.GetFullPath() };
+            resource.Read(stream, verifyFileSize: false);
+            using var content = FileExtract.Extract(resource, fileLoader);
+
+            if (content.Data == null || !LooksText(content.Data))
+            {
+                return string.Empty;
+            }
+
+            return string.Concat(Environment.NewLine, "Decompiled preview:", Environment.NewLine, DescribeContentFile(content));
+        }
+        catch (Exception exception)
+        {
+            return string.Concat(Environment.NewLine, "Decompiled preview failed: ", exception.Message, Environment.NewLine);
+        }
+    }
+
+    private static string DescribePackageEntry(Package package, PackageEntry entry)
+    {
+        var output = new StringBuilder();
+        output.AppendLine(entry.GetFullPath());
+        output.AppendLine($"Type: {entry.TypeName}");
+        output.AppendLine($"Size: {entry.TotalLength:N0} bytes");
+
+        if (!entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            output.Append(TryDescribeRawTextPreview(package, entry));
+            return output.ToString();
+        }
+
+        try
+        {
+            using var stream = GameFileLoader.GetPackageEntryStream(package, entry);
+            using var resource = new Resource { FileName = entry.GetFullPath() };
+            resource.Read(stream, verifyFileSize: false);
+
+            output.AppendLine();
+            output.Append(DescribeResource(entry.GetFullPath(), resource));
+        }
+        catch (Exception exception)
+        {
+            output.AppendLine();
+            output.AppendLine($"Failed to parse resource: {exception.Message}");
+        }
+
+        return output.ToString();
+    }
+
+    private static string DescribeResource(string path, Resource resource)
+    {
+        var output = new StringBuilder();
+        output.AppendLine($"Path: {path}");
+        output.AppendLine($"Resource type: {resource.ResourceType}");
+        output.AppendLine($"Version: {resource.Version}");
+        output.AppendLine($"Blocks: {string.Join(", ", resource.Blocks.Select(static block => block.Type))}");
+
+        if (resource.ExternalReferences?.ResourceRefInfoList.Count > 0)
+        {
+            output.AppendLine();
+            output.AppendLine("External references:");
+
+            foreach (var reference in resource.ExternalReferences.ResourceRefInfoList.Take(25))
+            {
+                output.AppendLine($"- {reference.Name}");
+            }
+
+            var remaining = resource.ExternalReferences.ResourceRefInfoList.Count - 25;
+            if (remaining > 0)
+            {
+                output.AppendLine($"... {remaining:N0} more");
+            }
+        }
+
+        return output.ToString();
+    }
+
+#pragma warning disable CA2000 // LoadedResource owns and disposes these objects.
+    private LoadedResource LoadSelectedResource()
+    {
+        if (currentPackage != null && EntryList.SelectedItem is PackageEntryItem item)
+        {
+            if (!item.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException("Selected package entry is not a compiled resource.");
+            }
+
+            var fileLoader = new GameFileLoader(currentPackage, currentPath);
+            var resource = new Resource { FileName = item.Path };
+            using var stream = GameFileLoader.GetPackageEntryStream(currentPackage, item.Entry);
+            resource.Read(stream, verifyFileSize: false);
+            return new LoadedResource(resource, fileLoader);
+        }
+
+        if (currentPackage == null && currentPath != null && currentPath.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            var fileLoader = new GameFileLoader(null, currentPath);
+            var resource = new Resource();
+            resource.Read(currentPath);
+            return new LoadedResource(resource, fileLoader);
+        }
+
+        throw new InvalidOperationException("Select a compiled resource first.");
+    }
+#pragma warning restore CA2000
+
+    private static byte[]? TryExtractLooseFilePreviewImageBytes(string path)
+    {
+        try
+        {
+            if (IsSupportedImageFileName(path))
+            {
+                return File.ReadAllBytes(path);
+            }
+
+            if (!path.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            using var fileLoader = new GameFileLoader(null, path);
+            using var resource = new Resource();
+            resource.Read(path);
+            using var content = FileExtract.Extract(resource, fileLoader);
+            return TryGetPreviewImageBytes(content);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static byte[]? TryExtractPackagePreviewImageBytes(Package package, string? packagePath, PackageEntry entry)
+    {
+        try
+        {
+            if (IsSupportedImageFileName(entry.GetFullPath()))
+            {
+                using var rawStream = GameFileLoader.GetPackageEntryStream(package, entry);
+                using var rawMemory = new MemoryStream();
+                rawStream.CopyTo(rawMemory);
+                return rawMemory.ToArray();
+            }
+
+            if (!entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            using var fileLoader = new GameFileLoader(package, packagePath);
+            using var stream = GameFileLoader.GetPackageEntryStream(package, entry);
+            using var resource = new Resource { FileName = entry.GetFullPath() };
+            resource.Read(stream, verifyFileSize: false);
+            using var content = FileExtract.Extract(resource, fileLoader);
+            return TryGetPreviewImageBytes(content);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private static byte[]? TryGetPreviewImageBytes(ContentFile content)
+    {
+        if (content.Data != null
+            && (IsSupportedImageFileName(content.FileName) || LooksSupportedImageBytes(content.Data)))
+        {
+            return content.Data;
+        }
+
+        foreach (var subFile in content.SubFiles)
+        {
+            if (subFile.Extract == null || !IsSupportedImageFileName(subFile.FileName))
+            {
+                continue;
+            }
+
+            try
+            {
+                var data = subFile.Extract();
+                if (LooksSupportedImageBytes(data))
+                {
+                    return data;
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        foreach (var additionalFile in content.AdditionalFiles)
+        {
+            var data = TryGetPreviewImageBytes(additionalFile);
+            if (data != null)
+            {
+                return data;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsSupportedImageFileName(string fileName)
+    {
+        var extension = Path.GetExtension(fileName);
+        return extension.Equals(".png", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".jpeg", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".bmp", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".gif", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".webp", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsAudioFileName(string fileName)
+    {
+        var extension = Path.GetExtension(fileName);
+        return extension.Equals(".wav", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".mp3", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".aac", StringComparison.OrdinalIgnoreCase)
+            || extension.Equals(".vsnd_c", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool LooksSupportedImageBytes(byte[] data)
+    {
+        if (data.Length >= 8
+            && data[0] == 0x89
+            && data[1] == (byte)'P'
+            && data[2] == (byte)'N'
+            && data[3] == (byte)'G')
+        {
+            return true;
+        }
+
+        if (data.Length >= 3
+            && data[0] == 0xFF
+            && data[1] == 0xD8
+            && data[2] == 0xFF)
+        {
+            return true;
+        }
+
+        if (data.Length >= 6
+            && data[0] == (byte)'G'
+            && data[1] == (byte)'I'
+            && data[2] == (byte)'F')
+        {
+            return true;
+        }
+
+        if (data.Length >= 2
+            && data[0] == (byte)'B'
+            && data[1] == (byte)'M')
+        {
+            return true;
+        }
+
+        return data.Length >= 12
+            && data[0] == (byte)'R'
+            && data[1] == (byte)'I'
+            && data[2] == (byte)'F'
+            && data[3] == (byte)'F'
+            && data[8] == (byte)'W'
+            && data[9] == (byte)'E'
+            && data[10] == (byte)'B'
+            && data[11] == (byte)'P';
+    }
+
+    private static int ExportVisibleEntries(string root, Package package, string? packagePath, PackageEntryItem[] entries, bool decompile)
+    {
+        var count = 0;
+        using var fileLoader = new GameFileLoader(package, packagePath);
+
+        foreach (var item in entries)
+        {
+            if (!decompile || !item.Entry.TypeName.EndsWith(GameFileLoader.CompiledFileSuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                CopyPackageEntry(root, package, item);
+                count++;
+                continue;
+            }
+
+            using var input = GameFileLoader.GetPackageEntryStream(package, item.Entry);
+            using var resource = new Resource { FileName = item.Path };
+            resource.Read(input, verifyFileSize: false);
+            using var content = FileExtract.Extract(resource, fileLoader);
+
+            count += WriteContentFile(root, item.Path, resource, content);
+        }
+
+        return count;
+    }
+
+    private static void CopyPackageEntry(string root, Package package, PackageEntryItem item)
+    {
+        var outputPath = GetSafeExportPath(root, item.Path);
+        Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+
+        using var input = GameFileLoader.GetPackageEntryStream(package, item.Entry);
+        using var output = File.Create(outputPath);
+        input.CopyTo(output);
+    }
+
+    private static int WriteContentFile(string root, string inputPath, Resource resource, ContentFile content)
+    {
+        var count = 0;
+
+        if (content.Data != null)
+        {
+            var outputPath = GetSafeExportPath(root, GetDecompiledPrimaryPath(inputPath, resource, content));
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllBytes(outputPath, content.Data);
+            count++;
+        }
+
+        foreach (var additionalFile in content.AdditionalFiles)
+        {
+            if (additionalFile.Data != null && !string.IsNullOrWhiteSpace(additionalFile.FileName))
+            {
+                var outputPath = GetSafeExportPath(root, additionalFile.FileName);
+                Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+                File.WriteAllBytes(outputPath, additionalFile.Data);
+                count++;
+            }
+
+            var folder = Path.GetDirectoryName(additionalFile.FileName) ?? string.Empty;
+            count += WriteSubFiles(root, folder, additionalFile);
+        }
+
+        var inputFolder = Path.GetDirectoryName(inputPath) ?? string.Empty;
+        return count + WriteSubFiles(root, inputFolder, content);
+    }
+
+    private static int WriteSubFiles(string root, string folder, ContentFile content)
+    {
+        var count = 0;
+
+        foreach (var subFile in content.SubFiles)
+        {
+            if (subFile.Extract == null)
+            {
+                continue;
+            }
+
+            var data = subFile.Extract();
+            if (data.Length == 0)
+            {
+                continue;
+            }
+
+            var relativePath = string.IsNullOrEmpty(folder)
+                ? subFile.FileName
+                : string.Concat(folder, SteamDatabase.ValvePak.Package.DirectorySeparatorChar, subFile.FileName);
+            var outputPath = GetSafeExportPath(root, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(outputPath)!);
+            File.WriteAllBytes(outputPath, data);
+            count++;
+        }
+
+        return count;
+    }
+
+    private static string GetDecompiledPrimaryPath(string inputPath, Resource resource, ContentFile content)
+    {
+        var extension = FileExtract.GetExtension(resource);
+        if (extension != null)
+        {
+            return Path.ChangeExtension(inputPath, extension);
+        }
+
+        return string.IsNullOrWhiteSpace(content.FileName)
+            ? inputPath
+            : content.FileName;
+    }
+
+    private static string GetSafeExportPath(string root, string packagePath)
+    {
+        var rootPath = Path.GetFullPath(root);
+        var relativePath = packagePath.Replace(SteamDatabase.ValvePak.Package.DirectorySeparatorChar, Path.DirectorySeparatorChar);
+        var outputPath = Path.GetFullPath(Path.Combine(rootPath, relativePath));
+        var rootPrefix = rootPath.EndsWith(Path.DirectorySeparatorChar)
+            ? rootPath
+            : rootPath + Path.DirectorySeparatorChar;
+
+        if (!outputPath.StartsWith(rootPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException($"Package entry path escapes export folder: {packagePath}");
+        }
+
+        return outputPath;
+    }
+
+    internal static void RunExportPathSelfCheck()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "vrf-export-check");
+        var valid = GetSafeExportPath(root, $"materials{SteamDatabase.ValvePak.Package.DirectorySeparatorChar}test.vtex_c");
+        var expected = Path.Combine(Path.GetFullPath(root), "materials", "test.vtex_c");
+        if (!string.Equals(valid, expected, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("Safe export path check failed for valid package path.");
+        }
+
+        try
+        {
+            GetSafeExportPath(root, $"..{SteamDatabase.ValvePak.Package.DirectorySeparatorChar}escape.txt");
+            throw new InvalidOperationException("Safe export path check failed to reject traversal.");
+        }
+        catch (InvalidDataException)
+        {
+        }
+    }
+
+    private static Bitmap? CreatePreviewBitmap(byte[]? data)
+    {
+        if (data == null)
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = new MemoryStream(data);
+            return new Bitmap(stream);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    private void SetPreviewImage(Bitmap? bitmap)
+    {
+        if (PreviewImage.Source is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        PreviewImage.Source = bitmap;
+        PreviewImageBorder.IsVisible = bitmap != null;
+    }
+
+    private static string DescribeContentFile(ContentFile content)
+    {
+        var output = new StringBuilder();
+        output.AppendLine($"Suggested file: {content.FileName}");
+        output.AppendLine($"Primary data: {(content.Data == null ? "none" : $"{content.Data.Length:N0} bytes")}");
+        output.AppendLine($"Additional files: {content.AdditionalFiles.Count:N0}");
+        output.AppendLine($"Subfiles: {content.SubFiles.Count:N0}");
+
+        if (content.Data == null)
+        {
+            return output.ToString();
+        }
+
+        output.AppendLine();
+        if (!LooksText(content.Data))
+        {
+            output.AppendLine("Primary decompiled output is binary; use Export decompiled.");
+            return output.ToString();
+        }
+
+        var text = Encoding.UTF8.GetString(content.Data);
+        const int MaxPreviewChars = 60_000;
+        if (text.Length > MaxPreviewChars)
+        {
+            text = string.Concat(text.AsSpan(0, MaxPreviewChars), Environment.NewLine, "... preview truncated ...");
+        }
+
+        output.Append(text);
+        return output.ToString();
+    }
+
+    private static bool LooksText(byte[] data)
+    {
+        var length = Math.Min(data.Length, 4096);
+        for (var i = 0; i < length; i++)
+        {
+            if (data[i] == 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private sealed class LoadedResource(Resource resource, GameFileLoader fileLoader) : IDisposable
+    {
+        public Resource Resource { get; } = resource;
+        public GameFileLoader FileLoader { get; } = fileLoader;
+
+        public void Dispose()
+        {
+            Resource.Dispose();
+            FileLoader.Dispose();
+        }
+    }
+
+    private sealed class PackageEntryItem(PackageEntry entry)
+    {
+        public PackageEntry Entry { get; } = entry;
+        public string Path { get; } = entry.GetFullPath();
+        public string TypeName => Entry.TypeName;
+        public string SizeText => Entry.TotalLength.ToString("N0");
+        public override string ToString() => $"{Path,-72} {TypeName,-12} {SizeText,10}";
+    }
+}

--- a/Source2Viewer.App/NativeRenderControl.cs
+++ b/Source2Viewer.App/NativeRenderControl.cs
@@ -1,0 +1,2065 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using Avalonia;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.OpenGL;
+using Avalonia.OpenGL.Controls;
+using Avalonia.Threading;
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenTK;
+using OpenTK.Graphics.OpenGL;
+using SkiaSharp;
+using SteamDatabase.ValvePak;
+using ValveResourceFormat;
+using ValveResourceFormat.Blocks;
+using ValveResourceFormat.IO;
+using ValveResourceFormat.Renderer;
+using ValveResourceFormat.Renderer.Materials;
+using ValveResourceFormat.Renderer.SceneEnvironment;
+using ValveResourceFormat.Renderer.SceneNodes;
+using ValveResourceFormat.Renderer.World;
+using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.ResourceTypes.ModelAnimation;
+using ValveResourceFormat.ResourceTypes.ModelAnimation2;
+using ValveResourceFormat.Serialization.KeyValues;
+using ValveResourceFormat.Utils;
+using VrfRenderer = ValveResourceFormat.Renderer.Renderer;
+using WorldResource = ValveResourceFormat.ResourceTypes.World;
+
+namespace Source2Viewer.App;
+
+public sealed class NativeRenderControl : OpenGlControlBase
+{
+    private static bool BindingsLoaded;
+    private readonly Lock renderLock = new();
+    private readonly HashSet<Key> pressedKeys = [];
+    private RenderRequest? pendingRequest;
+    private NativeRenderSession? session;
+    private bool clearRequested;
+    private bool resetCameraRequested;
+    private bool wireframe;
+    private bool orbitDrag;
+    private bool panDrag;
+    private bool lookDrag;
+    private Point? previousPointer;
+    private Vector2 pendingMouseDelta;
+    private float pendingWheelDelta;
+    private string renderMode = "Default";
+    private bool gridVisible = true;
+    private bool skyboxVisible = true;
+    private bool fogVisible = true;
+    private bool colorCorrectionEnabled = true;
+    private bool occlusionCullingEnabled = true;
+    private bool gpuCullingEnabled = true;
+    private bool depthPrepassEnabled;
+    private bool experimentalLightsEnabled;
+    private bool toolMaterialsVisible;
+    private bool occludedBoundsVisible;
+    private bool staticOctreeVisible;
+    private bool dynamicOctreeVisible;
+    private bool animationPaused;
+    private float animationSpeed = 1f;
+    private bool rootMotionEnabled;
+    private bool modelStatsVisible;
+    private string? lastError;
+    private string? pendingScreenshotPath;
+
+    public event Action<IReadOnlyList<string>>? MapCamerasChanged;
+    public event Action<IReadOnlyList<string>>? AnimationsChanged;
+    public event Action<IReadOnlyList<string>, IReadOnlySet<string>>? MeshGroupsChanged;
+    public event Action<IReadOnlyList<string>, string?>? MaterialGroupsChanged;
+    public event Action<IReadOnlyList<string>>? LodsChanged;
+    public event Action<IReadOnlyList<string>>? HitboxSetsChanged;
+    public event Action<bool>? SkeletonChanged;
+    public event Action<IReadOnlyList<string>, IReadOnlySet<string>>? WorldLayersChanged;
+    public event Action<IReadOnlyList<string>, IReadOnlySet<string>>? PhysicsGroupsChanged;
+    public event Action<IReadOnlyList<string>>? EntitiesChanged;
+    public event Action<IReadOnlyList<string>>? RenderModesChanged;
+    public event Action<string?>? ModelStatsChanged;
+    public event Action<string?>? ViewportErrorChanged;
+    public event Action<string>? ViewportStatusChanged;
+    public event Action<string>? ScreenshotSaved;
+
+    public NativeRenderControl()
+    {
+        Focusable = true;
+        LostFocus += OnControlLostFocus;
+    }
+
+    public void LoadLooseFile(string path)
+    {
+        SetPending(RenderRequest.ForLooseFile(path));
+    }
+
+    public void LoadPackageEntry(Package package, string packagePath, PackageEntry entry)
+    {
+        SetPending(RenderRequest.ForPackageEntry(package, packagePath, entry));
+    }
+
+    public void SaveScreenshot(string path)
+    {
+        using var _ = renderLock.EnterScope();
+        pendingScreenshotPath = path;
+        RequestNextFrameRendering();
+    }
+
+    public void ClearResource()
+    {
+        using var _ = renderLock.EnterScope();
+        pendingRequest = null;
+        clearRequested = true;
+        lastError = null;
+        NotifyMapCamerasChanged([]);
+        NotifyAnimationsChanged([]);
+        NotifyMeshGroupsChanged([], new HashSet<string>());
+        NotifyMaterialGroupsChanged([], null);
+        NotifyLodsChanged([]);
+        NotifyHitboxSetsChanged([]);
+        NotifySkeletonChanged(false);
+        NotifyWorldLayersChanged([], new HashSet<string>());
+        NotifyPhysicsGroupsChanged([], new HashSet<string>());
+        NotifyEntitiesChanged([]);
+        NotifyRenderModesChanged([]);
+        NotifyModelStatsChanged(null);
+        NotifyViewportErrorChanged(null);
+        RequestNextFrameRendering();
+    }
+
+    public void ResetCamera()
+    {
+        using var _ = renderLock.EnterScope();
+        resetCameraRequested = true;
+        RequestNextFrameRendering();
+    }
+
+    public void SetWireframe(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        wireframe = enabled;
+        session?.SetWireframe(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetRenderMode(string mode)
+    {
+        using var _ = renderLock.EnterScope();
+        renderMode = mode;
+        session?.SetRenderMode(mode);
+        RequestNextFrameRendering();
+    }
+
+    public void SetGridVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        gridVisible = visible;
+        session?.SetGridVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetSkyboxVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        skyboxVisible = visible;
+        session?.SetSkyboxVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetFogVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        fogVisible = visible;
+        session?.SetFogVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetColorCorrectionEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        colorCorrectionEnabled = enabled;
+        session?.SetColorCorrectionEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetOcclusionCullingEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        occlusionCullingEnabled = enabled;
+        session?.SetOcclusionCullingEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetGpuCullingEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        gpuCullingEnabled = enabled;
+        session?.SetGpuCullingEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetDepthPrepassEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        depthPrepassEnabled = enabled;
+        session?.SetDepthPrepassEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetExperimentalLightsEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        experimentalLightsEnabled = enabled;
+        session?.SetExperimentalLightsEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetToolMaterialsVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        toolMaterialsVisible = visible;
+        session?.SetToolMaterialsVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetOccludedBoundsVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        occludedBoundsVisible = visible;
+        session?.SetOccludedBoundsVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetStaticOctreeVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        staticOctreeVisible = visible;
+        session?.SetStaticOctreeVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetDynamicOctreeVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        dynamicOctreeVisible = visible;
+        session?.SetDynamicOctreeVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetMapCamera(int index)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetMapCamera(index);
+        RequestNextFrameRendering();
+    }
+
+    public string? GetEntityDetails(int index)
+    {
+        using var _ = renderLock.EnterScope();
+        return session?.GetEntityDetails(index);
+    }
+
+    public void FocusEntity(int index)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.FocusEntity(index);
+        RequestNextFrameRendering();
+    }
+
+    public void SetAnimation(string? name)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetAnimation(name);
+        RequestNextFrameRendering();
+    }
+
+    public void SetAnimationPaused(bool paused)
+    {
+        using var _ = renderLock.EnterScope();
+        animationPaused = paused;
+        session?.SetAnimationPaused(paused);
+        RequestNextFrameRendering();
+    }
+
+    public void SetAnimationSpeed(float speed)
+    {
+        using var _ = renderLock.EnterScope();
+        animationSpeed = speed;
+        session?.SetAnimationSpeed(speed);
+        RequestNextFrameRendering();
+    }
+
+    public void SetAnimationFrame(float fraction)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetAnimationFrame(fraction);
+        RequestNextFrameRendering();
+    }
+
+    public void SetRootMotionEnabled(bool enabled)
+    {
+        using var _ = renderLock.EnterScope();
+        rootMotionEnabled = enabled;
+        session?.SetRootMotionEnabled(enabled);
+        RequestNextFrameRendering();
+    }
+
+    public void SetModelStatsVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        modelStatsVisible = visible;
+        session?.SetModelStatsVisible(visible);
+        NotifyModelStatsChanged(session?.ModelStatsText);
+        RequestNextFrameRendering();
+    }
+
+    public void SetMeshGroups(IReadOnlyCollection<string> groups)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetMeshGroups(groups);
+        NotifyModelStatsChanged(session?.ModelStatsText);
+        RequestNextFrameRendering();
+    }
+
+    public void SetMaterialGroup(string group)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetMaterialGroup(group);
+        NotifyModelStatsChanged(session?.ModelStatsText);
+        RequestNextFrameRendering();
+    }
+
+    public void SetLod(int lod)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetLod(lod < 0 ? null : lod);
+        NotifyModelStatsChanged(session?.ModelStatsText);
+        RequestNextFrameRendering();
+    }
+
+    public void SetHitboxSet(string? name)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetHitboxSet(name);
+        RequestNextFrameRendering();
+    }
+
+    public void SetSkeletonVisible(bool visible)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetSkeletonVisible(visible);
+        RequestNextFrameRendering();
+    }
+
+    public void SetWorldLayers(IReadOnlyCollection<string> layers)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetWorldLayers(layers);
+        RequestNextFrameRendering();
+    }
+
+    public void SetPhysicsGroups(IReadOnlyCollection<string> groups)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.SetPhysicsGroups(groups);
+        RequestNextFrameRendering();
+    }
+
+    public void BeginPointerInput(Point position, bool left, bool right, bool middle)
+    {
+        using var _ = renderLock.EnterScope();
+        SetPointerButtons(left, right, middle);
+        previousPointer = position;
+        RequestNextFrameRendering();
+    }
+
+    public void EndPointerInput(bool left, bool right, bool middle)
+    {
+        using var _ = renderLock.EnterScope();
+        SetPointerButtons(left, right, middle);
+        if (!orbitDrag && !lookDrag && !panDrag)
+        {
+            previousPointer = null;
+        }
+
+        RequestNextFrameRendering();
+    }
+
+    public void MovePointerInput(Point position)
+    {
+        using var _ = renderLock.EnterScope();
+        if (previousPointer is not { } previous || (!orbitDrag && !lookDrag && !panDrag))
+        {
+            return;
+        }
+
+        pendingMouseDelta += new Vector2((float)(position.X - previous.X), (float)(position.Y - previous.Y));
+        previousPointer = position;
+        RequestNextFrameRendering();
+    }
+
+    public void WheelInput(float delta)
+    {
+        using var _ = renderLock.EnterScope();
+        pendingWheelDelta += delta;
+        RequestNextFrameRendering();
+    }
+
+    public void KeyInput(Key key, bool pressed)
+    {
+        using var _ = renderLock.EnterScope();
+        if (pressed && key == Key.F)
+        {
+            resetCameraRequested = true;
+            RequestNextFrameRendering();
+            return;
+        }
+
+        if (pressed)
+        {
+            pressedKeys.Add(key);
+        }
+        else
+        {
+            pressedKeys.Remove(key);
+        }
+
+        RequestNextFrameRendering();
+    }
+
+    protected override void OnOpenGlInit(GlInterface gl)
+    {
+        if (!BindingsLoaded)
+        {
+            GL.LoadBindings(new AvaloniaBindingsContext(gl));
+            BindingsLoaded = true;
+        }
+    }
+
+    protected override void OnOpenGlDeinit(GlInterface gl)
+    {
+        using var _ = renderLock.EnterScope();
+        session?.Dispose();
+        session = null;
+    }
+
+    protected override void OnOpenGlRender(GlInterface gl, int fb)
+    {
+        var width = Math.Max(1, (int)Bounds.Width);
+        var height = Math.Max(1, (int)Bounds.Height);
+
+        using (renderLock.EnterScope())
+        {
+            if (clearRequested)
+            {
+                session?.Dispose();
+                session = null;
+                clearRequested = false;
+            }
+
+            if (pendingRequest != null)
+            {
+                try
+                {
+                    session?.Dispose();
+                    session = NativeRenderSession.Load(pendingRequest, width, height);
+                    session.SetWireframe(wireframe);
+                    session.SetRenderMode(renderMode);
+                    session.SetGridVisible(gridVisible);
+                    session.SetSkyboxVisible(skyboxVisible);
+                    session.SetFogVisible(fogVisible);
+                    session.SetColorCorrectionEnabled(colorCorrectionEnabled);
+                    session.SetOcclusionCullingEnabled(occlusionCullingEnabled);
+                    session.SetGpuCullingEnabled(gpuCullingEnabled);
+                    session.SetDepthPrepassEnabled(depthPrepassEnabled);
+                    session.SetExperimentalLightsEnabled(experimentalLightsEnabled);
+                    session.SetToolMaterialsVisible(toolMaterialsVisible);
+                    session.SetOccludedBoundsVisible(occludedBoundsVisible);
+                    session.SetStaticOctreeVisible(staticOctreeVisible);
+                    session.SetDynamicOctreeVisible(dynamicOctreeVisible);
+                    session.SetAnimationPaused(animationPaused);
+                    session.SetAnimationSpeed(animationSpeed);
+                    session.SetRootMotionEnabled(rootMotionEnabled);
+                    session.SetModelStatsVisible(modelStatsVisible);
+                    lastError = null;
+                    NotifyViewportErrorChanged(null);
+                    NotifyViewportStatusChanged(session.StatusText);
+                    NotifyMapCamerasChanged(session.CameraNames);
+                    NotifyAnimationsChanged(session.AnimationNames);
+                    NotifyMeshGroupsChanged(session.MeshGroupNames, session.ActiveMeshGroupNames);
+                    NotifyMaterialGroupsChanged(session.MaterialGroupNames, session.ActiveMaterialGroupName);
+                    NotifyLodsChanged(session.LodNames);
+                    NotifyHitboxSetsChanged(session.HitboxSetNames);
+                    NotifySkeletonChanged(session.HasSkeleton);
+                    NotifyWorldLayersChanged(session.WorldLayerNames, session.EnabledWorldLayerNames);
+                    NotifyPhysicsGroupsChanged(session.PhysicsGroupNames, session.EnabledPhysicsGroupNames);
+                    NotifyEntitiesChanged(session.EntitySummaries);
+                    NotifyRenderModesChanged(session.RenderModeNames);
+                    NotifyModelStatsChanged(session.ModelStatsText);
+                }
+                catch (Exception exception)
+                {
+                    session = null;
+                    lastError = exception.Message;
+                    _ = Console.Error.WriteLineAsync(exception.ToString());
+                    NotifyViewportErrorChanged(lastError);
+                    NotifyMapCamerasChanged([]);
+                    NotifyAnimationsChanged([]);
+                    NotifyMeshGroupsChanged([], new HashSet<string>());
+                    NotifyMaterialGroupsChanged([], null);
+                    NotifyLodsChanged([]);
+                    NotifyHitboxSetsChanged([]);
+                    NotifySkeletonChanged(false);
+                    NotifyWorldLayersChanged([], new HashSet<string>());
+                    NotifyPhysicsGroupsChanged([], new HashSet<string>());
+                    NotifyEntitiesChanged([]);
+                    NotifyRenderModesChanged([]);
+                    NotifyModelStatsChanged(null);
+                }
+                finally
+                {
+                    pendingRequest = null;
+                }
+            }
+
+            if (session != null)
+            {
+                if (resetCameraRequested)
+                {
+                    session.ResetCamera();
+                    resetCameraRequested = false;
+                }
+
+                var input = ConsumeInput();
+                session.Render(fb, width, height, input);
+                if (pendingScreenshotPath != null)
+                {
+                    try
+                    {
+                        NativeRenderSession.SaveFramebufferPng(fb, width, height, pendingScreenshotPath);
+                        NotifyViewportStatusChanged($"Saved screenshot to {pendingScreenshotPath}.");
+                        NotifyScreenshotSaved(pendingScreenshotPath);
+                    }
+                    catch (Exception exception)
+                    {
+                        NotifyViewportErrorChanged($"Failed to save screenshot: {exception.Message}");
+                    }
+                    finally
+                    {
+                        pendingScreenshotPath = null;
+                    }
+                }
+                RequestNextFrameRendering();
+                return;
+            }
+        }
+
+        ClearPlaceholder(fb, width, height, lastError != null);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        KeyInput(e.Key, pressed: true);
+        e.Handled = true;
+        base.OnKeyDown(e);
+    }
+
+    protected override void OnKeyUp(KeyEventArgs e)
+    {
+        KeyInput(e.Key, pressed: false);
+        e.Handled = true;
+        base.OnKeyUp(e);
+    }
+
+    private void OnControlLostFocus(object? sender, RoutedEventArgs e)
+    {
+        using var _ = renderLock.EnterScope();
+        pressedKeys.Clear();
+        orbitDrag = false;
+        panDrag = false;
+        lookDrag = false;
+        previousPointer = null;
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        Focus();
+        var point = e.GetCurrentPoint(this);
+        BeginPointerInput(point.Position, point.Properties.IsLeftButtonPressed, point.Properties.IsRightButtonPressed, point.Properties.IsMiddleButtonPressed);
+        e.Pointer.Capture(this);
+        e.Handled = true;
+        base.OnPointerPressed(e);
+    }
+
+    protected override void OnPointerReleased(PointerReleasedEventArgs e)
+    {
+        var point = e.GetCurrentPoint(this);
+        EndPointerInput(point.Properties.IsLeftButtonPressed, point.Properties.IsRightButtonPressed, point.Properties.IsMiddleButtonPressed);
+        e.Pointer.Capture(null);
+        e.Handled = true;
+        base.OnPointerReleased(e);
+    }
+
+    protected override void OnPointerMoved(PointerEventArgs e)
+    {
+        MovePointerInput(e.GetPosition(this));
+        e.Handled = true;
+        base.OnPointerMoved(e);
+    }
+
+    protected override void OnPointerWheelChanged(PointerWheelEventArgs e)
+    {
+        WheelInput((float)e.Delta.Y);
+        e.Handled = true;
+        base.OnPointerWheelChanged(e);
+    }
+
+    private void SetPending(RenderRequest request)
+    {
+        using var _ = renderLock.EnterScope();
+        pendingRequest = request;
+        lastError = null;
+        RequestNextFrameRendering();
+    }
+
+    private void NotifyMapCamerasChanged(IReadOnlyList<string> cameras)
+    {
+        var snapshot = cameras.ToArray();
+        Dispatcher.UIThread.Post(() => MapCamerasChanged?.Invoke(snapshot));
+    }
+
+    private void NotifyAnimationsChanged(IReadOnlyList<string> animations)
+    {
+        var snapshot = animations.ToArray();
+        Dispatcher.UIThread.Post(() => AnimationsChanged?.Invoke(snapshot));
+    }
+
+    private void NotifyMeshGroupsChanged(IReadOnlyList<string> groups, IReadOnlySet<string> activeGroups)
+    {
+        var groupSnapshot = groups.ToArray();
+        var activeSnapshot = activeGroups.ToHashSet(StringComparer.Ordinal);
+        Dispatcher.UIThread.Post(() => MeshGroupsChanged?.Invoke(groupSnapshot, activeSnapshot));
+    }
+
+    private void NotifyMaterialGroupsChanged(IReadOnlyList<string> groups, string? activeGroup)
+    {
+        var groupSnapshot = groups.ToArray();
+        Dispatcher.UIThread.Post(() => MaterialGroupsChanged?.Invoke(groupSnapshot, activeGroup));
+    }
+
+    private void NotifyLodsChanged(IReadOnlyList<string> lods)
+    {
+        var snapshot = lods.ToArray();
+        Dispatcher.UIThread.Post(() => LodsChanged?.Invoke(snapshot));
+    }
+
+    private void NotifyHitboxSetsChanged(IReadOnlyList<string> hitboxSets)
+    {
+        var snapshot = hitboxSets.ToArray();
+        Dispatcher.UIThread.Post(() => HitboxSetsChanged?.Invoke(snapshot));
+    }
+
+    private void NotifySkeletonChanged(bool hasSkeleton)
+    {
+        Dispatcher.UIThread.Post(() => SkeletonChanged?.Invoke(hasSkeleton));
+    }
+
+    private void NotifyWorldLayersChanged(IReadOnlyList<string> layers, IReadOnlySet<string> enabledLayers)
+    {
+        var layerSnapshot = layers.ToArray();
+        var enabledSnapshot = enabledLayers.ToHashSet(StringComparer.Ordinal);
+        Dispatcher.UIThread.Post(() => WorldLayersChanged?.Invoke(layerSnapshot, enabledSnapshot));
+    }
+
+    private void NotifyPhysicsGroupsChanged(IReadOnlyList<string> groups, IReadOnlySet<string> enabledGroups)
+    {
+        var groupSnapshot = groups.ToArray();
+        var enabledSnapshot = enabledGroups.ToHashSet(StringComparer.Ordinal);
+        Dispatcher.UIThread.Post(() => PhysicsGroupsChanged?.Invoke(groupSnapshot, enabledSnapshot));
+    }
+
+    private void NotifyEntitiesChanged(IReadOnlyList<string> entities)
+    {
+        var snapshot = entities.ToArray();
+        Dispatcher.UIThread.Post(() => EntitiesChanged?.Invoke(snapshot));
+    }
+
+    private void NotifyRenderModesChanged(IReadOnlyList<string> modes)
+    {
+        var snapshot = modes.ToArray();
+        Dispatcher.UIThread.Post(() => RenderModesChanged?.Invoke(snapshot));
+    }
+
+    private void NotifyModelStatsChanged(string? stats)
+    {
+        Dispatcher.UIThread.Post(() => ModelStatsChanged?.Invoke(stats));
+    }
+
+    private void NotifyViewportErrorChanged(string? message)
+    {
+        Dispatcher.UIThread.Post(() => ViewportErrorChanged?.Invoke(message));
+    }
+
+    private void NotifyViewportStatusChanged(string message)
+    {
+        Dispatcher.UIThread.Post(() => ViewportStatusChanged?.Invoke(message));
+    }
+
+    private void NotifyScreenshotSaved(string path)
+    {
+        Dispatcher.UIThread.Post(() => ScreenshotSaved?.Invoke(path));
+    }
+
+    private void SetPointerButtons(bool left, bool right, bool middle)
+    {
+        orbitDrag = left;
+        lookDrag = right;
+        panDrag = middle;
+    }
+
+    private ViewInput ConsumeInput()
+    {
+        var input = new ViewInput(
+            pendingMouseDelta,
+            pendingWheelDelta,
+            orbitDrag,
+            lookDrag,
+            panDrag,
+            pressedKeys.Contains(Key.W) || pressedKeys.Contains(Key.Up),
+            pressedKeys.Contains(Key.S) || pressedKeys.Contains(Key.Down),
+            pressedKeys.Contains(Key.A) || pressedKeys.Contains(Key.Left),
+            pressedKeys.Contains(Key.D) || pressedKeys.Contains(Key.Right),
+            pressedKeys.Contains(Key.Q),
+            pressedKeys.Contains(Key.E),
+            pressedKeys.Contains(Key.LeftShift) || pressedKeys.Contains(Key.RightShift));
+
+        pendingMouseDelta = Vector2.Zero;
+        pendingWheelDelta = 0f;
+        return input;
+    }
+
+    private static void ClearPlaceholder(int fb, int width, int height, bool error)
+    {
+        GL.BindFramebuffer(FramebufferTarget.Framebuffer, fb);
+        GL.Viewport(0, 0, width, height);
+
+        if (error)
+        {
+            GL.ClearColor(0.18f, 0.03f, 0.04f, 1f);
+        }
+        else
+        {
+            GL.ClearColor(0.03f, 0.04f, 0.06f, 1f);
+        }
+
+        GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
+    }
+
+    private readonly record struct ViewInput(
+        Vector2 MouseDelta,
+        float WheelDelta,
+        bool OrbitDrag,
+        bool LookDrag,
+        bool PanDrag,
+        bool Forward,
+        bool Backward,
+        bool Left,
+        bool Right,
+        bool Down,
+        bool Up,
+        bool Fast);
+
+    private sealed class AvaloniaBindingsContext(GlInterface gl) : IBindingsContext
+    {
+        public IntPtr GetProcAddress(string procName)
+        {
+            return gl.GetProcAddress(procName);
+        }
+    }
+
+    private sealed class RenderRequest
+    {
+        public string DisplayPath { get; private init; } = string.Empty;
+        public string? LoosePath { get; private init; }
+        public Package? Package { get; private init; }
+        public string? PackagePath { get; private init; }
+        public PackageEntry? Entry { get; private init; }
+
+        public static RenderRequest ForLooseFile(string path)
+        {
+            return new RenderRequest
+            {
+                DisplayPath = path,
+                LoosePath = path,
+            };
+        }
+
+        public static RenderRequest ForPackageEntry(Package package, string packagePath, PackageEntry entry)
+        {
+            return new RenderRequest
+            {
+                DisplayPath = entry.GetFullPath(),
+                Package = package,
+                PackagePath = packagePath,
+                Entry = entry,
+            };
+        }
+    }
+
+    private sealed class NativeRenderSession : IDisposable
+    {
+        private readonly GameFileLoader fileLoader;
+        private readonly RendererContext rendererContext;
+        private readonly VrfRenderer renderer;
+        private readonly TextRenderer textRenderer;
+        private readonly Resource resource;
+        private readonly Framebuffer mainFramebuffer;
+        private InfiniteGrid? grid;
+        private readonly Stopwatch stopwatch = Stopwatch.StartNew();
+        private readonly List<Matrix4x4> cameraMatrices = [];
+        private readonly List<string> cameraNames = [];
+        private readonly List<string> animationNames = [];
+        private readonly List<string> meshGroupNames = [];
+        private readonly List<string> materialGroupNames = [];
+        private readonly List<string> lodNames = [];
+        private readonly List<string> hitboxSetNames = [];
+        private readonly List<string> worldLayerNames = [];
+        private readonly List<string> physicsGroupNames = [];
+        private readonly List<string> renderModeNames = [];
+        private readonly List<string> entitySummaries = [];
+        private readonly List<EntityLump.Entity> entities = [];
+        private readonly HashSet<string> activeMeshGroupNames = new(StringComparer.Ordinal);
+        private readonly HashSet<string> enabledWorldLayerNames = new(StringComparer.Ordinal);
+        private readonly HashSet<string> enabledPhysicsGroupNames = new(StringComparer.Ordinal);
+        private long lastUpdate = Stopwatch.GetTimestamp();
+        private Vector3 cameraTarget;
+        private bool cameraSetByWorld;
+        private string? activeMaterialGroupName;
+        private bool staticOctreeVisible;
+        private bool dynamicOctreeVisible;
+        private bool animationPaused;
+        private float animationSpeed = 1f;
+        private bool rootMotionEnabled;
+        private bool rootMotionInitialized;
+        private Vector3 lastRootMotionPosition;
+        private bool modelStatsVisible;
+
+        private NativeRenderSession(
+            GameFileLoader fileLoader,
+            RendererContext rendererContext,
+            VrfRenderer renderer,
+            TextRenderer textRenderer,
+            Resource resource,
+            Framebuffer mainFramebuffer)
+        {
+            this.fileLoader = fileLoader;
+            this.rendererContext = rendererContext;
+            this.renderer = renderer;
+            this.textRenderer = textRenderer;
+            this.resource = resource;
+            this.mainFramebuffer = mainFramebuffer;
+        }
+
+        public IReadOnlyList<string> CameraNames => cameraNames;
+        public IReadOnlyList<string> AnimationNames => animationNames;
+        public IReadOnlyList<string> MeshGroupNames => meshGroupNames;
+        public IReadOnlySet<string> ActiveMeshGroupNames => activeMeshGroupNames;
+        public IReadOnlyList<string> MaterialGroupNames => materialGroupNames;
+        public string? ActiveMaterialGroupName => activeMaterialGroupName;
+        public IReadOnlyList<string> LodNames => lodNames;
+        public IReadOnlyList<string> HitboxSetNames => hitboxSetNames;
+        public bool HasSkeleton => renderer.Scene.AllNodes.OfType<SkeletonSceneNode>().Any();
+        public IReadOnlyList<string> WorldLayerNames => worldLayerNames;
+        public IReadOnlySet<string> EnabledWorldLayerNames => enabledWorldLayerNames;
+        public IReadOnlyList<string> PhysicsGroupNames => physicsGroupNames;
+        public IReadOnlySet<string> EnabledPhysicsGroupNames => enabledPhysicsGroupNames;
+        public IReadOnlyList<string> RenderModeNames => renderModeNames;
+        public IReadOnlyList<string> EntitySummaries => entitySummaries;
+        public string? ModelStatsText { get; private set; }
+        public string StatusText { get; private set; } = string.Empty;
+
+        public static NativeRenderSession Load(RenderRequest request, int width, int height)
+        {
+            var fileLoader = request.Package != null
+                ? new GameFileLoader(request.Package, request.PackagePath)
+                : new GameFileLoader(null, request.LoosePath);
+
+            var resource = ReadResource(request);
+            var rendererContext = new RendererContext(fileLoader, NullLogger.Instance);
+            var renderer = new VrfRenderer(rendererContext);
+            var textRenderer = new TextRenderer(rendererContext, renderer.Camera);
+            var mainFramebuffer = CreateMainFramebuffer(width, height);
+
+            var session = new NativeRenderSession(fileLoader, rendererContext, renderer, textRenderer, resource, mainFramebuffer);
+            session.InitializeScene(request.DisplayPath);
+            return session;
+        }
+
+        public static void SaveFramebufferPng(int framebuffer, int width, int height, string path)
+        {
+            var pixels = new byte[width * height * 4];
+            GL.BindFramebuffer(FramebufferTarget.ReadFramebuffer, framebuffer);
+            GL.ReadPixels(0, 0, width, height, PixelFormat.Bgra, PixelType.UnsignedByte, pixels);
+
+            using var bitmap = new SKBitmap(width, height, SKColorType.Bgra8888, SKAlphaType.Unpremul);
+            var dest = bitmap.GetPixels();
+            var stride = width * 4;
+            for (var y = 0; y < height; y++)
+            {
+                Marshal.Copy(pixels, (height - 1 - y) * stride, IntPtr.Add(dest, y * stride), stride);
+            }
+
+            using var image = SKImage.FromBitmap(bitmap);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var output = File.Create(path);
+            data.SaveTo(output);
+        }
+
+        public void Render(int outputFramebuffer, int width, int height, ViewInput input)
+        {
+            Resize(width, height);
+
+            var current = Stopwatch.GetTimestamp();
+            var frameTime = MathF.Min(1f, (float)Stopwatch.GetElapsedTime(lastUpdate, current).TotalSeconds);
+            lastUpdate = current;
+
+            ApplyInput(input, frameTime);
+            ApplyRootMotion();
+
+            renderer.Uptime = (float)stopwatch.Elapsed.TotalSeconds;
+            renderer.DeltaTime = frameTime;
+            renderer.Camera.SetViewportSize(width, height);
+            renderer.Camera.RecalculateMatrices();
+
+            var updateContext = new Scene.UpdateContext
+            {
+                Camera = renderer.Camera,
+                TextRenderer = textRenderer,
+                Timestep = frameTime,
+            };
+
+            renderer.Update(updateContext);
+            renderer.Render(mainFramebuffer);
+            if (renderer.Scene.OcclusionDebugEnabled && renderer.Scene.OcclusionDebug != null)
+            {
+                renderer.Scene.OcclusionDebug.Render();
+            }
+
+            mainFramebuffer.Bind(FramebufferTarget.Framebuffer);
+            if (staticOctreeVisible)
+            {
+                renderer.Scene.StaticOctree.DebugRenderer?.Render();
+            }
+
+            if (dynamicOctreeVisible)
+            {
+                renderer.Scene.DynamicOctree.DebugRenderer?.Render();
+            }
+
+            if (grid != null)
+            {
+                grid.Render();
+            }
+
+            var output = Framebuffer.WrapExisting(outputFramebuffer, width, height);
+            renderer.PostprocessRender(mainFramebuffer, output);
+        }
+
+        public void ResetCamera()
+        {
+            FrameCamera();
+        }
+
+        public void SetMapCamera(int index)
+        {
+            if ((uint)index >= (uint)cameraMatrices.Count)
+            {
+                return;
+            }
+
+            SetCamera(cameraMatrices[index]);
+        }
+
+        public string? GetEntityDetails(int index)
+        {
+            if ((uint)index >= (uint)entities.Count)
+            {
+                return null;
+            }
+
+            var entity = entities[index];
+            var output = new StringBuilder();
+            output.AppendLine("Entity");
+            output.AppendLine($"Class: {entity.GetStringProperty("classname", "<unknown>")}");
+            var targetname = entity.GetStringProperty("targetname", string.Empty);
+            if (!string.IsNullOrEmpty(targetname))
+            {
+                output.AppendLine($"Name: {targetname}");
+            }
+
+            output.AppendLine();
+            foreach (var (key, value) in entity.OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                output.AppendLine($"{key}: {value}");
+            }
+
+            if (entity.Connections is { Count: > 0 })
+            {
+                output.AppendLine();
+                output.AppendLine("Connections:");
+                foreach (var connection in entity.Connections)
+                {
+                    output.AppendLine(connection.ToString());
+                }
+            }
+
+            return output.ToString();
+        }
+
+        public void FocusEntity(int index)
+        {
+            if ((uint)index >= (uint)entities.Count)
+            {
+                return;
+            }
+
+            var entity = entities[index];
+            if (entity.GetStringProperty("classname", string.Empty) == "worldspawn")
+            {
+                return;
+            }
+
+            var node = renderer.Scene.Find(entity) ?? renderer.SkyboxScene?.Find(entity);
+            if (node != null)
+            {
+                FocusBoundingBox(node.BoundingBox);
+                return;
+            }
+
+            var position = EntityTransformHelper.CalculateTransformationMatrix(entity).Translation;
+            cameraTarget = position;
+            renderer.Camera.SetLocation(position + new Vector3(128, 64, 128));
+            renderer.Camera.LookAt(position);
+        }
+
+        public void SetAnimation(string? name)
+        {
+            if (name == null)
+            {
+                foreach (var modelNode in GetModelNodes())
+                {
+                    modelNode.SetAnimation(null);
+                }
+
+                rootMotionInitialized = false;
+                return;
+            }
+
+            SetAnimation(renderer.Scene, name);
+            if (renderer.SkyboxScene != null)
+            {
+                SetAnimation(renderer.SkyboxScene, name);
+            }
+
+            ApplyAnimationPlayback();
+            rootMotionInitialized = false;
+        }
+
+        public void SetAnimationPaused(bool paused)
+        {
+            animationPaused = paused;
+            ApplyAnimationPlayback();
+        }
+
+        public void SetAnimationSpeed(float speed)
+        {
+            animationSpeed = speed;
+            ApplyAnimationPlayback();
+        }
+
+        public void SetAnimationFrame(float fraction)
+        {
+            foreach (var modelNode in GetModelNodes())
+            {
+                var animation = modelNode.AnimationController.ActiveAnimation;
+                if (animation == null)
+                {
+                    continue;
+                }
+
+                modelNode.AnimationController.Frame = (int)(Math.Clamp(fraction, 0f, 1f) * Math.Max(animation.FrameCount - 1, 0));
+            }
+
+            rootMotionInitialized = false;
+        }
+
+        public void SetRootMotionEnabled(bool enabled)
+        {
+            rootMotionEnabled = enabled;
+            rootMotionInitialized = false;
+        }
+
+        public void SetModelStatsVisible(bool visible)
+        {
+            modelStatsVisible = visible;
+            ModelStatsText = visible ? GetModelStatsText() : null;
+        }
+
+        public void SetMeshGroups(IReadOnlyCollection<string> groups)
+        {
+            activeMeshGroupNames.Clear();
+            activeMeshGroupNames.UnionWith(groups);
+
+            foreach (var modelNode in GetModelNodes())
+            {
+                modelNode.SetActiveMeshGroups(activeMeshGroupNames);
+            }
+
+            SetModelStatsVisible(modelStatsVisible);
+        }
+
+        public void SetMaterialGroup(string group)
+        {
+            activeMaterialGroupName = group;
+
+            foreach (var modelNode in GetModelNodes())
+            {
+                if (modelNode.GetMaterialGroups().Contains(group, StringComparer.OrdinalIgnoreCase))
+                {
+                    modelNode.SetMaterialGroup(group);
+                }
+            }
+
+            SetModelStatsVisible(modelStatsVisible);
+        }
+
+        public void SetLod(int? lod)
+        {
+            foreach (var modelNode in GetModelNodes())
+            {
+                modelNode.SetActiveLod(lod);
+            }
+
+            SetModelStatsVisible(modelStatsVisible);
+        }
+
+        public void SetHitboxSet(string? name)
+        {
+            foreach (var hitboxSetNode in renderer.Scene.AllNodes.OfType<HitboxSetSceneNode>())
+            {
+                hitboxSetNode.SetHitboxSet(name);
+            }
+        }
+
+        public void SetSkeletonVisible(bool visible)
+        {
+            foreach (var skeletonNode in renderer.Scene.AllNodes.OfType<SkeletonSceneNode>())
+            {
+                skeletonNode.Enabled = visible;
+            }
+        }
+
+        public void SetWorldLayers(IReadOnlyCollection<string> layers)
+        {
+            enabledWorldLayerNames.Clear();
+            enabledWorldLayerNames.UnionWith(layers);
+            renderer.Scene.SetEnabledLayers(enabledWorldLayerNames);
+            renderer.SkyboxScene?.SetEnabledLayers(enabledWorldLayerNames);
+            renderer.Scene.UpdateOctrees();
+            renderer.SkyboxScene?.UpdateOctrees();
+        }
+
+        public void SetPhysicsGroups(IReadOnlyCollection<string> groups)
+        {
+            enabledPhysicsGroupNames.Clear();
+            enabledPhysicsGroupNames.UnionWith(groups);
+
+            foreach (var physNode in renderer.Scene.AllNodes.OfType<PhysSceneNode>())
+            {
+                physNode.Enabled = enabledPhysicsGroupNames.Contains(physNode.PhysGroupName);
+            }
+
+            renderer.Scene.UpdateOctrees();
+        }
+
+        public void SetWireframe(bool enabled)
+        {
+            renderer.IsWireframe = enabled;
+        }
+
+        public void SetRenderMode(string mode)
+        {
+            if (renderer.ViewBuffer?.Data == null)
+            {
+                return;
+            }
+
+            renderer.ViewBuffer.Data.RenderMode = RenderModes.GetShaderId(mode);
+            renderer.Postprocess.Enabled = renderer.ViewBuffer.Data.RenderMode == 0;
+            renderer.Scene.EnableCompaction = mode != "Meshlets";
+
+            foreach (var node in renderer.Scene.AllNodes)
+            {
+                node.SetRenderMode(mode);
+            }
+
+            if (renderer.SkyboxScene != null)
+            {
+                foreach (var node in renderer.SkyboxScene.AllNodes)
+                {
+                    node.SetRenderMode(mode);
+                }
+            }
+        }
+
+        public void SetGridVisible(bool visible)
+        {
+            grid = visible ? (grid ?? new InfiniteGrid(renderer.Scene)) : null;
+        }
+
+        public void SetSkyboxVisible(bool visible)
+        {
+            renderer.ShowSkybox = visible;
+        }
+
+        public void SetFogVisible(bool visible)
+        {
+            renderer.Scene.FogEnabled = visible;
+            if (renderer.SkyboxScene != null)
+            {
+                renderer.SkyboxScene.FogEnabled = visible;
+            }
+        }
+
+        public void SetColorCorrectionEnabled(bool enabled)
+        {
+            renderer.Postprocess.ColorCorrectionEnabled = enabled;
+        }
+
+        public void SetOcclusionCullingEnabled(bool enabled)
+        {
+            renderer.Scene.EnableOcclusionCulling = enabled;
+            if (renderer.SkyboxScene != null)
+            {
+                renderer.SkyboxScene.EnableOcclusionCulling = enabled;
+            }
+        }
+
+        public void SetGpuCullingEnabled(bool enabled)
+        {
+            renderer.Scene.EnableIndirectDraws = enabled;
+            if (renderer.SkyboxScene != null)
+            {
+                renderer.SkyboxScene.EnableIndirectDraws = enabled;
+            }
+        }
+
+        public void SetDepthPrepassEnabled(bool enabled)
+        {
+            renderer.Scene.EnableDepthPrepass = enabled;
+            if (renderer.SkyboxScene != null)
+            {
+                renderer.SkyboxScene.EnableDepthPrepass = enabled;
+            }
+        }
+
+        public void SetExperimentalLightsEnabled(bool enabled)
+        {
+            if (renderer.ViewBuffer?.Data != null)
+            {
+                renderer.ViewBuffer.Data.ExperimentalLightsEnabled = enabled;
+            }
+        }
+
+        public void SetToolMaterialsVisible(bool visible)
+        {
+            renderer.Scene.ShowToolsMaterials = visible;
+            if (renderer.SkyboxScene != null)
+            {
+                renderer.SkyboxScene.ShowToolsMaterials = visible;
+            }
+        }
+
+        public void SetOccludedBoundsVisible(bool visible)
+        {
+            renderer.Scene.OcclusionDebugEnabled = visible;
+        }
+
+        public void SetStaticOctreeVisible(bool visible)
+        {
+            staticOctreeVisible = visible;
+            if (!visible)
+            {
+                return;
+            }
+
+            renderer.Scene.StaticOctree.DebugRenderer ??= new(renderer.Scene.StaticOctree, rendererContext, false);
+            renderer.Scene.StaticOctree.DebugRenderer.StaticBuild();
+        }
+
+        public void SetDynamicOctreeVisible(bool visible)
+        {
+            dynamicOctreeVisible = visible;
+            if (!visible)
+            {
+                return;
+            }
+
+            renderer.Scene.DynamicOctree.DebugRenderer ??= new(renderer.Scene.DynamicOctree, rendererContext, true);
+        }
+
+        public void Dispose()
+        {
+            mainFramebuffer.Delete();
+            renderer.Dispose();
+            resource.Dispose();
+            rendererContext.Dispose();
+            fileLoader.Dispose();
+        }
+
+        private static Resource ReadResource(RenderRequest request)
+        {
+            var resource = new Resource { FileName = request.DisplayPath };
+
+            if (request.Package != null && request.Entry != null)
+            {
+                var stream = GameFileLoader.GetPackageEntryStream(request.Package, request.Entry);
+                resource.Read(stream, verifyFileSize: false);
+                return resource;
+            }
+
+            if (request.LoosePath == null)
+            {
+                throw new InvalidOperationException("No resource path was supplied.");
+            }
+
+            resource.Read(request.LoosePath);
+            return resource;
+        }
+
+        private void InitializeScene(string displayPath)
+        {
+            textRenderer.Load();
+            renderer.Postprocess.Load(1);
+            renderer.Initialize();
+            renderer.MainFramebuffer = mainFramebuffer;
+
+            GLEnvironment.Initialize(rendererContext.Logger);
+            GLEnvironment.SetDefaultRenderState();
+
+            renderer.LoadRendererResources();
+            LoadResource(displayPath);
+            CollectAnimationNames();
+            CollectMeshGroups();
+            CollectMaterialGroups();
+            CollectLods();
+            CollectHitboxSets();
+            CollectWorldControls();
+            CollectRenderModes();
+
+            renderer.Scene.Initialize();
+            renderer.SkyboxScene?.Initialize();
+            UpdateStatusText();
+
+            if (!cameraSetByWorld)
+            {
+                FrameCamera();
+            }
+            else
+            {
+                SetTargetFromSceneCenter();
+            }
+        }
+
+        private void LoadResource(string displayPath)
+        {
+            if (resource.ResourceType == ResourceType.Map)
+            {
+                LoadMap(displayPath);
+            }
+            else if (resource.ResourceType == ResourceType.WorldVisibility
+                && resource.GetBlockByType(BlockType.VXVS) is VoxelVisibility voxelVisibility)
+            {
+                renderer.Scene.Add(new VisibilitySceneNode(renderer.Scene, voxelVisibility)
+                {
+                    LayerName = "Visibility clusters",
+                }, false);
+            }
+            else
+            {
+                switch (resource.DataBlock)
+                {
+                    case Model model:
+                        LoadDefaultLighting();
+                        LoadModel(model);
+                        break;
+                    case Mesh mesh:
+                        LoadDefaultLighting();
+                        renderer.Scene.Add(new MeshSceneNode(renderer.Scene, mesh, 0), true);
+                        break;
+                    case Material:
+                        if (resource.DataBlock is Material { ShaderName: "sky.vfx" })
+                        {
+                            renderer.Skybox2D = new SceneSkybox2D(rendererContext.MaterialLoader.LoadMaterial(resource));
+                        }
+                        else
+                        {
+                            LoadDefaultLighting();
+                            LoadMaterialPreview();
+                        }
+                        break;
+                    case PhysAggregateData phys:
+                        LoadDefaultLighting();
+                        foreach (var node in PhysSceneNode.CreatePhysSceneNodes(renderer.Scene, phys, displayPath))
+                        {
+                            renderer.Scene.Add(node, false);
+                        }
+                        break;
+                    case ParticleSystem particleSystem:
+                        LoadDefaultLighting();
+                        renderer.ViewBuffer!.Data!.ExperimentalLightsEnabled = true;
+                        renderer.Scene.LightingInfo.UseSceneBoundsForSunLightFrustum = false;
+                        renderer.Scene.Add(new ParticleSceneNode(renderer.Scene, particleSystem, null, preview: true), true);
+                        break;
+                    case SmartProp smartProp:
+                        LoadDefaultLighting();
+                        LoadSmartProp(smartProp);
+                        break;
+                    case AnimationClip clip:
+                        LoadAnimationClip(clip);
+                        break;
+                    case BinaryKV3 skeletonData when resource.ResourceType == ResourceType.NmSkeleton:
+                        LoadSkeleton(Skeleton.FromSkeletonData(skeletonData.Data), null);
+                        break;
+                    case WorldResource world:
+                        LoadWorld(world, resource.ExternalReferences);
+                        break;
+                    case WorldNode worldNode:
+                        LoadDefaultLighting();
+                        new WorldNodeLoader(rendererContext, worldNode, resource.ExternalReferences).Load(renderer.Scene);
+                        break;
+                    default:
+                        throw new NotSupportedException($"Rendering {resource.ResourceType} is not wired in the native viewport yet.");
+                }
+            }
+
+            var post = new ScenePostProcessVolume(renderer.Scene)
+            {
+                HasBloom = true,
+                IsMaster = true,
+            };
+            renderer.Scene.PostProcessInfo.AddPostProcessVolume(post);
+        }
+
+        private void LoadModel(Model model)
+        {
+            var modelNode = new ModelSceneNode(renderer.Scene, model);
+            renderer.Scene.Add(modelNode, true);
+            DisableStandaloneOverlayMaterials(modelNode);
+
+            if (model.Skeleton.Bones.Length > 0)
+            {
+                renderer.Scene.Add(new SkeletonSceneNode(renderer.Scene, modelNode.AnimationController, model.Skeleton), true);
+            }
+
+            if (model.HitboxSets is { Count: > 0 })
+            {
+                renderer.Scene.Add(new HitboxSetSceneNode(renderer.Scene, modelNode.AnimationController, model.HitboxSets), true);
+            }
+
+            var phys = model.GetEmbeddedPhys();
+            phys ??= model.GetReferencedPhysNames()
+                .Select(name => rendererContext.FileLoader.LoadFileCompiled(name)?.DataBlock)
+                .OfType<PhysAggregateData>()
+                .FirstOrDefault();
+
+            if (phys == null)
+            {
+                return;
+            }
+
+            foreach (var physNode in PhysSceneNode.CreatePhysSceneNodes(renderer.Scene, phys, null))
+            {
+                physNode.Enabled = modelNode.RenderableMeshes.Count == 0;
+                physNode.IsTranslucentRenderMode = false;
+                renderer.Scene.Add(physNode, false);
+            }
+        }
+
+        private void LoadAnimationClip(AnimationClip clip)
+        {
+            var skeletonResource = rendererContext.FileLoader.LoadFileCompiled(clip.SkeletonName);
+            if (skeletonResource?.DataBlock is not BinaryKV3 skeletonData)
+            {
+                return;
+            }
+
+            LoadSkeleton(Skeleton.FromSkeletonData(skeletonData.Data), clip);
+        }
+
+        private void LoadSkeleton(Skeleton skeleton, AnimationClip? clip)
+        {
+            var animationController = new AnimationController(skeleton, []);
+            if (clip != null)
+            {
+                animationController.SetAnimation(new Animation(clip));
+            }
+
+            var skeletonNode = new SkeletonSceneNode(renderer.Scene, animationController, skeleton)
+            {
+                Enabled = true,
+            };
+
+            renderer.Scene.Add(skeletonNode, true);
+            skeletonNode.Update(new Scene.UpdateContext
+            {
+                Camera = renderer.Camera,
+                TextRenderer = textRenderer,
+                Timestep = 0f,
+            });
+        }
+
+        private void LoadSmartProp(SmartProp smartProp)
+        {
+            foreach (var child in smartProp.Data.Root.GetArray("m_Children") ?? [])
+            {
+                LoadSmartPropChild(child);
+            }
+        }
+
+        private void LoadSmartPropChild(ValveKeyValue.KVObject child)
+        {
+            switch (child.GetStringProperty("_class"))
+            {
+                case "CSmartPropElement_Model":
+                    var modelName = child.GetStringProperty("m_sModelName");
+                    if (string.IsNullOrEmpty(modelName))
+                    {
+                        return;
+                    }
+
+                    using (var resource = rendererContext.FileLoader.LoadFileCompiled(modelName))
+                    {
+                        if (resource?.DataBlock is Model model)
+                        {
+                            LoadModel(model);
+                        }
+                    }
+                    break;
+                case "CSmartPropElement_Group":
+                case "CSmartPropElement_PickOne":
+                    foreach (var nestedChild in child.GetArray("m_Children") ?? [])
+                    {
+                        LoadSmartPropChild(nestedChild);
+                    }
+                    break;
+            }
+        }
+
+        private static void DisableStandaloneOverlayMaterials(ModelSceneNode modelNode)
+        {
+            if (modelNode.RenderableMeshes.Count != 1)
+            {
+                return;
+            }
+
+            var mesh = modelNode.RenderableMeshes[0];
+            if (mesh.DrawCallsOverlay.Count == 0 || mesh.DrawCallsOpaque.Count != 0 || mesh.DrawCallsBlended.Count != 0)
+            {
+                return;
+            }
+
+            foreach (var drawCall in mesh.DrawCallsOverlay)
+            {
+                drawCall.Material.IsOverlay = false;
+            }
+        }
+
+        private static void SetAnimation(Scene scene, string name)
+        {
+            foreach (var modelNode in scene.AllNodes.OfType<ModelSceneNode>())
+            {
+                if (modelNode.Animations.ContainsKey(name))
+                {
+                    modelNode.SetAnimationByName(name);
+                }
+            }
+        }
+
+        private void ApplyAnimationPlayback()
+        {
+            foreach (var modelNode in GetModelNodes())
+            {
+                modelNode.AnimationController.IsPaused = animationPaused;
+                modelNode.AnimationController.FrametimeMultiplier = animationSpeed;
+            }
+        }
+
+        private void ApplyRootMotion()
+        {
+            if (!rootMotionEnabled)
+            {
+                return;
+            }
+
+            var modelNode = renderer.Scene.AllNodes.OfType<ModelSceneNode>()
+                .FirstOrDefault(static node => node.AnimationController.AnimationFrame is { });
+            if (modelNode?.AnimationController.AnimationFrame is not Frame animationFrame)
+            {
+                return;
+            }
+
+            if (!rootMotionInitialized)
+            {
+                lastRootMotionPosition = animationFrame.Movement.Position;
+                rootMotionInitialized = true;
+                return;
+            }
+
+            var rootMotionDelta = animationFrame.Movement.Position - lastRootMotionPosition;
+            if (rootMotionDelta == Vector3.Zero)
+            {
+                return;
+            }
+
+            modelNode.Transform = modelNode.Transform with
+            {
+                Translation = modelNode.Transform.Translation + rootMotionDelta,
+            };
+            renderer.Camera.Location += rootMotionDelta;
+            cameraTarget += rootMotionDelta;
+            lastRootMotionPosition = animationFrame.Movement.Position;
+            renderer.Scene.MarkParentOctreeDirty(modelNode);
+        }
+
+        private void CollectAnimationNames()
+        {
+            animationNames.Clear();
+            animationNames.AddRange(GetModelNodes()
+                .SelectMany(static node => node.Animations.Keys)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase));
+        }
+
+        private void CollectMeshGroups()
+        {
+            meshGroupNames.Clear();
+            meshGroupNames.AddRange(GetModelNodes()
+                .SelectMany(static node => node.GetMeshGroups())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase));
+
+            activeMeshGroupNames.Clear();
+            activeMeshGroupNames.UnionWith(GetModelNodes().SelectMany(static node => node.GetActiveMeshGroups()));
+        }
+
+        private void CollectMaterialGroups()
+        {
+            materialGroupNames.Clear();
+            materialGroupNames.AddRange(GetModelNodes()
+                .SelectMany(static node => node.GetMaterialGroups())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase));
+            activeMaterialGroupName = GetModelNodes().FirstOrDefault()?.ActiveMaterialGroup;
+        }
+
+        private void CollectLods()
+        {
+            lodNames.Clear();
+            var lodInfo = GetModelNodes()
+                .Select(static node => node.LodInfo)
+                .FirstOrDefault(static lodInfo => lodInfo.HasDistinctLevels);
+            if (lodInfo == null)
+            {
+                return;
+            }
+
+            lodNames.Add("Auto");
+            for (var level = 0; level < lodInfo.LevelCount; level++)
+            {
+                lodNames.Add(lodInfo.AvailableLevels.Contains(level) ? $"LOD {level}" : $"LOD {level} (empty)");
+            }
+        }
+
+        private void CollectHitboxSets()
+        {
+            hitboxSetNames.Clear();
+            hitboxSetNames.AddRange(renderer.Scene.AllNodes
+                .OfType<HitboxSetSceneNode>()
+                .SelectMany(static node => node.HitboxSets)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Order(StringComparer.OrdinalIgnoreCase));
+        }
+
+        private void LoadMaterialPreview()
+        {
+            var material = rendererContext.MaterialLoader.LoadMaterial(resource);
+            var planeMesh = MeshSceneNode.CreateMaterialPreviewQuad(renderer.Scene, material, new Vector2(32));
+            renderer.Scene.Add(planeMesh, false);
+        }
+
+        private void LoadMap(string displayPath)
+        {
+            var loadedWorld = WorldLoader.LoadMap(displayPath, renderer.Scene);
+            renderer.SkyboxScene = loadedWorld.SkyboxScene;
+            renderer.Skybox2D = loadedWorld.Skybox2D;
+            NavMeshSceneNode.AddNavNodesToScene(loadedWorld.NavMesh, renderer.Scene);
+
+            if (loadedWorld.CameraMatrices.Count > 0)
+            {
+                cameraNames.AddRange(loadedWorld.CameraNames);
+                cameraMatrices.AddRange(loadedWorld.CameraMatrices);
+                SetCamera(cameraMatrices[0]);
+            }
+
+            SetDefaultWorldLayers(loadedWorld.DefaultEnabledLayers);
+            SetEntitySummaries(loadedWorld.Entities);
+        }
+
+        private void LoadWorld(WorldResource world, ValveResourceFormat.Blocks.ResourceExtRefList? externalReferences)
+        {
+            var loadedWorld = new WorldLoader(world, renderer.Scene);
+            loadedWorld.Load(externalReferences);
+            renderer.SkyboxScene = loadedWorld.SkyboxScene;
+            renderer.Skybox2D = loadedWorld.Skybox2D;
+            NavMeshSceneNode.AddNavNodesToScene(loadedWorld.NavMesh, renderer.Scene);
+
+            if (loadedWorld.CameraMatrices.Count > 0)
+            {
+                cameraNames.AddRange(loadedWorld.CameraNames);
+                cameraMatrices.AddRange(loadedWorld.CameraMatrices);
+                SetCamera(cameraMatrices[0]);
+            }
+
+            SetDefaultWorldLayers(loadedWorld.DefaultEnabledLayers);
+            SetEntitySummaries(loadedWorld.Entities);
+        }
+
+        private void SetEntitySummaries(IEnumerable<EntityLump.Entity> sourceEntities)
+        {
+            entities.Clear();
+            entities.AddRange(sourceEntities);
+            entitySummaries.Clear();
+            entitySummaries.AddRange(entities
+                .Select(static entity =>
+                {
+                    var classname = entity.GetStringProperty("classname", "<unknown>");
+                    var targetname = entity.GetStringProperty("targetname", string.Empty);
+                    return string.IsNullOrEmpty(targetname) ? classname : $"{classname} - {targetname}";
+                })
+                .Take(1000));
+        }
+
+        private void SetCamera(Matrix4x4 matrix)
+        {
+            renderer.Camera.SetFromTransformMatrix(matrix);
+            renderer.Camera.ClampRotation();
+            renderer.Camera.RecalculateDirectionVectors();
+            cameraSetByWorld = true;
+            SetTargetFromSceneCenter();
+        }
+
+        private void SetDefaultWorldLayers(HashSet<string> layers)
+        {
+            enabledWorldLayerNames.Clear();
+            enabledWorldLayerNames.UnionWith(layers);
+            renderer.Scene.SetEnabledLayers(enabledWorldLayerNames);
+            renderer.SkyboxScene?.SetEnabledLayers(enabledWorldLayerNames);
+        }
+
+        private void CollectWorldControls()
+        {
+            worldLayerNames.Clear();
+            worldLayerNames.AddRange(renderer.Scene.AllNodes
+                .Select(static node => node.LayerName)
+                .OfType<string>()
+                .Where(static name => !name.StartsWith("Internal -", StringComparison.Ordinal))
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal));
+
+            if (worldLayerNames.Count > 0 && enabledWorldLayerNames.Count == 0)
+            {
+                enabledWorldLayerNames.UnionWith(worldLayerNames);
+            }
+
+            physicsGroupNames.Clear();
+            physicsGroupNames.AddRange(renderer.Scene.AllNodes
+                .OfType<PhysSceneNode>()
+                .Select(static node => node.PhysGroupName)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal));
+
+            enabledPhysicsGroupNames.Clear();
+            enabledPhysicsGroupNames.UnionWith(renderer.Scene.AllNodes
+                .OfType<PhysSceneNode>()
+                .Where(static node => node.Enabled)
+                .Select(static node => node.PhysGroupName));
+        }
+
+        private void CollectRenderModes()
+        {
+            renderModeNames.Clear();
+            renderModeNames.AddRange(renderer.Scene.AllNodes
+                .Concat(renderer.SkyboxScene?.AllNodes ?? [])
+                .SelectMany(static node => node.GetSupportedRenderModes())
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal));
+        }
+
+        private IEnumerable<ModelSceneNode> GetModelNodes()
+        {
+            foreach (var node in renderer.Scene.AllNodes.OfType<ModelSceneNode>())
+            {
+                yield return node;
+            }
+
+            if (renderer.SkyboxScene == null)
+            {
+                yield break;
+            }
+
+            foreach (var node in renderer.SkyboxScene.AllNodes.OfType<ModelSceneNode>())
+            {
+                yield return node;
+            }
+        }
+
+        private void UpdateStatusText()
+        {
+            var nodes = renderer.Scene.AllNodes.ToList();
+            var meshes = nodes
+                .OfType<MeshCollectionNode>()
+                .SelectMany(static node => node.RenderableMeshes)
+                .ToList();
+            var drawCalls = meshes.Sum(static mesh => mesh.DrawCalls.Count());
+
+            StatusText = $"Loaded {nodes.Count:N0} nodes, {meshes.Count:N0} meshes, {drawCalls:N0} draw calls.";
+        }
+
+        private string? GetModelStatsText()
+        {
+            var modelNode = GetModelNodes().FirstOrDefault();
+            if (modelNode == null)
+            {
+                return null;
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine(CultureInfo.InvariantCulture, $"Mesh Count: {modelNode.RenderableMeshes.Count}");
+
+            foreach (var mesh in modelNode.RenderableMeshes)
+            {
+                var vertexTotal = 0L;
+                var triangleTotal = 0L;
+                var vertexBufferSize = 0L;
+                var indexBufferSize = 0L;
+
+                foreach (var draw in mesh.DrawCalls)
+                {
+                    vertexTotal += draw.VertexCount;
+                    triangleTotal += draw.IndexCount / 3;
+                    vertexBufferSize += draw.VertexCount * draw.VertexBuffers.Sum(static vb => vb.ElementSizeInBytes);
+                    indexBufferSize += draw.IndexCount * draw.IndexSizeInBytes;
+                }
+
+                var size = mesh.BoundingBox.Max - mesh.BoundingBox.Min;
+                sb.AppendLine(CultureInfo.InvariantCulture, $"{mesh.Name.Split(':')[^1]}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  Vertices:  {vertexTotal:N0} | {FormatBytes(vertexBufferSize)}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  Triangles: {triangleTotal:N0} | {FormatBytes(indexBufferSize)}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  Drawcalls: {mesh.DrawCalls.Count()}");
+                sb.AppendLine(CultureInfo.InvariantCulture, $"  Size: X {size.X:0.##} | Y {size.Y:0.##} | Z {size.Z:0.##}");
+            }
+
+            return sb.ToString();
+        }
+
+        private static string FormatBytes(long value)
+        {
+            string[] units = ["B", "KiB", "MiB", "GiB"];
+            var readable = (double)value;
+            var unit = 0;
+            while (readable >= 1024 && unit < units.Length - 1)
+            {
+                readable /= 1024;
+                unit++;
+            }
+
+            return $"{readable:0.##} {units[unit]}";
+        }
+
+        private void LoadDefaultLighting()
+        {
+            var rendererAssembly = Assembly.GetAssembly(typeof(RendererContext)) ?? throw new InvalidOperationException("Failed to get renderer assembly.");
+            using var stream = rendererAssembly.GetManifestResourceStream("Renderer.Resources.sky_furnace.vtex_c")
+                ?? throw new InvalidOperationException("Failed to load default environment map.");
+            using var ibl = new Resource { FileName = "sky_furnace.vtex_c" };
+            ibl.Read(stream);
+            VrfRenderer.LoadDefaultLighting(renderer.Scene, ibl);
+        }
+
+        private void FrameCamera()
+        {
+            var nodes = GetCameraFrameNodes();
+            if (nodes.Count == 0)
+            {
+                renderer.Camera.SetLocation(new Vector3(256));
+                renderer.Camera.LookAt(Vector3.Zero);
+                return;
+            }
+
+            var bbox = nodes[0].BoundingBox;
+            foreach (var node in nodes.Skip(1))
+            {
+                bbox = bbox.Union(node.BoundingBox);
+            }
+
+            FocusBoundingBox(bbox);
+        }
+
+        private void FocusBoundingBox(AABB bbox)
+        {
+            cameraTarget = bbox.Center;
+            var size = bbox.Size;
+            var distance = MathF.Max(MathF.Max(size.X, size.Y), size.Z) * 1.2f;
+            distance = Math.Clamp(distance, 64f, 2000f);
+            renderer.Camera.SetLocation(new Vector3(bbox.Center.X + distance, bbox.Center.Y + size.Y * 2f, bbox.Center.Z + distance));
+            renderer.Camera.LookAt(bbox.Center);
+        }
+
+        private void SetTargetFromSceneCenter()
+        {
+            var nodes = GetCameraFrameNodes();
+            if (nodes.Count == 0)
+            {
+                cameraTarget = renderer.Camera.Location + renderer.Camera.Forward * 1024f;
+                return;
+            }
+
+            var bbox = nodes[0].BoundingBox;
+            foreach (var node in nodes.Skip(1))
+            {
+                bbox = bbox.Union(node.BoundingBox);
+            }
+
+            cameraTarget = bbox.Center;
+        }
+
+        private List<SceneNode> GetCameraFrameNodes()
+        {
+            var visibleNodes = renderer.Scene.AllNodes
+                .Where(static node => node.LayerEnabled)
+                .ToList();
+
+            return visibleNodes.Count > 0
+                ? visibleNodes
+                : renderer.Scene.AllNodes.ToList();
+        }
+
+        private void ApplyInput(ViewInput input, float frameTime)
+        {
+            var camera = renderer.Camera;
+            camera.RecalculateDirectionVectors();
+
+            var distance = MathF.Max(1f, Vector3.Distance(camera.Location, cameraTarget));
+            var panScale = distance * 0.0015f;
+
+            if (input.OrbitDrag && input.MouseDelta != Vector2.Zero)
+            {
+                ApplyLookDelta(camera, input.MouseDelta);
+                camera.ClampRotation();
+                camera.RecalculateDirectionVectors();
+                camera.Location = cameraTarget - camera.Forward * distance;
+            }
+            else if (input.LookDrag && input.MouseDelta != Vector2.Zero)
+            {
+                ApplyLookDelta(camera, input.MouseDelta);
+                camera.ClampRotation();
+                camera.RecalculateDirectionVectors();
+                cameraTarget = camera.Location + camera.Forward * distance;
+            }
+            else if (input.PanDrag && input.MouseDelta != Vector2.Zero)
+            {
+                var pan = (-camera.Right * input.MouseDelta.X + camera.Up * input.MouseDelta.Y) * panScale;
+                cameraTarget += pan;
+                camera.Location += pan;
+            }
+
+            if (input.WheelDelta != 0f)
+            {
+                var zoom = MathF.Pow(0.85f, input.WheelDelta);
+                distance = Math.Clamp(distance * zoom, 1f, 1_000_000f);
+                camera.Location = cameraTarget - camera.Forward * distance;
+            }
+
+            var movement = Vector3.Zero;
+            if (input.Forward)
+            {
+                movement += camera.Forward;
+            }
+            if (input.Backward)
+            {
+                movement -= camera.Forward;
+            }
+            if (input.Right)
+            {
+                movement += camera.Right;
+            }
+            if (input.Left)
+            {
+                movement -= camera.Right;
+            }
+            if (input.Up)
+            {
+                movement += Vector3.UnitZ;
+            }
+            if (input.Down)
+            {
+                movement -= Vector3.UnitZ;
+            }
+
+            if (movement != Vector3.Zero)
+            {
+                movement = Vector3.Normalize(movement) * MathF.Max(64f, distance) * frameTime * (input.Fast ? 4f : 1f);
+                camera.Location += movement;
+                cameraTarget += movement;
+            }
+        }
+
+        private static void ApplyLookDelta(Camera camera, Vector2 mouseDelta)
+        {
+            const float Sensitivity = 0.008f;
+            camera.Yaw -= mouseDelta.X * Sensitivity;
+            camera.Pitch -= mouseDelta.Y * Sensitivity;
+        }
+
+        private void Resize(int width, int height)
+        {
+            mainFramebuffer.Resize(width, height, 1);
+            renderer.Camera.SetViewportSize(width, height);
+        }
+
+        private static Framebuffer CreateMainFramebuffer(int width, int height)
+        {
+            var framebuffer = Framebuffer.Prepare(nameof(NativeRenderControl),
+                Math.Max(1, width),
+                Math.Max(1, height),
+                1,
+                new(PixelInternalFormat.Rgba16f, PixelFormat.Rgba, PixelType.HalfFloat),
+                Framebuffer.DepthAttachmentFormat.Depth32FStencil8);
+
+            var status = framebuffer.Initialize();
+            if (status != FramebufferErrorCode.FramebufferComplete)
+            {
+                throw new InvalidOperationException($"Framebuffer failed to initialize: {status}");
+            }
+
+            framebuffer.ClearMask |= ClearBufferMask.StencilBufferBit;
+            return framebuffer;
+        }
+    }
+}

--- a/Source2Viewer.App/Program.cs
+++ b/Source2Viewer.App/Program.cs
@@ -1,0 +1,39 @@
+using Avalonia;
+using Avalonia.OpenGL;
+
+namespace Source2Viewer.App;
+
+internal static class Program
+{
+    public static string[] StartupArgs { get; private set; } = [];
+
+    [STAThread]
+    public static void Main(string[] args)
+    {
+        if (args is ["--self-check"])
+        {
+            MainWindow.RunExportPathSelfCheck();
+            return;
+        }
+
+        StartupArgs = args;
+        BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+    }
+
+    public static AppBuilder BuildAvaloniaApp()
+    {
+        return AppBuilder.Configure<App>()
+            .UsePlatformDetect()
+            .With(new X11PlatformOptions
+            {
+                GlProfiles =
+                [
+                    new GlVersion(GlProfileType.OpenGL, 4, 6),
+                    new GlVersion(GlProfileType.OpenGL, 4, 5),
+                    new GlVersion(GlProfileType.OpenGL, 4, 3),
+                ],
+            })
+            .WithInterFont()
+            .LogToTrace();
+    }
+}

--- a/Source2Viewer.App/Source2Viewer.App.csproj
+++ b/Source2Viewer.App/Source2Viewer.App.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.4" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Renderer\Renderer.csproj" />
+  </ItemGroup>
+</Project>

--- a/Source2Viewer.App/app.manifest
+++ b/Source2Viewer.App/app.manifest
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <!-- This manifest is used on Windows only.
+       Don't remove it as it might cause problems with window transparency and embedded controls.
+       For more details visit https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests -->
+  <assemblyIdentity version="1.0.0.0" name="Source2Viewer.App.Desktop"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows 10 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/ValveResourceFormat.slnx
+++ b/ValveResourceFormat.slnx
@@ -2,6 +2,7 @@
   <Project Path="CLI/CLI.csproj" />
   <Project Path="GUI/GUI.csproj" />
   <Project Path="Renderer/Renderer.csproj" />
+  <Project Path="Source2Viewer.App/Source2Viewer.App.csproj" />
   <Project Path="Tests/Tests.csproj" />
   <Project Path="ValveResourceFormat/ValveResourceFormat.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary

This introduces a Linux-native Source 2 Viewer application while keeping the existing Windows WinForms GUI unchanged.

The current branch provides a usable Linux-first GUI for opening VPK archives and loose Source 2 resources, browsing and filtering package contents, and rendering models and maps with the existing VRF renderer. It also includes renderer fixes found while exercising assets through the Linux OpenGL path.

This is submitted as a draft because the native viewer is functional, but it does not yet have full feature parity with the Windows GUI.

## Technology

- **.NET 10 / C#** for the application and shared code.
- **Avalonia 12** for the native cross-platform desktop shell, controls, file pickers, input, drag-and-drop, and theming.
- **Avalonia `OpenGlControlBase`** for the viewport lifecycle and OpenGL surface.
- The existing **Renderer** project and **OpenTK/OpenGL** rendering pipeline; this does not introduce a second renderer or a web/Electron layer.
- Existing **ValveResourceFormat** and **SteamDatabase.ValvePak** loaders for Source 2 resources and VPK archives.

## Current scope

- Adds `Source2Viewer.App`, targeting `net10.0`.
- Opens VPK archives and loose compiled Source 2 resources.
- Provides package navigation, search/filter/sort, preview, extraction/decompile actions, drag-and-drop, and recent-file startup behavior.
- Renders models, worlds/maps, particles, navigation resources, and sky content through the shared renderer.
- Supports orbit/pan/look navigation, wheel zoom, and model/entity focus.
- Exposes map cameras, layers, physics groups, entities, model groups, materials, LODs, hitboxes, skeletons, animations, render modes, and renderer debug toggles where available.
- Keeps the existing Windows GUI project intact.
- Fixes OpenGL buffer offsets/VAO state, sampler initialization, and missing vertex-color fallback issues observed on the Linux path.

## Plan

1. **Review and stabilize this Linux foundation**
   - Validate more games, maps, weapons, props, and GPU/driver combinations.
   - Address renderer regressions with small reproducible assets and focused tests where practical.
   - Keep Windows GUI behavior/builds unchanged.

2. **Close viewer parity gaps in follow-up PRs**
   - Add the remaining resource-specific viewers and richer document tabs.
   - Match package browsing, export, properties, audio/image, and navigation workflows from the Windows application.
   - Split follow-up work into reviewable viewer-specific changes instead of expanding this PR indefinitely.

3. **Harden the platform boundary**
   - Move reusable scene loading and viewer state out of Avalonia/WinForms controls where duplication appears.
   - Keep UI input/windowing separate from renderer lifecycle and scene data.
   - Add Linux packaging and a CI/headless smoke path after the host API settles.

4. **Leave room for a future path-tracing pipeline**
   - Path tracing is explicitly not part of this PR.
   - Future work should consume the same scene/material/camera description while remaining separate from the current raster debug visualization modes.
   - Camera, material, lighting, layer, and resolution changes must be able to invalidate progressive accumulation without coupling that behavior to Avalonia or WinForms.

## Validation

- `dotnet format Renderer/Renderer.csproj --verify-no-changes --no-restore`
- `dotnet format Source2Viewer.App/Source2Viewer.App.csproj --verify-no-changes --no-restore`
- `dotnet build ValveResourceFormat.slnx --configuration Release -p:EnableWindowsTargeting=true --no-restore -m:1 /p:UseSharedCompilation=false`
  - 0 warnings, 0 errors
- `dotnet test Tests/Tests.csproj --configuration Release --no-build --no-restore`
  - 272 passed, 2 skipped because optional local game/sample data was unavailable
