### PR TITLE
Select correct range on shift-click in the package list

### DIFF
--- a/GUI/Types/PackageViewer/BetterListView.cs
+++ b/GUI/Types/PackageViewer/BetterListView.cs
@@ -30,6 +30,18 @@ namespace GUI.Types.PackageViewer
 
         protected override void WndProc(ref Message m)
         {
+            const int WM_LBUTTONDOWN = 0x0201;
+
+            // On Shift+click, range-select from the anchor in reading order instead of the native 2D region.
+            if (m.Msg == WM_LBUTTONDOWN
+                && (ModifierKeys & (Keys.Shift | Keys.Control)) == Keys.Shift
+                && FocusedItem != null
+                && HitTest(PointToClient(Cursor.Position)).Item is { } clicked)
+            {
+                SelectIndexRange(FocusedItem.Index, clicked.Index);
+                return;
+            }
+
             base.WndProc(ref m);
             if (m.Msg == PInvoke.WM_VSCROLL)
             {
@@ -43,6 +55,27 @@ namespace GUI.Types.PackageViewer
                     ScrollEventType.EndScroll,
                     0 // no idea how to get scroll pos
                 ));
+            }
+        }
+
+        private void SelectIndexRange(int a, int b)
+        {
+            var min = Math.Min(a, b);
+            var max = Math.Max(a, b);
+
+            BeginUpdate();
+            try
+            {
+                SelectedIndices.Clear();
+
+                for (var i = min; i <= max; i++)
+                {
+                    SelectedIndices.Add(i);
+                }
+            }
+            finally
+            {
+                EndUpdate();
             }
         }
 


### PR DESCRIPTION
The native selection in the list view does not work properly. When shift-click selecting from e.g. `ctm_fbi_variantf (directory)` to `ctm_fbi_variantf (vmdl)` it incorrectly select rows to the left of the directory in the upper row and to the right of the bottom row.

Default behaviour:
<img width="1739" height="477" alt="incorrect" src="https://github.com/user-attachments/assets/83dbdd76-efb0-41cc-8d21-7ea8e7cf6d38" />

Correct behaviour:
<img width="1739" height="482" alt="correct" src="https://github.com/user-attachments/assets/91a08c17-9fbc-4a41-a448-81758307a97f" />
