### PR TITLE
Renderer fixes

### DIFF
--- a/Renderer/Renderer/GPUMeshBufferCache.cs
+++ b/Renderer/Renderer/GPUMeshBufferCache.cs
@@ -19,7 +19,7 @@ namespace ValveResourceFormat.Renderer
         private readonly Dictionary<string, GPUMeshBuffers> gpuBuffers = [];
         private readonly Dictionary<VAOKey, int> vertexArrayObjects = [];
 
-        private record struct VAOKey(string MeshName, int Shader, int VertexIndex, int IndexIndex);
+        private record struct VAOKey(string MeshName, int Shader, string VertexBuffers, int IndexIndex);
 
         /// <summary>Initializes a new GPU mesh buffer cache.</summary>
         /// <param name="rendererContext">The renderer context owning this cache.</param>
@@ -104,7 +104,7 @@ namespace ValveResourceFormat.Renderer
             {
                 MeshName = meshName,
                 Shader = material.Shader.Program,
-                VertexIndex = vertexBuffers[0].Handle, // Probably good enough since every draw call will be creating new buffers
+                VertexBuffers = GetVertexBufferKey(vertexBuffers),
                 IndexIndex = idxIndex,
             };
 
@@ -122,11 +122,11 @@ namespace ValveResourceFormat.Renderer
             GL.BindVertexArray(newVaoHandle);
 
             var bindingIndex = 0;
-            vertexBuffers = AddMissingAttributes(vertexBuffers, material.Shader);
+            SetMissingAttributes(vertexBuffers, material.Shader);
 
             foreach (var curVertexBuffer in vertexBuffers)
             {
-                GL.VertexArrayVertexBuffer(newVaoHandle, bindingIndex, curVertexBuffer.Handle, 0, (int)curVertexBuffer.ElementSizeInBytes);
+                GL.VertexArrayVertexBuffer(newVaoHandle, bindingIndex, curVertexBuffer.Handle, (nint)curVertexBuffer.Offset, (int)curVertexBuffer.ElementSizeInBytes);
 
                 foreach (var attribute in curVertexBuffer.InputLayoutFields)
                 {
@@ -189,29 +189,17 @@ namespace ValveResourceFormat.Renderer
             return newVaoHandle;
         }
 
-        private VertexDrawBuffer[] AddMissingAttributes(VertexDrawBuffer[] vertexBuffers, Shader shader)
+        private static string GetVertexBufferKey(VertexDrawBuffer[] vertexBuffers)
+            => string.Join(';', vertexBuffers.Select(static vertexBuffer =>
+                $"{vertexBuffer.Handle}:{vertexBuffer.Offset}:{vertexBuffer.ElementSizeInBytes}"));
+
+        private static void SetMissingAttributes(VertexDrawBuffer[] vertexBuffers, Shader shader)
         {
             if (shader.Attributes.TryGetValue("vCOLOR", out var colorAttributeLocation)
                         && !vertexBuffers.Any(vb => vb.InputLayoutFields.Any(f => f.SemanticName == "COLOR")))
             {
-                var defaultColor = new VertexDrawBuffer
-                {
-                    Handle = VectorOneVertexBuffer,
-                    ElementSizeInBytes = 0, // required for the singular attribute to apply to all vertices
-                    InputLayoutFields =
-                    [
-                        new VBIB.RenderInputLayoutField
-                        {
-                            SemanticName = "COLOR",
-                            Format = DXGI_FORMAT.R32G32B32A32_FLOAT,
-                        },
-                    ],
-                };
-
-                vertexBuffers = [.. vertexBuffers, defaultColor];
+                GL.VertexAttrib4(colorAttributeLocation, 1f, 1f, 1f, 1f);
             }
-
-            return vertexBuffers;
         }
 
         private static void BindVertexAttrib(int vao, VBIB.RenderInputLayoutField attribute, int attributeLocation, int offset, int bindingIndex)

--- a/Renderer/Renderer/RenderableMesh.cs
+++ b/Renderer/Renderer/RenderableMesh.cs
@@ -372,17 +372,16 @@ namespace ValveResourceFormat.Renderer
                 var indexBufferObject = objectDrawCall.GetSubCollection("m_indexBuffer");
                 var bufferIndex = indexBufferObject.GetUInt32Property("m_hBuffer");
                 var indexBindOffset = indexBufferObject.GetUInt32Property("m_nBindOffsetBytes");
-                Debug.Assert(indexBindOffset == 0, "Non-zero index buffer bind offset is not currently applied at draw time");
 
                 var indexBuffer = new IndexDrawBuffer
                 {
                     Handle = gpuVbib.IndexBuffers[(int)bufferIndex],
-                    Offset = indexBindOffset
+                    Offset = indexBindOffset,
                 };
                 drawCall.IndexBuffer = indexBuffer;
 
                 var indexElementSize = vbib.IndexBuffers[(int)bufferIndex].ElementSizeInBytes;
-                drawCall.StartIndex = (nint)(objectDrawCall.GetUInt32Property("m_nStartIndex") * indexElementSize);
+                drawCall.StartIndex = (nint)(indexBindOffset + (objectDrawCall.GetUInt32Property("m_nStartIndex") * indexElementSize));
                 drawCall.IndexCount = objectDrawCall.GetInt32Property("m_nIndexCount");
 
                 drawCall.IndexType = indexElementSize switch
@@ -447,7 +446,6 @@ namespace ValveResourceFormat.Renderer
                     }
 
                     var vertexBindOffset = vertexBufferObject.GetUInt32Property("m_nBindOffsetBytes");
-                    Debug.Assert(vertexBindOffset == 0, "Non-zero vertex buffer bind offset is not currently applied at draw time");
 
                     var vertexBuffer = new VertexDrawBuffer
                     {

--- a/Renderer/Renderer/Shaders/Shader.cs
+++ b/Renderer/Renderer/Shaders/Shader.cs
@@ -109,17 +109,24 @@ namespace ValveResourceFormat.Renderer.Shaders
         private unsafe void StoreUniformLocations()
         {
             Span<float> floatVal = stackalloc float[16];
+            var nextTextureSlot = (int)ReservedTextureSlots.Last + 1;
 
             // Stores uniform types and locations
             var uniforms = GetAllUniformNames();
 
             // Stores uniform values
-            foreach (var uniform in uniforms)
+            foreach (var activeUniform in uniforms)
             {
-                var name = uniform.Name;
-                var type = uniform.Type;
-                var index = uniform.Index;
-                var size = uniform.Size;
+                var name = activeUniform.Name;
+                var type = activeUniform.Type;
+                var index = activeUniform.Index;
+                var size = activeUniform.Size;
+                var isTexture = IsSamplerType(type);
+
+                if (isTexture && Uniforms.TryGetValue(name, out var cachedUniform))
+                {
+                    SetInitialTextureSlots(name, cachedUniform.Location, size, ref nextTextureSlot);
+                }
 
                 if (!name.StartsWith("g_", StringComparison.Ordinal) && !name.StartsWith("F_", StringComparison.Ordinal))
                 {
@@ -131,7 +138,6 @@ namespace ValveResourceFormat.Renderer.Shaders
                     continue;
                 }
 
-                var isTexture = type is >= ActiveUniformType.Sampler2D and <= ActiveUniformType.SamplerCube;
                 var isVector = type is >= ActiveUniformType.FloatVec2 and <= ActiveUniformType.IntVec4;
                 var isScalar = type == ActiveUniformType.Float;
                 var isBoolean = type == ActiveUniformType.Bool;
@@ -199,6 +205,95 @@ namespace ValveResourceFormat.Renderer.Shaders
                     );
                 }
             }
+        }
+
+        private static bool IsSamplerType(ActiveUniformType type) => type.ToString().Contains("Sampler", StringComparison.Ordinal);
+
+        private void SetInitialTextureSlots(string name, int location, int size, ref int nextTextureSlot)
+        {
+            if (size <= 1)
+            {
+                GL.ProgramUniform1(Program, location, GetInitialTextureSlot(name, ref nextTextureSlot));
+                return;
+            }
+
+            var slots = new int[size];
+            for (var i = 0; i < slots.Length; i++)
+            {
+                slots[i] = GetInitialTextureSlot($"{name}[{i}]", ref nextTextureSlot);
+            }
+
+            GL.ProgramUniform1(Program, location, slots.Length, slots);
+        }
+
+        private static int GetInitialTextureSlot(string name, ref int nextTextureSlot)
+        {
+            if (name.Contains("BRDFLookup", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BRDFLookup;
+            }
+            if (name.Contains("BlueNoise", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BlueNoise;
+            }
+            if (name.Contains("FogCubeTexture", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.FogCubeTexture;
+            }
+            if (name.Contains("ShadowDepthBufferDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.ShadowDepthBufferDepth;
+            }
+            if (name.Contains("BarnLightShadowDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.BarnLightShadowDepth;
+            }
+            if (name.Contains("EnvironmentMap", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.EnvironmentMap;
+            }
+            if (name.Contains("LPV_Irradiance", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe1;
+            }
+            if (name.Contains("LPV_Indices", StringComparison.OrdinalIgnoreCase) || name.Contains("LPV_Shadows", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe2;
+            }
+            if (name.Contains("LPV_Scalars", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.Probe3;
+            }
+            if (name.Contains("LightCookieTextureWrap", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.LightCookieTextureWrap;
+            }
+            if (name.Contains("LightCookieTexture", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.LightCookieTexture;
+            }
+            if (name.Contains("SceneColor", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneColor;
+            }
+            if (name.Contains("SceneDepth", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneDepth;
+            }
+            if (name.Contains("SceneStencil", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.SceneStencil;
+            }
+            if (name.Contains("DepthPyramid", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.DepthPyramid;
+            }
+            if (name.Contains("Morph", StringComparison.OrdinalIgnoreCase))
+            {
+                return (int)ReservedTextureSlots.MorphCompositeTexture;
+            }
+
+            return nextTextureSlot++;
         }
 
         /// <summary>Installs this shader program as part of the current rendering state.</summary>


### PR DESCRIPTION
This pulls the renderer-only changes out of #1192. There are no Linux UI changes in this branch.

The changes are:

- Apply `m_nBindOffsetBytes` when binding vertex buffers and calculating the index start offset.
- Include the complete vertex-buffer binding in the VAO cache key so draw calls using different offsets do not reuse the wrong VAO.
- Use a constant white value when a shader expects `vCOLOR` but the mesh has no color stream. The previous one-element buffer advanced once per vertex.
- Initialize active sampler uniforms to their reserved or material texture units. This avoids different sampler types all starting on texture unit 0 before their textures are bound.
- Treat all OpenGL sampler types as textures, including arrays, cube, shadow, and integer samplers.

These fixed blank or incomplete models and map entities seen while loading CS2 assets. The buffer-offset changes also replace the zero-offset debug assertions currently on `master`.

Tested with:

- `dotnet format Renderer/Renderer.csproj --verify-no-changes --no-restore`
- `dotnet build Renderer/Renderer.csproj --configuration Release --no-restore`
- `dotnet test Tests/Tests.csproj --configuration Release --no-restore` (275 passed, 2 skipped because local sample game data was unavailable)
