### PR TITLE
Apply scene object transform to decompiled hammer meshes

### DIFF
--- a/ValveResourceFormat/IO/HammerMeshBuilder.cs
+++ b/ValveResourceFormat/IO/HammerMeshBuilder.cs
@@ -647,7 +647,7 @@ namespace ValveResourceFormat.IO
             return mesh;
         }
 
-        public void AddVertices(VertexStreams streams, Vector3 positionOffset)
+        public void AddVertices(VertexStreams streams, Vector3 positionOffset = new Vector3())
         {
             vertexStreams = streams;
 
@@ -1228,13 +1228,20 @@ namespace ValveResourceFormat.IO
             }
         }
 
-        public void AddRenderMesh(DmeMesh shape, Vector3 positionOffset)
+        public void AddRenderMesh(DmeMesh shape, Matrix4x4 transform)
         {
             var facesets = shape.FaceSets;
 
             var vertexdata = (DmeVertexData)shape.BaseStates[0];
 
             var baseVertex = Vertices.Count;
+
+            var hasTransform = !transform.IsIdentity;
+            var normalMatrix = Matrix4x4.Identity;
+            if (hasTransform && Matrix4x4.Invert(transform, out var inverse))
+            {
+                normalMatrix = Matrix4x4.Transpose(inverse);
+            }
 
             var positions = GetElementArraySafe<Vector3>(vertexdata, "position$0");
             var texcoords = GetElementArraySafe<Vector2>(vertexdata, "texcoord$0");
@@ -1347,6 +1354,11 @@ namespace ValveResourceFormat.IO
                 }
             }
 
+            if (hasTransform)
+            {
+                TransformVertexStreams(newVertices, newNormals, newTangents, transform, normalMatrix);
+            }
+
             VertexStreams streams = new()
             {
                 positions = newVertices,
@@ -1358,11 +1370,31 @@ namespace ValveResourceFormat.IO
                 VertexPaintTintColor = newVertexPaintTintColor,
             };
 
-            AddVertices(streams, positionOffset);
+            AddVertices(streams);
 
             foreach (var face in faceList)
             {
                 AddFace(CollectionsMarshal.AsSpan(face.Item1), face.Item2.Material.MaterialName);
+            }
+        }
+
+        private static void TransformVertexStreams(List<Vector3> positions, List<Vector3> normals, List<Vector4> tangents, Matrix4x4 transform, Matrix4x4 normalMatrix)
+        {
+            for (var i = 0; i < positions.Count; i++)
+            {
+                positions[i] = Vector3.Transform(positions[i], transform);
+            }
+
+            for (var i = 0; i < normals.Count; i++)
+            {
+                normals[i] = Vector3.Normalize(Vector3.TransformNormal(normals[i], normalMatrix));
+            }
+
+            for (var i = 0; i < tangents.Count; i++)
+            {
+                var tangent = tangents[i];
+                var direction = Vector3.Normalize(Vector3.TransformNormal(new Vector3(tangent.X, tangent.Y, tangent.Z), transform));
+                tangents[i] = new Vector4(direction, tangent.W);
             }
         }
 

--- a/ValveResourceFormat/IO/MapExtract.cs
+++ b/ValveResourceFormat/IO/MapExtract.cs
@@ -586,7 +586,7 @@ public sealed class MapExtract
         EntitiesSelectionSet = S2VSelectionSet.Children.AddReturn(new CMapSelectionSet("Entities"));
     }
 
-    internal List<CMapMesh> RenderMeshToHammerMesh(Model model, Resource resource, Vector3 offset = new Vector3(), string? entityClassname = null)
+    internal List<CMapMesh> RenderMeshToHammerMesh(Model model, Resource resource, string? entityClassname = null, Matrix4x4? transform = null)
     {
         List<CMapMesh> hammerMeshesToReturn = [];
 
@@ -594,6 +594,8 @@ public sealed class MapExtract
         {
             return hammerMeshesToReturn;
         }
+
+        var meshTransform = transform ?? Matrix4x4.Identity;
 
         var modelExtract = new ModelExtract(resource, FileLoader);
         modelExtract.GrabMaterialInputSignatures(resource);
@@ -624,7 +626,7 @@ public sealed class MapExtract
                 };
                 if (dag.Shape is DmeMesh meshShape)
                 {
-                    builder.AddRenderMesh(meshShape, offset);
+                    builder.AddRenderMesh(meshShape, meshTransform);
                 }
                 var hammerMesh = new CMapMesh() { MeshData = builder.GenerateMesh() };
 
@@ -908,6 +910,8 @@ public sealed class MapExtract
 
             FolderExtractFilter.Add(modelName ?? meshName);
 
+            var objectTransform = sceneObject.GetArray("m_vTransform").ToMatrix4x4();
+
             if (SceneObjectShouldConvertToHammerMesh(modelName))
             {
                 var meshNameCompiled = modelName + GameFileLoader.CompiledFileSuffix;
@@ -919,8 +923,27 @@ public sealed class MapExtract
                 }
 
                 var model = (Model)mesh.DataBlock;
-                foreach (var hammermesh in RenderMeshToHammerMesh(model, mesh))
+
+                // Source 2 bakes a mesh's scale into its vertices, so bake it here and keep only origin/angles on the node.
+                var meshOrigin = Vector3.Zero;
+                var meshAngles = new Datamodel.QAngle();
+                var scaleTransform = Matrix4x4.Identity;
+                if (!objectTransform.IsIdentity)
                 {
+                    if (!Matrix4x4.Decompose(objectTransform, out var scales, out var rotation, out var translation))
+                    {
+                        throw new InvalidOperationException("Matrix decompose failed");
+                    }
+
+                    meshOrigin = translation;
+                    meshAngles = ModelExtract.ToEulerAngles(rotation);
+                    scaleTransform = Matrix4x4.CreateScale(scales);
+                }
+
+                foreach (var hammermesh in RenderMeshToHammerMesh(model, mesh, transform: scaleTransform))
+                {
+                    hammermesh.Origin = meshOrigin;
+                    hammermesh.Angles = meshAngles;
                     MapDocument.World.Children.Add(hammermesh);
                 }
                 return;
@@ -936,7 +959,6 @@ public sealed class MapExtract
                 .WithClassName("prop_static")
                 .WithProperty("model", modelName!);
 
-            var objectTransform = sceneObject.GetArray("m_vTransform").ToMatrix4x4();
             if (!objectTransform.IsIdentity)
             {
                 if (!Matrix4x4.Decompose(objectTransform, out var scales, out var rotation, out var translation))
@@ -1388,7 +1410,7 @@ public sealed class MapExtract
             }
             else
             {
-                foreach (var hammermesh in RenderMeshToHammerMesh(data, model, offset, associatedEntityClass))
+                foreach (var hammermesh in RenderMeshToHammerMesh(data, model, associatedEntityClass, Matrix4x4.CreateTranslation(offset)))
                 {
                     mapEntity.Children.Add(hammermesh);
                 }


### PR DESCRIPTION
Fixes #895

Scene objects that get converted to a Hammer mesh (instead of a prop_static) were exported without their transform. Not just the scale/orientation, the whole transform was dropped, so these meshes ended up at 0, 0, 0. Most visible on de_train. The renderer placed them correctly from the scene object's m_vTransform already, only the map export ignored it.

Pretty rare in practice: across all official CS2 maps only 50 baked hammer-meshes have a non-identity transform (all others have an identity transform). 28 of those are on train, 10 on alpine, 10 on warden and 2 on italy. Every other official map is unaffected.