### PR TITLE
Export animation graph clips & bake transforms for gltf

### DIFF
--- a/CLI/Decompiler.cs
+++ b/CLI/Decompiler.cs
@@ -1422,7 +1422,7 @@ namespace CLI
             return highestByShader.Values.Select(x => x.FilePath).ToHashSet();
         }
 
-        private static void DumpContentFile(string path, ContentFile contentFile, bool dumpSubFiles = true)
+        private void DumpContentFile(string path, ContentFile contentFile, bool dumpSubFiles = true)
         {
             if (contentFile.Data != null)
             {
@@ -1431,7 +1431,10 @@ namespace CLI
 
             foreach (var additionalFile in contentFile.AdditionalFiles)
             {
-                DumpContentFile(Path.Combine(Path.GetDirectoryName(path)!, Path.GetFileName(additionalFile.FileName)), additionalFile);
+                var additionalPath = additionalFile.KeepFullPath && OutputFile != null && (IsInputFolder || Directory.Exists(OutputFile))
+                    ? Path.Combine(OutputFile, additionalFile.FileName)
+                    : Path.Combine(Path.GetDirectoryName(path)!, Path.GetFileName(additionalFile.FileName));
+                DumpContentFile(additionalPath, additionalFile);
             }
 
             if (dumpSubFiles)

--- a/CLI/Decompiler.cs
+++ b/CLI/Decompiler.cs
@@ -1431,6 +1431,10 @@ namespace CLI
 
             foreach (var additionalFile in contentFile.AdditionalFiles)
             {
+                // Additional files (animation-graph clips) carry their full resource path. With a real output
+                // directory we keep it; otherwise we flatten to the leaf name next to the parent file, which can
+                // collide on shared names. Resolving these relative to the parent's output path properly needs a
+                // bigger rework of the extract path handling (also in the GUI's ExtractProgressForm).
                 var additionalPath = additionalFile.KeepFullPath && OutputFile != null && (IsInputFolder || Directory.Exists(OutputFile))
                     ? Path.Combine(OutputFile, additionalFile.FileName)
                     : Path.Combine(Path.GetDirectoryName(path)!, Path.GetFileName(additionalFile.FileName));

--- a/CLI/Decompiler.cs
+++ b/CLI/Decompiler.cs
@@ -179,8 +179,8 @@ namespace CLI
             GltfExportFormat = gltf_export_format;
             GltfExportMaterials = gltf_export_materials;
             GltfExportAnimations = gltf_export_animations;
-            GltfAnimationFilter = gltf_animation_list?.Split(',') ?? [];
-            GltfMeshFilter = gltf_mesh_list?.Split(',') ?? [];
+            GltfAnimationFilter = gltf_animation_list?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? [];
+            GltfMeshFilter = gltf_mesh_list?.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries) ?? [];
             GltfExportAdaptTextures = gltf_textures_adapt;
             GltfExportExtras = gltf_export_extras;
             ToolsAssetInfoShort = tools_asset_info_short;

--- a/GUI/Forms/ExtractProgressForm.cs
+++ b/GUI/Forms/ExtractProgressForm.cs
@@ -475,10 +475,11 @@ namespace GUI.Forms
                 {
                     extractedFiles.Add(additionalFile.FileName + GameFileLoader.CompiledFileSuffix);
                     var fileNameOut = additionalFile.FileName;
+                    var flattenThis = flatSubfiles && !additionalFile.KeepFullPath;
 
                     if (additionalFile.Data != null)
                     {
-                        if (flatSubfiles)
+                        if (flattenThis)
                         {
                             fileNameOut = Path.GetFileName(fileNameOut);
                         }
@@ -493,7 +494,7 @@ namespace GUI.Forms
                         await File.WriteAllBytesAsync(outPath.Full, additionalFile.Data, cancellationTokenSource.Token).ConfigureAwait(false);
                     }
 
-                    var contentRelativeFolder = flatSubfiles ? string.Empty : Path.GetDirectoryName(fileNameOut) ?? string.Empty;
+                    var contentRelativeFolder = flattenThis ? string.Empty : Path.GetDirectoryName(fileNameOut) ?? string.Empty;
 
                     await ExtractSubfiles(contentRelativeFolder, additionalFile).ConfigureAwait(false);
                 }

--- a/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using ValveResourceFormat.IO;
 using ValveResourceFormat.Renderer.Buffers;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
@@ -117,15 +118,9 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                     AnimationController.RegisterExternalSkeleton(skeletonName, skeleton);
                 }
 
-                var animGraphs = model.Data.GetArray("m_animGraph2Refs");
-
-                // just in case there is any recursive or duplicate references
-                var visitedResources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-                foreach (var animGraphRef in animGraphs)
+                foreach (var clipName in AnimationGraphLoader.GetClipNames(model, Scene.RendererContext.FileLoader))
                 {
-                    var graphName = animGraphRef.GetStringProperty("m_hGraph");
-                    LoadAnimGraphResources(graphName, visitedResources);
+                    LoadAnimationClip(clipName);
                 }
             }
 
@@ -410,43 +405,6 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             }
 
             LoadAnimationClip(clip);
-            return true;
-        }
-
-        private bool LoadAnimGraphResources(string graphName, HashSet<string> visited)
-        {
-            var resource = Scene.RendererContext.FileLoader.LoadFileCompiled(graphName);
-            if (resource?.DataBlock is not BinaryKV3 graphData)
-            {
-                return false;
-            }
-
-            var graphResources = graphData.Data.Root.GetArray<string>("m_resources");
-            if (graphResources == null)
-            {
-                return false;
-            }
-
-            var clipExt = ResourceType.NmClip.GetExtension()!;
-            var graphExt = ResourceType.NmGraph.GetExtension()!;
-
-            foreach (var graphResource in graphResources)
-            {
-                if (!visited.Add(graphResource))
-                {
-                    continue;
-                }
-
-                if (graphResource.EndsWith(clipExt, StringComparison.OrdinalIgnoreCase))
-                {
-                    LoadAnimationClip(graphResource);
-                }
-                else if (graphResource.EndsWith(graphExt, StringComparison.OrdinalIgnoreCase))
-                {
-                    LoadAnimGraphResources(graphResource, visited);
-                }
-            }
-
             return true;
         }
 

--- a/Tests/GltfExtractTest.cs
+++ b/Tests/GltfExtractTest.cs
@@ -146,7 +146,7 @@ namespace Tests
 
         // The non-skinned mesh path bakes the conversion into vertex positions and leaves the node at
         // identity (it used to live on the node transform). Verify the geometry is in meters with no residual
-        // node scale or placement, which also guards the aggregate path against applying the conversion twice.
+        // node scale or placement.
         [Test]
         public void TestStaticMeshConversionBakedIntoGeometry()
         {

--- a/Tests/GltfExtractTest.cs
+++ b/Tests/GltfExtractTest.cs
@@ -83,6 +83,135 @@ namespace Tests
             }
         }
 
+        // Regression guard for issue #1135: the source->glTF conversion is baked into geometry and bone
+        // transforms instead of living on a node, so the armature carries no scale. If a 0.0254 scale leaked
+        // back onto the skeleton or mesh nodes, applying transforms in Blender would blow the skinned mesh up.
+        [Test]
+        public void TestSkinnedArmatureHasUnitScale()
+        {
+            WithExportedGlb("box_creature_ik_model.vmdl_c", root =>
+            {
+                var skin = root.LogicalSkins[0];
+
+                using (Assert.EnterMultipleScope())
+                {
+                    for (var i = 0; i < skin.JointsCount; i++)
+                    {
+                        var (joint, _) = skin.GetJoint(i);
+                        Assert.That(WorldScale(joint), Is.LessThan(0.02f), $"joint {joint.Name} should be unit-scaled");
+                    }
+
+                    foreach (var node in root.LogicalNodes.Where(n => n.Mesh != null))
+                    {
+                        Assert.That(WorldScale(node), Is.LessThan(0.02f), $"mesh node {node.Name} should be unit-scaled");
+                    }
+                }
+            });
+        }
+
+        // Regression guard for issue #1135: bone translation keyframes must be baked into meters (matching
+        // the unit-scaled armature), not left in source inches. In-inches channels under a 0.0254 armature
+        // scale are exactly what made bones stretch ~39x once transforms were applied.
+        [Test]
+        public void TestSkinnedAnimationStaysMeterScaled()
+        {
+            WithExportedGlb("box_creature_ik_model.vmdl_c", root =>
+            {
+                var anim = root.LogicalAnimations.Single(a => a.Name == "box_creature_leggy_walk");
+
+                var maxTranslation = 0f;
+                foreach (var channel in anim.Channels)
+                {
+                    var sampler = channel.GetTranslationSampler();
+                    if (sampler == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var key in sampler.GetLinearKeys())
+                    {
+                        maxTranslation = MathF.Max(maxTranslation, MathF.Abs(key.Value.X));
+                        maxTranslation = MathF.Max(maxTranslation, MathF.Abs(key.Value.Y));
+                        maxTranslation = MathF.Max(maxTranslation, MathF.Abs(key.Value.Z));
+                    }
+                }
+
+                using (Assert.EnterMultipleScope())
+                {
+                    Assert.That(maxTranslation, Is.GreaterThan(0.5f), "expected meter-scale motion (baked root motion ~1.2 m)");
+                    Assert.That(maxTranslation, Is.LessThan(3f), "translations must be in meters, not source inches (~39x larger)");
+                }
+            });
+        }
+
+        // The non-skinned mesh path bakes the conversion into vertex positions and leaves the node at
+        // identity (it used to live on the node transform). Verify the geometry is in meters with no residual
+        // node scale or placement, which also guards the aggregate path against applying the conversion twice.
+        [Test]
+        public void TestStaticMeshConversionBakedIntoGeometry()
+        {
+            WithExportedGlb("chen_weapon.vmesh_c", root =>
+            {
+                var meshNodes = root.LogicalNodes.Where(n => n.Mesh != null).ToList();
+                Assert.That(meshNodes, Is.Not.Empty);
+
+                var min = new Vector3(float.MaxValue);
+                var max = new Vector3(float.MinValue);
+
+                using (Assert.EnterMultipleScope())
+                {
+                    foreach (var node in meshNodes)
+                    {
+                        Assert.That(node.WorldMatrix.IsIdentity, Is.True, $"node {node.Name} should be identity; the conversion is baked into the geometry");
+
+                        foreach (var primitive in node.Mesh.Primitives)
+                        {
+                            foreach (var position in primitive.GetVertexAccessor("POSITION").AsVector3Array())
+                            {
+                                min = Vector3.Min(min, position);
+                                max = Vector3.Max(max, position);
+                            }
+                        }
+                    }
+
+                    var extent = (max - min).Length();
+                    Assert.That(extent, Is.GreaterThan(1f), "expected real geometry");
+                    Assert.That(extent, Is.LessThan(20f), "geometry must be in meters, not source inches (~39x larger)");
+                }
+            });
+        }
+
+        private static float WorldScale(Node node)
+        {
+            Matrix4x4.Decompose(node.WorldMatrix, out var scale, out _, out _);
+            return (scale - Vector3.One).Length();
+        }
+
+        private static void WithExportedGlb(string fileName, Action<ModelRoot> assert)
+        {
+            using var resource = new Resource();
+            resource.Read(Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", fileName));
+
+            var dir = Path.Combine(Path.GetTempPath(), "vrf_gltf_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(dir);
+
+            try
+            {
+                var outPath = Path.Combine(dir, "export.glb");
+                new GltfModelExporter(new NullFileLoader())
+                {
+                    ExportMaterials = false,
+                    ProgressReporter = new Progress<string>(_ => { }),
+                }.Export(resource, outPath);
+
+                assert(ModelRoot.Load(outPath));
+            }
+            finally
+            {
+                Directory.Delete(dir, true);
+            }
+        }
+
         [Test]
         public void TestExportSucceedsWithoutClothAnchor()
         {

--- a/Tests/GltfExtractTest.cs
+++ b/Tests/GltfExtractTest.cs
@@ -28,13 +28,13 @@ namespace Tests
         }
 
         [Test]
-        public void TestRootMotionIsBakedIntoExport()
+        public void TestSkinnedAnimatedExport()
         {
             using var resource = new Resource();
             var modelPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", "box_creature_ik_model.vmdl_c");
             resource.Read(modelPath);
 
-            var dir = Path.Combine(Path.GetTempPath(), "vrf_rootmotion_" + Guid.NewGuid().ToString("N"));
+            var dir = Path.Combine(Path.GetTempPath(), "vrf_skinned_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(dir);
             var outPath = Path.Combine(dir, "box_creature.glb");
 
@@ -48,17 +48,34 @@ namespace Tests
                 gltf.Export(resource, outPath);
 
                 var root = ModelRoot.Load(outPath);
-                var anim = root.LogicalAnimations.Single(a => a.Name == "box_creature_leggy_walk");
 
                 // The root_motion bone has no per-frame bone animation, so any net displacement of its
-                // translation channel comes purely from the baked root motion (~47.92 source units forward).
+                // translation channel comes purely from the baked root motion (~47.92 source units forward,
+                // ~1.22 m once the source->glTF unit conversion is baked into the export).
+                var anim = root.LogicalAnimations.Single(a => a.Name == "box_creature_leggy_walk");
                 var rootMotionNode = root.LogicalNodes.Single(n => n.Name == "root_motion");
                 var sampler = anim.FindTranslationChannel(rootMotionNode)?.GetTranslationSampler();
                 Assert.That(sampler, Is.Not.Null, "root_motion bone should have a translation channel");
 
                 var keys = sampler.GetLinearKeys().ToArray();
                 var displacement = keys[^1].Value - keys[0].Value;
-                Assert.That(displacement.X, Is.GreaterThan(40f), "root motion should travel the skeleton forward");
+                Assert.That(displacement.Length(), Is.GreaterThan(1f), "root motion should travel the skeleton forward");
+
+                // Each joint's world transform times its inverse-bind matrix is unit-scaled: the conversion is
+                // baked into the geometry, so the armature is identity.
+                var skin = root.LogicalSkins[0];
+                for (var i = 0; i < skin.JointsCount; i++)
+                {
+                    var (joint, inverseBind) = skin.GetJoint(i);
+                    var bind = joint.WorldMatrix * inverseBind;
+
+                    using (Assert.EnterMultipleScope())
+                    {
+                        Assert.That(new Vector3(bind.M11, bind.M12, bind.M13).Length(), Is.EqualTo(1f).Within(0.01f), $"joint {joint.Name}");
+                        Assert.That(new Vector3(bind.M21, bind.M22, bind.M23).Length(), Is.EqualTo(1f).Within(0.01f), $"joint {joint.Name}");
+                        Assert.That(new Vector3(bind.M31, bind.M32, bind.M33).Length(), Is.EqualTo(1f).Within(0.01f), $"joint {joint.Name}");
+                    }
+                }
             }
             finally
             {

--- a/ValveResourceFormat/IO/AnimationGraphLoader.cs
+++ b/ValveResourceFormat/IO/AnimationGraphLoader.cs
@@ -1,0 +1,65 @@
+using ValveResourceFormat.ResourceTypes;
+using ValveResourceFormat.Serialization.KeyValues;
+
+namespace ValveResourceFormat.IO
+{
+    /// <summary>
+    /// Resolves the animation clips referenced by a model's animation graphs (animgraph2).
+    /// </summary>
+    public static class AnimationGraphLoader
+    {
+        private static readonly string NmClipExtension = ResourceType.NmClip.GetExtension()!;
+        private static readonly string NmGraphExtension = ResourceType.NmGraph.GetExtension()!;
+
+        /// <summary>
+        /// Gets the clip (.vnmclip) resource names referenced by the model's animation graphs, recursing
+        /// into nested graphs. These are not part of <see cref="Model.GetAllAnimations"/>.
+        /// </summary>
+        public static IReadOnlyList<string> GetClipNames(Model model, IFileLoader fileLoader)
+        {
+            var graphRefs = model.Data.GetArray("m_animGraph2Refs");
+            if (graphRefs == null)
+            {
+                return [];
+            }
+
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var clipNames = new List<string>();
+            foreach (var graphRef in graphRefs)
+            {
+                CollectClips(graphRef.GetStringProperty("m_hGraph"), fileLoader, visited, clipNames);
+            }
+
+            return clipNames;
+        }
+
+        private static void CollectClips(string graphName, IFileLoader fileLoader, HashSet<string> visited, List<string> clipNames)
+        {
+            if (!visited.Add(graphName) || fileLoader.LoadFileCompiled(graphName)?.DataBlock is not BinaryKV3 graph)
+            {
+                return;
+            }
+
+            var resources = graph.Data.Root.GetArray<string>("m_resources");
+            if (resources == null)
+            {
+                return;
+            }
+
+            foreach (var resource in resources)
+            {
+                if (resource.EndsWith(NmClipExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    if (visited.Add(resource))
+                    {
+                        clipNames.Add(resource);
+                    }
+                }
+                else if (resource.EndsWith(NmGraphExtension, StringComparison.OrdinalIgnoreCase))
+                {
+                    CollectClips(resource, fileLoader, visited, clipNames);
+                }
+            }
+        }
+    }
+}

--- a/ValveResourceFormat/IO/AnimationGraphLoader.cs
+++ b/ValveResourceFormat/IO/AnimationGraphLoader.cs
@@ -13,7 +13,8 @@ namespace ValveResourceFormat.IO
 
         /// <summary>
         /// Gets the clip (.vnmclip) resource names referenced by the model's animation graphs, recursing
-        /// into nested graphs. These are not part of <see cref="Model.GetAllAnimations"/>.
+        /// into nested graphs. These are not part of <see cref="Model.GetAllAnimations"/>. The returned
+        /// list is de-duplicated (each clip appears once) and preserves first-seen order.
         /// </summary>
         public static IReadOnlyList<string> GetClipNames(Model model, IFileLoader fileLoader)
         {

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -48,6 +48,12 @@ namespace ValveResourceFormat.IO
         public List<ContentFile> AdditionalFiles { get; init; } = [];
 
         /// <summary>
+        /// When true, writers place this file (and its subfiles) at its full <see cref="FileName"/> relative
+        /// to the output root instead of next to the parent content file.
+        /// </summary>
+        public bool KeepFullPath { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether this instance has been disposed.
         /// </summary>
         protected bool Disposed { get; private set; }

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -179,7 +179,7 @@ namespace ValveResourceFormat.IO
                     break;
 
                 case ResourceType.Model:
-                    contentFile = new ModelExtract(resource, fileLoader).ToContentFile();
+                    contentFile = new ModelExtract(resource, fileLoader) { ProgressReporter = progress }.ToContentFile();
                     break;
 
                 case ResourceType.AnimationGraph:

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -224,6 +224,10 @@ public partial class GltfModelExporter
     {
         var retargets = new Dictionary<string, (AnimationWriter Writer, Node?[] Joints)?>();
 
+        // UseAnimation is find-or-create by name, so a clip sharing a name with an already-written
+        // animation (embedded, or an earlier clip) would merge its channels onto it. Keep the first, skip the rest.
+        var writtenNames = exportedModel.LogicalAnimations.Select(a => a.Name).ToHashSet();
+
         foreach (var clipName in AnimationGraphLoader.GetClipNames(model, FileLoader))
         {
             CancellationToken.ThrowIfCancellationRequested();
@@ -231,6 +235,12 @@ public partial class GltfModelExporter
             if (FileLoader.LoadFileCompiled(clipName)?.DataBlock is not VAnimationClip clip
                 || (animationFilter.Count > 0 && !animationFilter.Contains(clip.Name)))
             {
+                continue;
+            }
+
+            if (writtenNames.Contains(clip.Name))
+            {
+                ProgressReporter?.Report($"Skipping animation graph clip '{clip.Name}': an animation with that name was already exported.");
                 continue;
             }
 
@@ -242,6 +252,7 @@ public partial class GltfModelExporter
             if (retarget != null)
             {
                 retarget.Value.Writer.WriteAnimation(exportedModel, retarget.Value.Joints, new VAnim(clip));
+                writtenNames.Add(clip.Name);
             }
         }
     }

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -272,7 +272,6 @@ public partial class GltfModelExporter
     // path with the .vnmclip extension stripped (the path keeps them unique across clip folders).
     private static string ClipAnimationName(string clipName) => Path.ChangeExtension(clipName, null)!;
 
-    // Loads a clip's skeleton and maps its bones onto the model's joints by name. Null if none match.
     private (AnimationWriter Writer, Node?[] Joints)? BuildClipRetarget(VModel model, Node[] joints, string clipSkeletonName)
     {
         if (FileLoader.LoadFileCompiled(clipSkeletonName)?.DataBlock is not BinaryKV3 skeletonData)

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -244,7 +244,7 @@ public partial class GltfModelExporter
 
             var animationName = ClipAnimationName(clip.Name);
 
-            if (animationFilter.Count > 0 && !animationFilter.Contains(animationName))
+            if (!IncludeAnimation(animationFilter, animationName))
             {
                 continue;
             }

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -1,9 +1,12 @@
 using System.Diagnostics;
 using System.Linq;
 using SharpGLTF.Schema2;
+using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
 using ValveResourceFormat.ResourceTypes.ModelFlex;
 using VAnim = ValveResourceFormat.ResourceTypes.ModelAnimation.Animation;
+using VAnimationClip = ValveResourceFormat.ResourceTypes.ModelAnimation2.AnimationClip;
+using VModel = ValveResourceFormat.ResourceTypes.Model;
 
 namespace ValveResourceFormat.IO;
 
@@ -36,9 +39,11 @@ public partial class GltfModelExporter
         }
 
         /// <summary>
-        /// Writes a skeletal animation to the glTF model.
+        /// Writes a skeletal animation to the glTF model. Entries in <paramref name="joints"/> may be
+        /// null when an animation targets a skeleton with bones the exported model does not have
+        /// (e.g. animation graph clips retargeted by bone name); those bones are skipped.
         /// </summary>
-        public void WriteAnimation(ModelRoot model, Node[] joints, VAnim animation)
+        public void WriteAnimation(ModelRoot model, Node?[] joints, VAnim animation)
         {
             Debug.Assert(joints.Length == BoneCount);
 
@@ -82,10 +87,23 @@ public partial class GltfModelExporter
                 }
             }
 
+            // bake additive clips over the bind pose, same as the renderer
+            var additive = animation.Clip?.IsAdditive ?? false;
+
             for (var f = 0; f < animation.FrameCount; f++)
             {
                 Frame.FrameIndex = f;
                 animation.DecodeFrame(Frame);
+
+                if (additive)
+                {
+                    for (var boneID = 0; boneID < BoneCount; boneID++)
+                    {
+                        var bind = new FrameBone(Skeleton.Bones[boneID].Position, 1f, Skeleton.Bones[boneID].Angle);
+                        Frame.Bones[boneID] = Frame.Bones[boneID].BlendAdd(bind, 1f);
+                    }
+                }
+
                 var time = f / fps;
                 var prevFrameTime = (f - 1) / fps;
 
@@ -189,11 +207,68 @@ public partial class GltfModelExporter
                 }
 
                 var jointNode = joints[boneID];
+                if (jointNode == null)
+                {
+                    continue;
+                }
+
                 outputAnimation.CreateRotationChannel(jointNode, RotationWriter.Channels[boneID], true);
                 outputAnimation.CreateTranslationChannel(jointNode, PositionWriter.Channels[boneID], true);
                 outputAnimation.CreateScaleChannel(jointNode, ScaleWriter.Channels[boneID], true);
             }
         }
+    }
+
+    // Animation-graph clips aren't part of GetAllAnimations; write them here, retargeted by bone name.
+    private void WriteAnimationGraphClips(ModelRoot exportedModel, VModel model, Node[] joints, HashSet<string> animationFilter)
+    {
+        var retargets = new Dictionary<string, (AnimationWriter Writer, Node?[] Joints)?>();
+
+        foreach (var clipName in AnimationGraphLoader.GetClipNames(model, FileLoader))
+        {
+            CancellationToken.ThrowIfCancellationRequested();
+
+            if (FileLoader.LoadFileCompiled(clipName)?.DataBlock is not VAnimationClip clip
+                || (animationFilter.Count > 0 && !animationFilter.Contains(clip.Name)))
+            {
+                continue;
+            }
+
+            if (!retargets.TryGetValue(clip.SkeletonName, out var retarget))
+            {
+                retargets[clip.SkeletonName] = retarget = BuildClipRetarget(model, joints, clip.SkeletonName);
+            }
+
+            if (retarget != null)
+            {
+                retarget.Value.Writer.WriteAnimation(exportedModel, retarget.Value.Joints, new VAnim(clip));
+            }
+        }
+    }
+
+    // Loads a clip's skeleton and maps its bones onto the model's joints by name. Null if none match.
+    private (AnimationWriter Writer, Node?[] Joints)? BuildClipRetarget(VModel model, Node[] joints, string clipSkeletonName)
+    {
+        if (FileLoader.LoadFileCompiled(clipSkeletonName)?.DataBlock is not BinaryKV3 skeletonData)
+        {
+            return null;
+        }
+
+        var clipSkeleton = Skeleton.FromSkeletonData(skeletonData.Data);
+        var remappedJoints = new Node?[clipSkeleton.Bones.Length];
+        var matched = false;
+
+        for (var i = 0; i < clipSkeleton.Bones.Length; i++)
+        {
+            var modelBone = model.Skeleton[clipSkeleton.Bones[i].Name];
+            if (modelBone != null)
+            {
+                remappedJoints[i] = joints[modelBone.Index];
+                matched = true;
+            }
+        }
+
+        return matched ? (new AnimationWriter(clipSkeleton, model.FlexControllers), remappedJoints) : null;
     }
 
     record struct AnimationChannelWriter<T>(Dictionary<float, T>[] Channels, T?[] LastValue, bool[] ValueOmmited) where T : struct

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using SharpGLTF.Schema2;
 using ValveResourceFormat.ResourceTypes;
@@ -43,7 +44,7 @@ public partial class GltfModelExporter
         /// null when an animation targets a skeleton with bones the exported model does not have
         /// (e.g. animation graph clips retargeted by bone name); those bones are skipped.
         /// </summary>
-        public void WriteAnimation(ModelRoot model, Node?[] joints, VAnim animation)
+        public void WriteAnimation(ModelRoot model, Node?[] joints, VAnim animation, string? animationName = null)
         {
             Debug.Assert(joints.Length == BoneCount);
 
@@ -54,7 +55,7 @@ public partial class GltfModelExporter
             PositionWriter.Clear();
             ScaleWriter.Clear();
 
-            var outputAnimation = model.UseAnimation(animation.Name);
+            var outputAnimation = model.UseAnimation(animationName ?? animation.Name);
 
             var fps = animation.Fps;
 
@@ -236,15 +237,21 @@ public partial class GltfModelExporter
         {
             CancellationToken.ThrowIfCancellationRequested();
 
-            if (FileLoader.LoadFileCompiled(clipName)?.DataBlock is not VAnimationClip clip
-                || (animationFilter.Count > 0 && !animationFilter.Contains(clip.Name)))
+            if (FileLoader.LoadFileCompiled(clipName)?.DataBlock is not VAnimationClip clip)
             {
                 continue;
             }
 
-            if (writtenNames.Contains(clip.Name))
+            var animationName = ClipAnimationName(clip.Name);
+
+            if (animationFilter.Count > 0 && !animationFilter.Contains(animationName))
             {
-                ProgressReporter?.Report($"Skipping animation graph clip '{clip.Name}': an animation with that name was already exported.");
+                continue;
+            }
+
+            if (writtenNames.Contains(animationName))
+            {
+                ProgressReporter?.Report($"Skipping animation graph clip '{animationName}': an animation with that name was already exported.");
                 continue;
             }
 
@@ -255,11 +262,15 @@ public partial class GltfModelExporter
 
             if (retarget != null)
             {
-                retarget.Value.Writer.WriteAnimation(exportedModel, retarget.Value.Joints, new VAnim(clip));
-                writtenNames.Add(clip.Name);
+                retarget.Value.Writer.WriteAnimation(exportedModel, retarget.Value.Joints, new VAnim(clip), animationName);
+                writtenNames.Add(animationName);
             }
         }
     }
+
+    // glTF holds all animations in one flat named list, so AG2 clips are labelled by their resource
+    // path with the .vnmclip extension stripped (the path keeps them unique across clip folders).
+    private static string ClipAnimationName(string clipName) => Path.ChangeExtension(clipName, null)!;
 
     // Loads a clip's skeleton and maps its bones onto the model's joints by name. Null if none match.
     private (AnimationWriter Writer, Node?[] Joints)? BuildClipRetarget(VModel model, Node[] joints, string clipSkeletonName)

--- a/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Anim.cs
@@ -191,6 +191,8 @@ public partial class GltfModelExporter
                         }
                     }
 
+                    (position, rotation) = BakeConversion(position, rotation, bone.Parent == null);
+
                     RotationWriter.SubmitKeyframe(boneID, time, prevFrameTime, rotation);
                     PositionWriter.SubmitKeyframe(boneID, time, prevFrameTime, position);
                     ScaleWriter.SubmitKeyframe(boneID, time, prevFrameTime, scale);
@@ -201,8 +203,10 @@ public partial class GltfModelExporter
             {
                 if (animation.FrameCount == 0)
                 {
-                    RotationWriter.Channels[boneID].Add(0f, Skeleton.Bones[boneID].Angle);
-                    PositionWriter.Channels[boneID].Add(0f, Skeleton.Bones[boneID].Position);
+                    var bone = Skeleton.Bones[boneID];
+                    var (bindPosition, bindRotation) = BakeConversion(bone.Position, bone.Angle, bone.Parent == null);
+                    RotationWriter.Channels[boneID].Add(0f, bindRotation);
+                    PositionWriter.Channels[boneID].Add(0f, bindPosition);
                     ScaleWriter.Channels[boneID].Add(0f, Vector3.One);
                 }
 

--- a/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Numerics;
+
+namespace ValveResourceFormat.IO;
+
+public partial class GltfModelExporter
+{
+    // NOTE: Swaps Y and Z axes - gltf up axis is Y (source engine up is Z)
+    // Also scales inches to meters (gltf units are meters, source engine units are inches)
+    // https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
+    private const float SourceToGltfScale = 0.0254f;
+    private static readonly Quaternion SourceToGltfRotation = Quaternion.CreateFromYawPitchRoll(0, MathF.PI / -2f, MathF.PI / -2f);
+    private static readonly Matrix4x4 TransformSourceToGltf = Matrix4x4.CreateScale(SourceToGltfScale) * Matrix4x4.CreateFromQuaternion(SourceToGltfRotation);
+
+    // The conversion is baked into the exported geometry (bones, vertices, animation tracks) so the armature
+    // is identity-scaled and the bind matrices are clean inverses. The scale folds into translations (a bone
+    // has no rest scale); the rotation bakes into the skeleton roots.
+
+    /// <summary>
+    /// Applies the conversion to a bone-local transform: scales the translation, and on skeleton roots also
+    /// applies the axis rotation (children inherit it through the hierarchy). Used for both bone rest poses
+    /// and animation keyframes.
+    /// </summary>
+    private static (Vector3 Translation, Quaternion Rotation) BakeConversion(Vector3 translation, Quaternion rotation, bool isRoot)
+    {
+        translation *= SourceToGltfScale;
+        if (isRoot)
+        {
+            translation = Vector3.Transform(translation, SourceToGltfRotation);
+            rotation = SourceToGltfRotation * rotation;
+        }
+
+        return (translation, rotation);
+    }
+
+    /// <summary>
+    /// The node transform for placed geometry. The conversion is already baked into the geometry, so a
+    /// standalone model resolves to identity; a world/entity placement is conjugated by the conversion so it
+    /// positions the converted geometry correctly.
+    /// </summary>
+    private static Matrix4x4 GetPlacementTransform(Matrix4x4 transform)
+    {
+        Matrix4x4.Invert(TransformSourceToGltf, out var gltfToSource);
+        return gltfToSource * transform * TransformSourceToGltf;
+    }
+
+    private static void BakePositions(Span<Vector3> positions)
+    {
+        for (var i = 0; i < positions.Length; i++)
+        {
+            positions[i] = Vector3.Transform(positions[i], TransformSourceToGltf);
+        }
+    }
+
+    private static void BakeDirections(Span<Vector3> directions)
+    {
+        for (var i = 0; i < directions.Length; i++)
+        {
+            directions[i] = Vector3.Transform(directions[i], SourceToGltfRotation);
+        }
+    }
+
+    private static void BakeTangents(Span<Vector4> tangents)
+    {
+        for (var i = 0; i < tangents.Length; i++)
+        {
+            var rotated = Vector3.Transform(new Vector3(tangents[i].X, tangents[i].Y, tangents[i].Z), SourceToGltfRotation);
+            tangents[i] = new Vector4(rotated, tangents[i].W);
+        }
+    }
+}

--- a/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Numerics;
-
 namespace ValveResourceFormat.IO;
 
 public partial class GltfModelExporter
@@ -11,6 +8,7 @@ public partial class GltfModelExporter
     private const float SourceToGltfScale = 0.0254f;
     private static readonly Quaternion SourceToGltfRotation = Quaternion.CreateFromYawPitchRoll(0, MathF.PI / -2f, MathF.PI / -2f);
     private static readonly Matrix4x4 TransformSourceToGltf = Matrix4x4.CreateScale(SourceToGltfScale) * Matrix4x4.CreateFromQuaternion(SourceToGltfRotation);
+    private static readonly Matrix4x4 TransformGltfToSource = Invert(TransformSourceToGltf);
 
     // The conversion is baked into the exported geometry (bones, vertices, animation tracks) so the armature
     // is identity-scaled and the bind matrices are clean inverses. The scale folds into translations (a bone
@@ -40,8 +38,13 @@ public partial class GltfModelExporter
     /// </summary>
     private static Matrix4x4 GetPlacementTransform(Matrix4x4 transform)
     {
-        Matrix4x4.Invert(TransformSourceToGltf, out var gltfToSource);
-        return gltfToSource * transform * TransformSourceToGltf;
+        return TransformGltfToSource * transform * TransformSourceToGltf;
+    }
+
+    private static Matrix4x4 Invert(Matrix4x4 matrix)
+    {
+        Matrix4x4.Invert(matrix, out var inverse);
+        return inverse;
     }
 
     private static void BakePositions(Span<Vector3> positions)

--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -533,7 +533,9 @@ public partial class GltfModelExporter
             CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath: null, tintColor);
 
             var newNode = scene.CreateNode(name).WithMesh(mesh);
-            newNode.WorldMatrix = transform * TransformSourceToGltf;
+            // The conversion is baked into the geometry (CreateVertexBufferAccessors), so the placement
+            // transform is conjugated by it rather than multiplied on top - otherwise it applies twice.
+            newNode.WorldMatrix = GetPlacementTransform(transform);
         }
 
         return true;

--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -144,10 +144,12 @@ public partial class GltfModelExporter
                 {
                     var (normals, tangents) = VBIB.GetNormalTangentArray(vertexBuffer, attribute);
                     FixZeroLengthVectors(normals);
+                    BakeDirections(normals);
 
                     if (tangents.Length > 0)
                     {
                         FixZeroLengthVectors(tangents);
+                        BakeTangents(tangents);
                         accessors["NORMAL"] = CreateAccessor(exportedModel, normals);
                         accessors["TANGENT"] = CreateAccessor(exportedModel, tangents);
                     }
@@ -180,6 +182,10 @@ public partial class GltfModelExporter
                         case 3:
                             {
                                 var vectors = VBIB.GetVector3AttributeArray(vertexBuffer, attribute);
+                                if (accessorName == "POSITION")
+                                {
+                                    BakePositions(vectors);
+                                }
                                 accessors[accessorName] = CreateAccessor(exportedModel, vectors);
                                 break;
                             }
@@ -190,6 +196,7 @@ public partial class GltfModelExporter
                                 if (accessorName == "TANGENT")
                                 {
                                     FixZeroLengthVectors(vectors);
+                                    BakeTangents(vectors);
                                 }
 
                                 accessors[accessorName] = CreateAccessor(exportedModel, vectors);
@@ -526,7 +533,7 @@ public partial class GltfModelExporter
             CreateMeshFromDrawCall(drawCall, mesh, vbib, vertexBufferAccessors, exportedModel, skinMaterialPath: null, tintColor);
 
             var newNode = scene.CreateNode(name).WithMesh(mesh);
-            newNode.WorldMatrix = transform * TRANSFORMSOURCETOGLTF;
+            newNode.WorldMatrix = transform * TransformSourceToGltf;
         }
 
         return true;

--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -553,8 +553,12 @@ public partial class GltfModelExporter
                 continue;
             }
 
+            // Morph deltas share the base mesh's vertex space, which is baked into glTF units, so bake them too.
+            var deltas = rectData[vertexOffset..(vertexOffset + vertexCount)];
+            BakePositions(deltas);
+
             var bufferView = model.CreateBufferView(3 * sizeof(float) * vertexCount, 0, BufferMode.ARRAY_BUFFER);
-            new Vector3Array(bufferView.Content).Fill(rectData[vertexOffset..(vertexOffset + vertexCount)]);
+            new Vector3Array(bufferView.Content).Fill(deltas);
 
             var acc = model.CreateAccessor();
             acc.Name = morphName;

--- a/ValveResourceFormat/IO/GltfModelExporter.NavMesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.NavMesh.cs
@@ -49,7 +49,7 @@ public partial class GltfModelExporter
 
                 var node = scene.CreateNode(meshName);
                 node.Mesh = gltfMesh;
-                node.WorldMatrix = TRANSFORMSOURCETOGLTF;
+                node.WorldMatrix = TransformSourceToGltf;
                 node.Extras = new System.Text.Json.Nodes.JsonObject
                 {
                     ["HullIndex"] = i,
@@ -77,7 +77,7 @@ public partial class GltfModelExporter
 
                 var node = scene.CreateNode(meshName);
                 node.Mesh = gltfMesh;
-                node.WorldMatrix = TRANSFORMSOURCETOGLTF;
+                node.WorldMatrix = TransformSourceToGltf;
             }
         }
     }

--- a/ValveResourceFormat/IO/GltfModelExporter.Physics.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Physics.cs
@@ -98,7 +98,7 @@ public partial class GltfModelExporter
                         collisionAttributes[collisionAttrIndex], physicsSurfaceNames, surfacePropIndex, classname);
                     var node = scene.CreateNode(meshName);
                     node.Mesh = gltfMesh;
-                    node.WorldMatrix = transform * TRANSFORMSOURCETOGLTF;
+                    node.WorldMatrix = transform * TransformSourceToGltf;
 
                     var interactAsStrings = collisionAttributes[collisionAttrIndex].GetArray<string>("m_InteractAsStrings");
                     var interactAsArray = new System.Text.Json.Nodes.JsonArray([.. interactAsStrings!]);

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -626,7 +626,7 @@ namespace ValveResourceFormat.IO
                 {
                     var animation = new ResourceTypes.ModelAnimation.Animation(clip);
                     var animationWriter = new AnimationWriter(skeletonData, []);
-                    animationWriter.WriteAnimation(exportedModel, joints, animation);
+                    animationWriter.WriteAnimation(exportedModel, joints, animation, ClipAnimationName(clip.Name));
                 }
             }
 

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -68,9 +68,14 @@ namespace ValveResourceFormat.IO
         public bool ExportExtras { get; set; }
 
         /// <summary>
-        /// Gets the set of animation names to filter during export.
+        /// Gets the set of animation names to filter during export. An entry matches an animation by its
+        /// full name or, for animation graph clips named by resource path, by its leaf name (e.g. "idle_knife"
+        /// matches "animation/anims/.../idle_knife"). Empty means export every animation.
         /// </summary>
         public HashSet<string> AnimationFilter { get; } = [];
+
+        // Filter entries that matched at least one animation, so unmatched ones can be reported after export.
+        private readonly HashSet<string> matchedAnimationFilter = [];
 
         /// <summary>
         /// Gets the set of mesh names to filter during export.
@@ -149,9 +154,11 @@ namespace ValveResourceFormat.IO
             try
             {
                 exportAction();
+                ReportUnmatchedAnimationFilter();
             }
             finally
             {
+                matchedAnimationFilter.Clear();
                 ExportedMeshes.Clear();
                 PhysicsToExport.Clear();
                 TextureExportingTasks.Clear();
@@ -161,6 +168,45 @@ namespace ValveResourceFormat.IO
                 TexturesExportedSoFar = 0;
                 DstDir = string.Empty;
                 IsExporting = false;
+            }
+        }
+
+        // Whether an animation passes AnimationFilter, matching on its full name or, for path-named graph
+        // clips, its leaf name. Records which filter entry matched so misses can be reported afterwards.
+        private bool IncludeAnimation(HashSet<string> filter, string name)
+        {
+            if (filter.Count == 0)
+            {
+                return true;
+            }
+
+            if (filter.Contains(name))
+            {
+                matchedAnimationFilter.Add(name);
+                return true;
+            }
+
+            var leafName = Path.GetFileName(name);
+            if (leafName.Length != name.Length && filter.Contains(leafName))
+            {
+                matchedAnimationFilter.Add(leafName);
+                return true;
+            }
+
+            return false;
+        }
+
+        private void ReportUnmatchedAnimationFilter()
+        {
+            if (AnimationFilter.Count == 0)
+            {
+                return;
+            }
+
+            var unmatched = AnimationFilter.Where(name => !matchedAnimationFilter.Contains(name)).ToList();
+            if (unmatched.Count > 0)
+            {
+                ProgressReporter?.Report($"glTF animation filter matched no animations for: {string.Join(", ", unmatched)}");
             }
         }
 
@@ -676,7 +722,7 @@ namespace ValveResourceFormat.IO
 
                 foreach (var animation in animations)
                 {
-                    if (animationFilter.Count > 0 && !animationFilter.Contains(animation.Name))
+                    if (!IncludeAnimation(animationFilter, animation.Name))
                     {
                         continue;
                     }

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -27,11 +27,6 @@ namespace ValveResourceFormat.IO
     /// </summary>
     public partial class GltfModelExporter
     {
-        // NOTE: Swaps Y and Z axes - gltf up axis is Y (source engine up is Z)
-        // Also divides by 100, gltf units are in meters, source engine units are in inches
-        // https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#coordinate-system-and-units
-        private readonly static Matrix4x4 TRANSFORMSOURCETOGLTF = Matrix4x4.CreateScale(0.0254f) * Matrix4x4.CreateFromYawPitchRoll(0, MathF.PI / -2f, MathF.PI / -2f);
-
         // https://github.com/KhronosGroup/glTF-Blender-IO/blob/6b29ca135d5255dbfe1dd72424ce7243be73c0be/addons/io_scene_gltf2/blender/com/conversion.py#L20
         private const float PbrWattsTolumens = 683;
 
@@ -398,7 +393,7 @@ namespace ValveResourceFormat.IO
 
                         var node = scene.CreateNode(className);
                         node.PunctualLight = CreateGltfLightEnvironment(exportedModel, entity);
-                        node.LocalMatrix = lightMatrix * TRANSFORMSOURCETOGLTF;
+                        node.LocalMatrix = lightMatrix * TransformSourceToGltf;
                     }
                     else if (className == "point_template")
                     {
@@ -633,8 +628,6 @@ namespace ValveResourceFormat.IO
                     var animationWriter = new AnimationWriter(skeletonData, []);
                     animationWriter.WriteAnimation(exportedModel, joints, animation);
                 }
-
-                skeletonNode.WorldMatrix = TRANSFORMSOURCETOGLTF;
             }
 
             ExportAnimationClip(animationClip);
@@ -699,8 +692,7 @@ namespace ValveResourceFormat.IO
                 Debug.Assert(joints == null);
             }
 
-            // Swap Rotate upright, scale inches to meters.
-            transform *= TRANSFORMSOURCETOGLTF;
+            var nodeTransform = GetPlacementTransform(transform);
 
             var skinMaterialPath = skinName != null ? GetSkinPathFromModel(model, skinName) : null;
 
@@ -723,7 +715,7 @@ namespace ValveResourceFormat.IO
                 var node = AddMeshNode(exportedModel, scene, meshName, tintColor, m.Mesh, m.Mesh.VBIB, joints, boneRemapTable, skinMaterialPath, entity);
                 if (node != null)
                 {
-                    node.WorldMatrix = transform;
+                    node.WorldMatrix = nodeTransform;
 
                     DebugValidateGLTF();
                 }
@@ -733,7 +725,7 @@ namespace ValveResourceFormat.IO
             // WorldMatrix should only be set after everything else.
             if (skeletonNode != null)
             {
-                skeletonNode.WorldMatrix = transform;
+                skeletonNode.WorldMatrix = nodeTransform;
             }
         }
 
@@ -778,13 +770,7 @@ namespace ValveResourceFormat.IO
         {
             var exportedModel = CreateModelRoot(resourceName, out var scene);
             var name = Path.GetFileName(resourceName);
-            var node = AddMeshNode(exportedModel, scene, name, Vector4.One, mesh, mesh.VBIB, joints: null);
-
-            if (node != null)
-            {
-                // Swap Rotate upright, scale inches to meters.
-                node.WorldMatrix = TRANSFORMSOURCETOGLTF;
-            }
+            AddMeshNode(exportedModel, scene, name, Vector4.One, mesh, mesh.VBIB, joints: null);
 
             WriteModelFile(exportedModel, fileName);
         }
@@ -922,22 +908,24 @@ namespace ValveResourceFormat.IO
             var joints = new Node[skeleton.Bones.Length];
             foreach (var root in skeleton.Roots)
             {
-                CreateBonesRecursive(root, skeletonNode, ref joints);
+                CreateBonesRecursive(root, skeletonNode, ref joints, isRoot: true);
             }
             return (skeletonNode, joints);
         }
 
-        private static void CreateBonesRecursive(Bone bone, Node parent, ref Node[] joints)
+        private static void CreateBonesRecursive(Bone bone, Node parent, ref Node[] joints, bool isRoot)
         {
+            var (translation, rotation) = BakeConversion(bone.Position, bone.Angle, isRoot);
+
             var node = parent.CreateNode(bone.Name)
-                .WithLocalTranslation(bone.Position)
-                .WithLocalRotation(bone.Angle);
+                .WithLocalTranslation(translation)
+                .WithLocalRotation(rotation);
             joints[bone.Index] = node;
 
             // Recurse into children
             foreach (var child in bone.Children)
             {
-                CreateBonesRecursive(child, node, ref joints);
+                CreateBonesRecursive(child, node, ref joints, isRoot: false);
             }
         }
 
@@ -1002,7 +990,7 @@ namespace ValveResourceFormat.IO
 
             primitive.WithMaterial(material);
 
-            return scene.CreateNode().WithSkinnedMesh(mesh, TRANSFORMSOURCETOGLTF, joints);
+            return scene.CreateNode().WithSkinnedMesh(mesh, Matrix4x4.Identity, joints);
         }
 
         private static PunctualLight CreateGltfLightEnvironment(ModelRoot exportedModel, VEntityLump.Entity entity)

--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -691,6 +691,8 @@ namespace ValveResourceFormat.IO
                     animationWriter.WriteAnimation(exportedModel, joints, animation);
                     CancellationToken.ThrowIfCancellationRequested();
                 }
+
+                WriteAnimationGraphClips(exportedModel, model, joints!, animationFilter);
             }
             else
             {

--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -26,9 +26,6 @@ partial class ModelExtract
         }
     }
 
-    // Bundles the model's animation-graph clips (animgraph2) as content files, so a decompiled model
-    // includes them and not just the embedded animations. Each clip is extracted to its own NmSkel
-    // skeleton via NmClipExtract, written at its full resource path.
     private void AddAnimationGraphClips(ContentFile vmdl)
     {
         if (Type != ModelExtractType.Default || model == null || fileLoader == null)
@@ -36,7 +33,6 @@ partial class ModelExtract
             return;
         }
 
-        // GetClipNames already returns a de-duplicated list, so no extra bookkeeping is needed here.
         foreach (var clipName in AnimationGraphLoader.GetClipNames(model, fileLoader))
         {
             var clipResource = fileLoader.LoadFileCompiled(clipName);

--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -36,14 +36,9 @@ partial class ModelExtract
             return;
         }
 
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        // GetClipNames already returns a de-duplicated list, so no extra bookkeeping is needed here.
         foreach (var clipName in AnimationGraphLoader.GetClipNames(model, fileLoader))
         {
-            if (!seen.Add(clipName))
-            {
-                continue;
-            }
-
             var clipResource = fileLoader.LoadFileCompiled(clipName);
             if (clipResource?.DataBlock is not AnimationClip)
             {
@@ -60,7 +55,7 @@ partial class ModelExtract
             catch (Exception e)
             {
                 // A single malformed clip shouldn't fail the whole model export.
-                Console.Error.WriteLine($"Skipping animation graph clip '{clipName}': {e.Message}");
+                ProgressReporter?.Report($"Skipping animation graph clip '{clipName}': {e.Message}");
             }
         }
     }

--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -3,6 +3,7 @@ using Datamodel;
 using ValveResourceFormat.IO.ContentFormats.DmxModel;
 using ValveResourceFormat.ResourceTypes;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
+using ValveResourceFormat.ResourceTypes.ModelAnimation2;
 using ValveResourceFormat.ResourceTypes.ModelFlex;
 
 namespace ValveResourceFormat.IO;
@@ -22,6 +23,52 @@ partial class ModelExtract
             {
                 AnimationsToExtract.Add((anim, GetDmxFileName_ForAnimation(anim.Name)));
             }
+        }
+    }
+
+    // Bundles the model's animation-graph clips (animgraph2) as content files, so a decompiled model
+    // includes them and not just the embedded animations. Each clip is extracted to its own NmSkel
+    // skeleton via NmClipExtract, written at its full resource path.
+    private void AddAnimationGraphClips(ContentFile vmdl)
+    {
+        if (Type != ModelExtractType.Default || model == null || fileLoader == null)
+        {
+            return;
+        }
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var clipName in AnimationGraphLoader.GetClipNames(model, fileLoader))
+        {
+            if (!seen.Add(clipName))
+            {
+                continue;
+            }
+
+            var clipResource = fileLoader.LoadFileCompiled(clipName);
+            if (clipResource?.DataBlock is not AnimationClip)
+            {
+                continue;
+            }
+
+            try
+            {
+                var clipContent = new NmClipExtract(clipResource, fileLoader).ToContentFile();
+                clipContent.FileName = clipName;
+                clipContent.KeepFullPath = true;
+                vmdl.AdditionalFiles.Add(clipContent);
+            }
+#if DEBUG
+            catch (Exception e)
+            {
+                // A single malformed clip shouldn't fail the whole model export.
+                Console.WriteLine($"Skipping animation graph clip '{clipName}': {e.Message}");
+            }
+#else
+            catch (Exception)
+            {
+                // A single malformed clip shouldn't fail the whole model export.
+            }
+#endif
         }
     }
 

--- a/ValveResourceFormat/IO/ModelExtract.Anim.cs
+++ b/ValveResourceFormat/IO/ModelExtract.Anim.cs
@@ -57,18 +57,11 @@ partial class ModelExtract
                 clipContent.KeepFullPath = true;
                 vmdl.AdditionalFiles.Add(clipContent);
             }
-#if DEBUG
             catch (Exception e)
             {
                 // A single malformed clip shouldn't fail the whole model export.
-                Console.WriteLine($"Skipping animation graph clip '{clipName}': {e.Message}");
+                Console.Error.WriteLine($"Skipping animation graph clip '{clipName}': {e.Message}");
             }
-#else
-            catch (Exception)
-            {
-                // A single malformed clip shouldn't fail the whole model export.
-            }
-#endif
         }
     }
 

--- a/ValveResourceFormat/IO/ModelExtract.cs
+++ b/ValveResourceFormat/IO/ModelExtract.cs
@@ -156,6 +156,8 @@ public partial class ModelExtract
             );
         }
 
+        AddAnimationGraphClips(vmdl);
+
         return vmdl;
     }
 

--- a/ValveResourceFormat/IO/ModelExtract.cs
+++ b/ValveResourceFormat/IO/ModelExtract.cs
@@ -40,7 +40,7 @@ public partial class ModelExtract
     public ModelExtractType Type { get; init; } = ModelExtractType.Default;
 
     /// <summary>Optional sink for non-fatal progress and warning messages.</summary>
-    public IProgress<string>? ProgressReporter { get; set; }
+    public IProgress<string>? ProgressReporter { get; init; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ModelExtract"/> class.

--- a/ValveResourceFormat/IO/ModelExtract.cs
+++ b/ValveResourceFormat/IO/ModelExtract.cs
@@ -39,6 +39,9 @@ public partial class ModelExtract
     /// <summary>Gets the extraction type to apply when generating assets.</summary>
     public ModelExtractType Type { get; init; } = ModelExtractType.Default;
 
+    /// <summary>Optional sink for non-fatal progress and warning messages.</summary>
+    public IProgress<string>? ProgressReporter { get; set; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ModelExtract"/> class.
     /// </summary>


### PR DESCRIPTION
## 1 - Animation graph clips (fixes #1174)

Since ag2 models reference their animations as separate nmclip (.vnmclip) files through an animation graph (instead of embedding them) they were not written out when decompiling the model, so a decompiled AnimGraph2 model lost most of its animations (except for the few embedded ones).

A new helper, `AnimationGraphLoader.cs`, walks the model's animation graph(s), following m_animGraph2Refs and recursing into nested graphs, returning the referenced clip names, de-duplicated.

Both exporters consume it: glTF writes one animation track per clip into the single .glb (retargeted onto the model's joints by bone name), and DMX writes each clip as its own file alongside the model.

## 2 - Conversion baking (fixes #1135)

This wasn't only a Robot Repair issue (where it was reported) - it broke every skinned model in every game.

The source-to-glTF axis swap and inch-to-meter scale used to live on the armature/mesh node transform, so skinned models broke (exploded) when applying transforms in Blender. The conversion is now fully baked into the geometry and animation data instead, so the armature stays identity-scaled. The conversion/baking code is consolidated in `GltfModelExporter.Conversion.cs`.

It basically is the same as before, but now it doesn't break in blender when applying transforms.

## 3 - CLI option --gltf_animation_list

This option already existed and it kind of fixes #994 - though the export-everything from 1.) is what actually solves it, this is just the "pick specific ones" part, and it's CLI only, not possible in the GUI.

It also didn't really work for Ag2 before, so I fixed a few things:

- it now matches clips by their leaf name (e.g. "idle_knife"), not just the full resource path - before, only the full path matched, so for Ag2 clips you couldn't filter easily.
- it trims whitespace and warns when names in the list don't match anything.

And obviously you can also just export the model with all its animations and delete the ones you don't want.

The ticket mentions vnmskel but I think they must have meant vnmclip.
