### PR TITLE
Increase svg to png export resolution

### DIFF
--- a/GUI/Forms/SvgExportForm.cs
+++ b/GUI/Forms/SvgExportForm.cs
@@ -236,5 +236,20 @@ namespace GUI.Forms
             var scale = longEdge / SourceLongEdge;
             return ((int)(sourceWidth * scale), (int)(sourceHeight * scale));
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                formatComboBox.Dispose();
+                presetComboBox.Dispose();
+                customNumeric.Dispose();
+                resolutionLabel.Dispose();
+                customRow.Dispose();
+                outputLabel.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/GUI/Forms/SvgExportForm.cs
+++ b/GUI/Forms/SvgExportForm.cs
@@ -33,12 +33,15 @@ namespace GUI.Forms
 
         public SvgExportFormat SelectedFormat => formats[formatComboBox.SelectedIndex];
 
+        // Guard against a degenerate zero-size svg so the scale math never divides by zero.
+        private float SourceLongEdge => MathF.Max(MathF.Max(sourceWidth, sourceHeight), 1f);
+
         /// <summary>The scale to rasterize at, relative to the svg's native resolution (1 = native).</summary>
-        public float SelectedScale => ChosenLongEdge / MathF.Max(sourceWidth, sourceHeight);
+        public float SelectedScale => ChosenLongEdge / SourceLongEdge;
 
         private float ChosenLongEdge => itemLongEdges[presetComboBox.SelectedIndex] switch
         {
-            0 => MathF.Max(sourceWidth, sourceHeight),
+            0 => SourceLongEdge,
             -1 => customNumeric.Value,
             var longEdge => longEdge,
         };
@@ -63,7 +66,8 @@ namespace GUI.Forms
             AutoSizeMode = AutoSizeMode.GrowAndShrink;
 
             var nativeLongEdge = (int)MathF.Ceiling(MathF.Max(sourceWidth, sourceHeight));
-            var minLongEdge = Math.Min(nativeLongEdge, 8192);
+            var minLongEdge = nativeLongEdge;
+            var maxLongEdge = Math.Max(nativeLongEdge, 8192);
 
             formatComboBox = MakeComboBox();
             foreach (var (format, label) in BuildFormats(canExportSvg))
@@ -96,9 +100,9 @@ namespace GUI.Forms
             customNumeric = new ThemedIntNumeric
             {
                 MinValue = minLongEdge,
-                MaxValue = 8192,
+                MaxValue = maxLongEdge,
                 Increment = 1,
-                Value = Math.Clamp(1024, minLongEdge, 8192),
+                Value = Math.Clamp(1024, minLongEdge, maxLongEdge),
                 Width = 72,
                 Margin = new Padding(0, 0, 8, 0),
             };
@@ -150,8 +154,10 @@ namespace GUI.Forms
                 Anchor = AnchorStyles.Right,
                 Margin = new Padding(0, 18, 0, 0),
             };
-            buttonRow.Controls.Add(MakeButton("Save", DialogResult.OK, out var saveButton));
-            buttonRow.Controls.Add(MakeButton("Cancel", DialogResult.Cancel, out var cancelButton));
+            var saveButton = MakeButton("Save", DialogResult.OK);
+            var cancelButton = MakeButton("Cancel", DialogResult.Cancel);
+            buttonRow.Controls.Add(saveButton);
+            buttonRow.Controls.Add(cancelButton);
 
             layout.Controls.Add(buttonRow, 0, 4);
             layout.SetColumnSpan(buttonRow, 2);
@@ -191,17 +197,13 @@ namespace GUI.Forms
             Margin = new Padding(0, 0, 12, 0),
         };
 
-        private static ThemedButton MakeButton(string text, DialogResult result, out ThemedButton button)
+        private static ThemedButton MakeButton(string text, DialogResult result) => new()
         {
-            button = new ThemedButton
-            {
-                Text = text,
-                DialogResult = result,
-                Size = new Size(90, 30),
-                Margin = new Padding(8, 0, 0, 0),
-            };
-            return button;
-        }
+            Text = text,
+            DialogResult = result,
+            Size = new Size(90, 30),
+            Margin = new Padding(8, 0, 0, 0),
+        };
 
         private void OnFormatChanged(object? sender, EventArgs e) => UpdateResolutionVisibility();
 
@@ -231,23 +233,8 @@ namespace GUI.Forms
         // Output dimensions when the svg is scaled so its long edge becomes longEdge, preserving aspect ratio.
         private (int Width, int Height) DimensionsForLongEdge(float longEdge)
         {
-            var scale = longEdge / MathF.Max(sourceWidth, sourceHeight);
-            return ((int)MathF.Round(sourceWidth * scale), (int)MathF.Round(sourceHeight * scale));
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                formatComboBox.Dispose();
-                presetComboBox.Dispose();
-                customNumeric.Dispose();
-                resolutionLabel.Dispose();
-                customRow.Dispose();
-                outputLabel.Dispose();
-            }
-
-            base.Dispose(disposing);
+            var scale = longEdge / SourceLongEdge;
+            return ((int)(sourceWidth * scale), (int)(sourceHeight * scale));
         }
     }
 }

--- a/GUI/Forms/SvgExportForm.cs
+++ b/GUI/Forms/SvgExportForm.cs
@@ -1,0 +1,253 @@
+using System.Drawing;
+using System.Windows.Forms;
+using GUI.Controls;
+
+namespace GUI.Forms
+{
+    public enum SvgExportFormat
+    {
+        Svg,
+        Png,
+        Jpg,
+    }
+
+    /// <summary>
+    /// Asks which format to export an svg as, and (for raster formats) the resolution to rasterize at.
+    /// The chosen resolution is a uniform scale that preserves aspect ratio.
+    /// </summary>
+    public sealed class SvgExportForm : ThemedForm
+    {
+        private static readonly int[] PresetLongEdges = [64, 128, 256, 512, 1024, 2048, 4096];
+
+        private readonly float sourceWidth;
+        private readonly float sourceHeight;
+        private readonly List<SvgExportFormat> formats = [];
+        // Long edge in pixels for each resolution item; 0 means the svg's native size, -1 means the custom field.
+        private readonly List<int> itemLongEdges = [];
+        private readonly ThemedComboBox formatComboBox;
+        private readonly ThemedComboBox presetComboBox;
+        private readonly ThemedIntNumeric customNumeric;
+        private readonly Label resolutionLabel;
+        private readonly FlowLayoutPanel customRow;
+        private readonly Label outputLabel;
+
+        public SvgExportFormat SelectedFormat => formats[formatComboBox.SelectedIndex];
+
+        /// <summary>The scale to rasterize at, relative to the svg's native resolution (1 = native).</summary>
+        public float SelectedScale => ChosenLongEdge / MathF.Max(sourceWidth, sourceHeight);
+
+        private float ChosenLongEdge => itemLongEdges[presetComboBox.SelectedIndex] switch
+        {
+            0 => MathF.Max(sourceWidth, sourceHeight),
+            -1 => customNumeric.Value,
+            var longEdge => longEdge,
+        };
+
+        public SvgExportForm(float sourceWidth, float sourceHeight, bool canExportSvg)
+        {
+            this.sourceWidth = sourceWidth;
+            this.sourceHeight = sourceHeight;
+
+            Text = "Export image";
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterParent;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            TopMost = true;
+            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleDimensions = new SizeF(7F, 17F);
+            Font = new Font("Segoe UI", 10F);
+            AutoSize = true;
+            AutoSizeMode = AutoSizeMode.GrowAndShrink;
+
+            var nativeLongEdge = (int)MathF.Ceiling(MathF.Max(sourceWidth, sourceHeight));
+            var minLongEdge = Math.Min(nativeLongEdge, 8192);
+
+            formatComboBox = MakeComboBox();
+            foreach (var (format, label) in BuildFormats(canExportSvg))
+            {
+                formats.Add(format);
+                formatComboBox.Items.Add(label);
+            }
+            // Default to SVG when available (lossless), otherwise PNG.
+            var defaultFormat = formats.Contains(SvgExportFormat.Svg) ? SvgExportFormat.Svg : SvgExportFormat.Png;
+            formatComboBox.SelectedIndex = formats.IndexOf(defaultFormat);
+
+            presetComboBox = MakeComboBox();
+            itemLongEdges.Add(0);
+            presetComboBox.Items.Add($"Original  ({(int)sourceWidth} × {(int)sourceHeight})");
+
+            foreach (var preset in PresetLongEdges)
+            {
+                if (preset > nativeLongEdge)
+                {
+                    itemLongEdges.Add(preset);
+                    var (width, height) = DimensionsForLongEdge(preset);
+                    presetComboBox.Items.Add($"{width} × {height}");
+                }
+            }
+
+            itemLongEdges.Add(-1);
+            presetComboBox.Items.Add("Custom…");
+            presetComboBox.SelectedIndex = 0;
+
+            customNumeric = new ThemedIntNumeric
+            {
+                MinValue = minLongEdge,
+                MaxValue = 8192,
+                Increment = 1,
+                Value = Math.Clamp(1024, minLongEdge, 8192),
+                Width = 72,
+                Margin = new Padding(0, 0, 8, 0),
+            };
+
+            customRow = new FlowLayoutPanel
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                FlowDirection = FlowDirection.LeftToRight,
+                WrapContents = false,
+                Margin = Padding.Empty,
+            };
+            customRow.Controls.Add(customNumeric);
+            customRow.Controls.Add(MakeFieldLabel("px (long edge)"));
+
+            resolutionLabel = MakeFieldLabel("Resolution:");
+            outputLabel = MakeFieldLabel(string.Empty);
+            outputLabel.Margin = new Padding(0, 10, 0, 0);
+
+            var layout = new TableLayoutPanel
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                ColumnCount = 2,
+                RowCount = 5,
+                Padding = new Padding(20, 18, 20, 14),
+            };
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            layout.ColumnStyles.Add(new ColumnStyle(SizeType.AutoSize));
+            for (var i = 0; i < layout.RowCount; i++)
+            {
+                layout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+            }
+
+            layout.Controls.Add(MakeFieldLabel("Format:"), 0, 0);
+            layout.Controls.Add(formatComboBox, 1, 0);
+            layout.Controls.Add(resolutionLabel, 0, 1);
+            layout.Controls.Add(presetComboBox, 1, 1);
+            layout.Controls.Add(customRow, 1, 2);
+            layout.Controls.Add(outputLabel, 0, 3);
+            layout.SetColumnSpan(outputLabel, 2);
+
+            var buttonRow = new FlowLayoutPanel
+            {
+                AutoSize = true,
+                AutoSizeMode = AutoSizeMode.GrowAndShrink,
+                FlowDirection = FlowDirection.RightToLeft,
+                WrapContents = false,
+                Anchor = AnchorStyles.Right,
+                Margin = new Padding(0, 18, 0, 0),
+            };
+            buttonRow.Controls.Add(MakeButton("Save", DialogResult.OK, out var saveButton));
+            buttonRow.Controls.Add(MakeButton("Cancel", DialogResult.Cancel, out var cancelButton));
+
+            layout.Controls.Add(buttonRow, 0, 4);
+            layout.SetColumnSpan(buttonRow, 2);
+
+            Controls.Add(layout);
+
+            AcceptButton = saveButton;
+            CancelButton = cancelButton;
+
+            formatComboBox.SelectedIndexChanged += OnFormatChanged;
+            presetComboBox.SelectedIndexChanged += OnPresetChanged;
+            // CustomTextChanged fires on every keystroke (and on drag); ValueChanged only fires on commit.
+            customNumeric.CustomTextChanged += (_, _) => UpdateOutputLabel();
+
+            UpdateResolutionVisibility();
+            UpdateOutputLabel();
+        }
+
+        private static (SvgExportFormat Format, string Label)[] BuildFormats(bool canExportSvg)
+            => canExportSvg
+                ? [(SvgExportFormat.Svg, "SVG (vector)"), (SvgExportFormat.Png, "PNG"), (SvgExportFormat.Jpg, "JPG")]
+                : [(SvgExportFormat.Png, "PNG"), (SvgExportFormat.Jpg, "JPG")];
+
+        private static ThemedComboBox MakeComboBox() => new()
+        {
+            DropDownStyle = ComboBoxStyle.DropDownList,
+            Width = 210,
+            Margin = new Padding(0, 4, 0, 4),
+            Anchor = AnchorStyles.Left,
+        };
+
+        private static Label MakeFieldLabel(string text) => new()
+        {
+            Text = text,
+            AutoSize = true,
+            Anchor = AnchorStyles.Left,
+            Margin = new Padding(0, 0, 12, 0),
+        };
+
+        private static ThemedButton MakeButton(string text, DialogResult result, out ThemedButton button)
+        {
+            button = new ThemedButton
+            {
+                Text = text,
+                DialogResult = result,
+                Size = new Size(90, 30),
+                Margin = new Padding(8, 0, 0, 0),
+            };
+            return button;
+        }
+
+        private void OnFormatChanged(object? sender, EventArgs e) => UpdateResolutionVisibility();
+
+        private void OnPresetChanged(object? sender, EventArgs e)
+        {
+            UpdateResolutionVisibility();
+            UpdateOutputLabel();
+        }
+
+        private void UpdateResolutionVisibility()
+        {
+            var isRaster = SelectedFormat != SvgExportFormat.Svg;
+            var isCustom = itemLongEdges[presetComboBox.SelectedIndex] == -1;
+
+            resolutionLabel.Visible = isRaster;
+            presetComboBox.Visible = isRaster;
+            outputLabel.Visible = isRaster;
+            customRow.Visible = isRaster && isCustom;
+        }
+
+        private void UpdateOutputLabel()
+        {
+            var (width, height) = DimensionsForLongEdge(ChosenLongEdge);
+            outputLabel.Text = $"Output: {width} × {height} px";
+        }
+
+        // Output dimensions when the svg is scaled so its long edge becomes longEdge, preserving aspect ratio.
+        private (int Width, int Height) DimensionsForLongEdge(float longEdge)
+        {
+            var scale = longEdge / MathF.Max(sourceWidth, sourceHeight);
+            return ((int)MathF.Round(sourceWidth * scale), (int)MathF.Round(sourceHeight * scale));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                formatComboBox.Dispose();
+                presetComboBox.Dispose();
+                customNumeric.Dispose();
+                resolutionLabel.Dispose();
+                customRow.Dispose();
+                outputLabel.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -687,7 +687,8 @@ namespace GUI.Types.GLViewers
 
             if (Svg?.Picture != null)
             {
-                using var svgBitmap = RasterizeSvg(Svg.Picture, OriginalWidth * TextureScale, OriginalHeight * TextureScale);
+                var (svgWidth, svgHeight) = GetSvgExportSize();
+                using var svgBitmap = RasterizeSvg(Svg.Picture, svgWidth, svgHeight);
                 using var pixmap = svgBitmap.PeekPixels();
                 pixmap.Encode(fs, format, 100);
                 return;
@@ -703,7 +704,8 @@ namespace GUI.Types.GLViewers
         {
             if (Svg?.Picture != null)
             {
-                return RasterizeSvg(Svg.Picture, OriginalWidth * TextureScale, OriginalHeight * TextureScale);
+                var (svgWidth, svgHeight) = GetSvgExportSize();
+                return RasterizeSvg(Svg.Picture, svgWidth, svgHeight);
             }
 
             return ReadPixelsToBitmap(hdr: false);
@@ -1238,22 +1240,30 @@ namespace GUI.Types.GLViewers
             InvalidateRender();
         }
 
+        /// <summary>
+        /// Computes the export dimensions for an svg: the long edge is rounded up to the
+        /// nearest power of two within [1024, 4096], the short edge scales proportionally.
+        /// </summary>
+        private (float Width, float Height) GetSvgExportSize()
+        {
+            // TODO: let the user pick an explicit export resolution when the save UI is reworked.
+            // Never export below the svg's native resolution, even when zoomed out to fit the viewport.
+            var exportScale = MathF.Max(1f, TextureScale);
+            var longEdge = (int)MathF.Ceiling(MathF.Max(OriginalWidth, OriginalHeight) * exportScale);
+            longEdge = Math.Clamp(longEdge, 1024, 4096);
+            var target = (int)BitOperations.RoundUpToPowerOf2((uint)longEdge);
+            var scale = target / MathF.Max(OriginalWidth, OriginalHeight);
+            return (MathF.Round(OriginalWidth * scale), MathF.Round(OriginalHeight * scale));
+        }
+
         private static SKBitmap RasterizeSvg(SKPicture picture, float width, float height)
         {
             var imageInfo = new SKImageInfo((int)width, (int)height, SKColorType.Bgra8888, SKAlphaType.Premul, null);
             var bitmap = new SKBitmap(imageInfo);
 
             using var canvas = new SKCanvas(bitmap);
-            var scaleX = width / picture.CullRect.Width;
-            var scaleY = height / picture.CullRect.Height;
-            canvas.Scale(scaleX, scaleY);
-
-            using var paint = new SKPaint
-            {
-                IsAntialias = true,
-            };
-
-            canvas.DrawPicture(picture, paint);
+            canvas.Scale(width / picture.CullRect.Width, height / picture.CullRect.Height);
+            canvas.DrawPicture(picture);
 
             return bitmap;
         }

--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using GUI.Controls;
+using GUI.Forms;
 using GUI.Utils;
 using OpenTK.Graphics.OpenGL;
 using SkiaSharp;
@@ -621,25 +622,27 @@ namespace GUI.Types.GLViewers
                 return;
             }
 
+            var fileName = (Resource != null
+                ? Path.GetFileNameWithoutExtension(Resource.FileName)
+                : Path.GetFileNameWithoutExtension(VrfGuiContext.FileName)) ?? string.Empty;
+
+            // The svg export picks format (and raster resolution) up front, before the file dialog.
+            if (Svg?.Picture != null)
+            {
+                SaveSvg(fileName);
+                return;
+            }
+
             var filter = "PNG Image|*.png|JPG Image|*.jpg";
             var alternativeImageFormatIndex = 2;
 
             var isHdrTexture = Resource?.DataBlock is Texture textureData && textureData.IsHighDynamicRange;
 
-            if (Svg != null)
-            {
-                filter = $"SVG (Scalable Vector Graphics)|*.svg|{filter}";
-                alternativeImageFormatIndex++;
-            }
-            else if (isHdrTexture)
+            if (isHdrTexture)
             {
                 filter = "EXR Image|*.exr|" + filter;
                 alternativeImageFormatIndex++;
             }
-
-            var fileName = Resource != null
-                ? Path.GetFileNameWithoutExtension(Resource.FileName)
-                : Path.GetFileNameWithoutExtension(VrfGuiContext.FileName);
 
             using var saveFileDialog = new SaveFileDialog
             {
@@ -663,12 +666,6 @@ namespace GUI.Types.GLViewers
 
             using var fs = saveFileDialog.OpenFile();
 
-            if (Svg != null && saveFileDialog.FilterIndex == 1 && Resource?.DataBlock is Panorama panoramaData)
-            {
-                fs.Write(panoramaData.Data);
-                return;
-            }
-
             if (isHdrTexture && saveFileDialog.FilterIndex == 1)
             {
                 using var hdrBitmap = ReadPixelsToBitmap(hdr: true);
@@ -685,19 +682,63 @@ namespace GUI.Types.GLViewers
                     break;
             }
 
-            if (Svg?.Picture != null)
-            {
-                var (svgWidth, svgHeight) = GetSvgExportSize();
-                using var svgBitmap = RasterizeSvg(Svg.Picture, svgWidth, svgHeight);
-                using var pixmap = svgBitmap.PeekPixels();
-                pixmap.Encode(fs, format, 100);
-                return;
-            }
-
             // TODO: nonpow2 sizes?
             using var bitmap = ReadPixelsToBitmap();
             using var bitmapPixmap = bitmap.PeekPixels();
             bitmapPixmap.Encode(fs, format, 100);
+        }
+
+        private void SaveSvg(string fileName)
+        {
+            Debug.Assert(Svg?.Picture != null);
+
+            using var exportForm = new SvgExportForm(OriginalWidth, OriginalHeight, Resource?.DataBlock is Panorama);
+            if (exportForm.ShowDialog(UiControl) != DialogResult.OK)
+            {
+                return;
+            }
+
+            var (filter, extension) = exportForm.SelectedFormat switch
+            {
+                SvgExportFormat.Svg => ("SVG (Scalable Vector Graphics)|*.svg", "svg"),
+                SvgExportFormat.Jpg => ("JPG Image|*.jpg", "jpg"),
+                _ => ("PNG Image|*.png", "png"),
+            };
+
+            using var saveFileDialog = new SaveFileDialog
+            {
+                InitialDirectory = Settings.Config.SaveDirectory,
+                Filter = filter,
+                Title = "Save an Image File",
+                FileName = $"{fileName}.{extension}",
+                AddToRecent = true,
+            };
+
+            if (saveFileDialog.ShowDialog(UiControl) != DialogResult.OK)
+            {
+                return;
+            }
+
+            var directory = Path.GetDirectoryName(saveFileDialog.FileName);
+            if (directory != null)
+            {
+                Settings.Config.SaveDirectory = directory;
+            }
+
+            using var fs = saveFileDialog.OpenFile();
+
+            if (exportForm.SelectedFormat == SvgExportFormat.Svg && Resource?.DataBlock is Panorama panoramaData)
+            {
+                fs.Write(panoramaData.Data);
+                return;
+            }
+
+            var scale = exportForm.SelectedScale;
+            var format = exportForm.SelectedFormat == SvgExportFormat.Jpg ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png;
+
+            using var svgBitmap = RasterizeSvg(Svg.Picture, OriginalWidth * scale, OriginalHeight * scale);
+            using var pixmap = svgBitmap.PeekPixels();
+            pixmap.Encode(fs, format, 100);
         }
 
         protected override SKBitmap ReadPixelsToBitmap()
@@ -1241,12 +1282,12 @@ namespace GUI.Types.GLViewers
         }
 
         /// <summary>
-        /// Computes the export dimensions for an svg: the long edge is rounded up to the
-        /// nearest power of two within [1024, 4096], the short edge scales proportionally.
+        /// Auto export dimensions for an svg, used when copying to the clipboard: the long edge is rounded
+        /// up to the nearest power of two within [1024, 4096], the short edge scales proportionally. Saving
+        /// to a file instead asks the user for an explicit multiple of the native resolution.
         /// </summary>
         private (float Width, float Height) GetSvgExportSize()
         {
-            // TODO: let the user pick an explicit export resolution when the save UI is reworked.
             // Never export below the svg's native resolution, even when zoomed out to fit the viewport.
             var exportScale = MathF.Max(1f, TextureScale);
             var longEdge = (int)MathF.Ceiling(MathF.Max(OriginalWidth, OriginalHeight) * exportScale);


### PR DESCRIPTION
Fixes #982

When exporting vsvg files to png they came out aliased. The cause isn't missing anti-aliasing though, because Svg.Skia already applies AA by default (https://github.com/wieslawsoltes/Svg.Skia/blob/v5.0.0/src/Svg.Model/Services/PaintingService.cs#L640). So the "aliasing" is just a symptom of low resolution on the export. That's why, instead of saving the SVG at exactly the size it's rendered at in the viewer, I floored the export at 1024 (if you export an SVG as PNG I don't think we have to be economical with the resolution, since that conversion is inefficient in itself anyway - files are still only a few kB).

Also the DrawPicture call had a no-op IsAntialias = true. When a paint is passed to DrawPicture this flag is not used.

Exports now rasterize at a resolution derived from the native size scaled by the current zoom in the viewer, rounded up to the nearest power of two and clamped to 1024 - 4096. So effectively there are three export resolutions now: 1024, 2048 or 4096.

In the future it would make most sense for the user to select it manually (instead of it being derived from the zoom level), but I think that makes more sense as part of the GUI rework. 

I also tried some stuff like supersampling, etc. but everything looks worse than what Skia does by default.