### PR TITLE
Take the GL lock when changing mesh groups

### DIFF
--- a/GUI/Types/GLViewers/GLModelViewer.cs
+++ b/GUI/Types/GLViewers/GLModelViewer.cs
@@ -362,6 +362,7 @@ namespace GUI.Types.GLViewers
                         }
                     }, groups =>
                     {
+                        using var lockedGl = MakeCurrent();
                         modelSceneNode.SetActiveMeshGroups(groups);
                         modelStatsDirty = true;
                     });


### PR DESCRIPTION
Toggling a model's mesh groups rebuilds its renderable-mesh list on the UI thread without taking the GL lock. Rare race condition crashing the application.