### PR TITLE
Export lip-sync phonemes (vsnd) to source text

### DIFF
--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -776,6 +776,10 @@ namespace GUI.Types.Viewers
         {
             switch (resource.ResourceType)
             {
+                case ResourceType.Sound when resource.DataBlock is Sound { Sentence: { } sentence }:
+                    IViewer.AddContentTab(resTabs, "Reconstructed phonemes", sentence.ToValveSentence());
+                    break;
+
                 case ResourceType.Material:
                     var vmatTab = IViewer.AddContentTab(resTabs, "Reconstructed vmat", new MaterialExtract(resource, vrfGuiContext).ToValveMaterial);
                     break;

--- a/Tests/SoundTest.cs
+++ b/Tests/SoundTest.cs
@@ -36,6 +36,43 @@ namespace Tests
         }
 
         [Test]
+        public void TestSentenceExport()
+        {
+            var sentence = new Sentence
+            {
+                RunTimePhonemes =
+                [
+                    new PhonemeTag { StartTime = 0f, EndTime = 0.048f, PhonemeCode = 240 },
+                    new PhonemeTag { StartTime = 0.048f, EndTime = 0.1f, PhonemeCode = 115 },
+                ]
+            };
+
+            var expected = string.Join('\n',
+                "VERSION 1.0",
+                "PLAINTEXT",
+                "{",
+                "}",
+                "WORDS",
+                "{",
+                "\tWORD ðs 0.000 0.100",
+                "\t{",
+                "\t\t240 ð 0.000 0.048 1",
+                "\t\t115 s 0.048 0.100 1",
+                "\t}",
+                "}",
+                "EMPHASIS",
+                "{",
+                "}",
+                "OPTIONS",
+                "{",
+                "\tvoice_duck 0",
+                "}",
+                "");
+
+            Assert.That(sentence.ToValveSentence(), Is.EqualTo(expected));
+        }
+
+        [Test]
         public void TestSoundNoFileName()
         {
             var file = Path.Combine(TestContext.CurrentContext.TestDirectory, "Files", "beep.vsnd_c");

--- a/ValveResourceFormat/IO/FileExtract.cs
+++ b/ValveResourceFormat/IO/FileExtract.cs
@@ -209,6 +209,16 @@ namespace ValveResourceFormat.IO
                         soundStream.TryGetBuffer(out var buffer);
                         contentFile.Data = [.. buffer];
 
+                        // Lip-sync phoneme data; the compiler bakes this back in when the txt sits next to the source sound.
+                        if (soundData.Sentence != null)
+                        {
+                            contentFile.AdditionalFiles.Add(new ContentFile
+                            {
+                                FileName = Path.ChangeExtension(resource.FileName, "txt") ?? "exported.txt",
+                                Data = Encoding.UTF8.GetBytes(soundData.Sentence.ToValveSentence())
+                            });
+                        }
+
                         // TODO: Refactor this into a SoundExtract?
                         if (resource.GetBlockByType(BlockType.CTRL) is BinaryKV3 ctrlData)
                         {

--- a/ValveResourceFormat/Resource/ResourceTypes/Sentence.Export.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Sentence.Export.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using System.Text;
+
+namespace ValveResourceFormat.ResourceTypes
+{
+    public partial class Sentence
+    {
+        /// <summary>
+        /// Serializes the sentence to the plaintext phoneme format used by Source's
+        /// <c>resourcecompiler -extract_sentence</c>. Placing the resulting <c>.txt</c> next to a
+        /// source sound recompiles the phoneme data back into the <c>vsnd</c>.
+        /// </summary>
+        /// <remarks>
+        /// A compiled sound only stores the flat runtime phoneme stream, so the original word
+        /// grouping, plaintext and emphasis samples cannot be recovered. All phonemes are emitted
+        /// into a single <c>WORD</c> block, which the compiler flattens back to the same stream.
+        /// A phoneme code is the unicode code point of its IPA symbol; the compiler keys off the
+        /// numeric code, so the symbol is written purely for readability.
+        /// </remarks>
+        public string ToValveSentence()
+        {
+            var sb = new StringBuilder();
+
+            sb.Append("VERSION 1.0\n");
+            sb.Append("PLAINTEXT\n{\n}\n");
+            sb.Append("WORDS\n{\n");
+
+            if (RunTimePhonemes.Length > 0)
+            {
+                var word = new StringBuilder(RunTimePhonemes.Length);
+                foreach (var phoneme in RunTimePhonemes)
+                {
+                    word.Append((char)phoneme.PhonemeCode);
+                }
+
+                var start = RunTimePhonemes[0].StartTime;
+                var end = RunTimePhonemes[^1].EndTime;
+
+                sb.Append("\tWORD ").Append(word).Append(CultureInfo.InvariantCulture, $" {start:0.000} {end:0.000}\n\t{{\n");
+
+                foreach (var phoneme in RunTimePhonemes)
+                {
+                    var symbol = (char)phoneme.PhonemeCode;
+                    sb.Append(CultureInfo.InvariantCulture, $"\t\t{phoneme.PhonemeCode} {symbol} {phoneme.StartTime:0.000} {phoneme.EndTime:0.000} 1\n");
+                }
+
+                sb.Append("\t}\n");
+            }
+
+            sb.Append("}\n");
+            sb.Append("EMPHASIS\n{\n}\n");
+            sb.Append("OPTIONS\n{\n\tvoice_duck 0\n}\n");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/ValveResourceFormat/Resource/ResourceTypes/Sound.cs
+++ b/ValveResourceFormat/Resource/ResourceTypes/Sound.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using ValveKeyValue;
 using ValveResourceFormat.Serialization.KeyValues;
 
 namespace ValveResourceFormat.ResourceTypes
@@ -49,7 +50,7 @@ namespace ValveResourceFormat.ResourceTypes
     /// Represents a sentence with phoneme and emphasis data for voice playback.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/soundsystem_voicecontainers/CAudioSentence">CAudioSentence</seealso>
-    public class Sentence
+    public partial class Sentence
     {
         /*
         /// <summary>
@@ -327,7 +328,7 @@ namespace ValveResourceFormat.ResourceTypes
             Duration = sound.GetFloatProperty("m_flDuration");
             StreamingDataSize = sound.GetUInt32Property("m_nStreamingSize");
 
-            // TODO: m_Sentences
+            ReadSentenceFromCtrl(sound);
 
             return true;
         }
@@ -408,6 +409,38 @@ namespace ValveResourceFormat.ResourceTypes
                 };
 
                 Sentence.RunTimePhonemes[i] = phonemeTag;
+            }
+        }
+
+        private void ReadSentenceFromCtrl(KVObject sound)
+        {
+            var sentences = sound.GetArray("m_Sentences");
+
+            if (sentences == null || sentences.Count == 0)
+            {
+                return;
+            }
+
+            var phonemes = sentences[0].GetArray("m_RunTimePhonemes");
+
+            if (phonemes == null)
+            {
+                return;
+            }
+
+            Sentence = new Sentence
+            {
+                RunTimePhonemes = new PhonemeTag[phonemes.Count]
+            };
+
+            for (var i = 0; i < phonemes.Count; i++)
+            {
+                Sentence.RunTimePhonemes[i] = new PhonemeTag
+                {
+                    StartTime = phonemes[i].GetFloatProperty("m_flStartTime"),
+                    EndTime = phonemes[i].GetFloatProperty("m_flEndTime"),
+                    PhonemeCode = (ushort)phonemes[i].GetInt32Property("m_nPhonemeCode"),
+                };
             }
         }
 


### PR DESCRIPTION
## Lip-sync phonemes (`vsnd_c`), Closes #380
Exports the per-sound sentence/phoneme stream as a `.txt` in the format that the `resourcecompiler` reads, so dropping it next to the source sound bakes the lip-sync data back into the `vsnd`.

The viewer gains a "Reconstructed phonemes" tab. A compiled sound only keeps the flat phoneme stream, so the original word grouping and plaintext can't be recovered unfortunately.

All phonemes go into a single `WORD` block, which the compiler flattens back to the same stream on recompile.

It uses the IPA (International Phonetic Alphabet), so it's a bit hard to read manually.

## Testing
I decompiled every `vsnd_c` across all my installed Source 2 games and it works for every single one.

The phoneme `.txt` round-trips through the CS2 `resourcecompiler`. Dropping it next to the source sound and recompiling bakes the same phoneme stream back into the `vsnd`.

Example to look at: `Source2Viewer.exe "vpk:dota 2 beta/game/dota/pak01_dir.vpk:sounds/vo/announcer_dlc_cavej/cavej_ann_twr_deny_yr_follow_up_01.vsnd_c"`