### PR TITLE
Fix light_environment sun direction in glTF export

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.cs
@@ -422,24 +422,26 @@ namespace ValveResourceFormat.IO
                     // TODO: Add point and spot lights
                     if (className == "light_environment")
                     {
-                        if (!Matrix4x4.Decompose(transform, out var scale, out var _, out var positionVector))
+                        if (!Matrix4x4.Decompose(transform, out var _, out var _, out var positionVector))
                         {
                             throw new InvalidOperationException("Matrix decompose failed");
                         }
 
-                        var pitchYawRoll = entity.GetVector3Property("angles");
-                        var rollMatrix = Matrix4x4.CreateRotationX(float.DegreesToRadians(pitchYawRoll.Z));
-                        var pitchMatrix = Matrix4x4.CreateRotationY(float.DegreesToRadians(pitchYawRoll.X - 90)); // copypasta because of this
-                        var yawMatrix = Matrix4x4.CreateRotationZ(float.DegreesToRadians(pitchYawRoll.Y));
-                        var rotationMatrix = rollMatrix * pitchMatrix * yawMatrix;
+                        // glTF directional lights emit along node-local -Z; orient the node so that
+                        // -Z matches the sun's forward (travel) direction, i.e. the entity's local +X.
+                        var rotation = EntityTransformHelper.CreateRotationMatrixFromEulerAngles(entity.GetVector3Property("angles"));
+                        var direction = Vector3.Transform(Vector3.UnitX, rotation);
 
-                        var scaleMatrix = Matrix4x4.CreateScale(scale);
-                        var positionMatrix = Matrix4x4.CreateTranslation(positionVector);
-                        var lightMatrix = scaleMatrix * rotationMatrix * positionMatrix;
+                        var directionGltf = Vector3.Transform(direction, SourceToGltfRotation);
+                        var positionGltf = Vector3.Transform(positionVector, TransformSourceToGltf);
+
+                        // 'up' only anchors the meaningless roll around the beam, but CreateWorld degenerates
+                        // when it is parallel to the direction, so for a near-vertical sun (along Y) use Z instead.
+                        var up = MathF.Abs(directionGltf.Y) > 0.999f ? Vector3.UnitZ : Vector3.UnitY;
 
                         var node = scene.CreateNode(className);
                         node.PunctualLight = CreateGltfLightEnvironment(exportedModel, entity);
-                        node.LocalMatrix = lightMatrix * TransformSourceToGltf;
+                        node.LocalMatrix = Matrix4x4.CreateWorld(positionGltf, directionGltf, up);
                     }
                     else if (className == "point_template")
                     {


### PR DESCRIPTION
The exported sun used the entity's roll for its direction, so suns with roll came out tilted. Too much roll flipped them to shine up from under the map. The direction now depends only on pitch/yaw. Roll is the twist/rotation around the beam, which is meaningless for a directional light (the sun in this case), so it should be ignored.

sun_test vpk with the values the reporter provided:
[sun_test.zip](https://github.com/user-attachments/files/29225774/sun_test.zip)
