### PR TITLE
Fix NaN in some shaders due to pow(0, 0) + minor bloom bug fix

### DIFF
--- a/Renderer/Shaders/common/fog.slang
+++ b/Renderer/Shaders/common/fog.slang
@@ -20,7 +20,7 @@ void ApplyGradientFog(inout vec3 pixelColor, vec3 positionWS, vec3 cameraCentere
     gradientFogComponents.x = length(cameraCenteredPixelPos);
     gradientFogComponents.y = positionWS.z;
 
-    gradientFogComponents = pow( saturate(gradientFogComponents * g_vGradientFogBiasAndScale.zw + g_vGradientFogBiasAndScale.xy), m_vGradientFogExponents );
+    gradientFogComponents = SafePow( saturate(gradientFogComponents * g_vGradientFogBiasAndScale.zw + g_vGradientFogBiasAndScale.xy), m_vGradientFogExponents );
 
     float gradientFogBlend = gradientFogComponents.x * gradientFogComponents.y * g_vGradientFogColor_Opacity.a;
 
@@ -34,8 +34,8 @@ uniform samplerCube g_tFogCubeTexture;
 void ApplyCubemapFog(inout vec3 pixelColor, vec3 positionWS, vec3 posRelativeToCamera)
 {
     vec2 cubeFogComponents;
-    cubeFogComponents.x = pow(ClampToPositive(length(posRelativeToCamera.xy) * g_vCubeFog_Offset_Scale_Bias_Exponent.y + g_vCubeFog_Offset_Scale_Bias_Exponent.x), g_vCubeFog_Offset_Scale_Bias_Exponent.w);
-    cubeFogComponents.y = pow(ClampToPositive(positionWS.z * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.y + g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.x), g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.z);
+    cubeFogComponents.x = SafePow(ClampToPositive(length(posRelativeToCamera.xy) * g_vCubeFog_Offset_Scale_Bias_Exponent.y + g_vCubeFog_Offset_Scale_Bias_Exponent.x), g_vCubeFog_Offset_Scale_Bias_Exponent.w);
+    cubeFogComponents.y = SafePow(ClampToPositive(positionWS.z * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.y + g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.x), g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.z);
 
     float cubemapFogBlend = saturate(cubeFogComponents.x) * saturate(cubeFogComponents.y);
 
@@ -85,7 +85,7 @@ vec4 g_vSphericalVignetteColor_Opacity;
 void ApplySphericalVignette( inout vec3 pixelColor, vec3 worldPositionLightingOffset)
 {
 	float sphericalVignetteLinear = saturate(g_vSphericalVignetteBiasAndScale.y * distance(worldPositionLightingOffset, g_vSphericalVignetteOrigin_Exponent.xyz) + g_vSphericalVignetteBiasAndScale.x);
-	float sphericalVignetteBlend = pow(sphericalVignetteLinear, g_vSphericalVignetteOrigin_Exponent.w);
+	float sphericalVignetteBlend = SafePow(sphericalVignetteLinear, g_vSphericalVignetteOrigin_Exponent.w);
 	PixelColor = mix(pixelColor, g_vSphericalVignetteColor_Opacity.rgb, g_vSphericalVignetteColor_Opacity.a * sphericalVignetteBlend);
 }
 #endif

--- a/Renderer/Shaders/common/fog.slang
+++ b/Renderer/Shaders/common/fog.slang
@@ -20,7 +20,7 @@ void ApplyGradientFog(inout vec3 pixelColor, vec3 positionWS, vec3 cameraCentere
     gradientFogComponents.x = length(cameraCenteredPixelPos);
     gradientFogComponents.y = positionWS.z;
 
-    gradientFogComponents = SafePow( saturate(gradientFogComponents * g_vGradientFogBiasAndScale.zw + g_vGradientFogBiasAndScale.xy), m_vGradientFogExponents );
+    gradientFogComponents = pow( clamp(gradientFogComponents * g_vGradientFogBiasAndScale.zw + g_vGradientFogBiasAndScale.xy, 0.0001, 1.0), m_vGradientFogExponents );
 
     float gradientFogBlend = gradientFogComponents.x * gradientFogComponents.y * g_vGradientFogColor_Opacity.a;
 
@@ -34,8 +34,8 @@ uniform samplerCube g_tFogCubeTexture;
 void ApplyCubemapFog(inout vec3 pixelColor, vec3 positionWS, vec3 posRelativeToCamera)
 {
     vec2 cubeFogComponents;
-    cubeFogComponents.x = SafePow(ClampToPositive(length(posRelativeToCamera.xy) * g_vCubeFog_Offset_Scale_Bias_Exponent.y + g_vCubeFog_Offset_Scale_Bias_Exponent.x), g_vCubeFog_Offset_Scale_Bias_Exponent.w);
-    cubeFogComponents.y = SafePow(ClampToPositive(positionWS.z * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.y + g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.x), g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.z);
+    cubeFogComponents.x = pow(max(length(posRelativeToCamera.xy) * g_vCubeFog_Offset_Scale_Bias_Exponent.y + g_vCubeFog_Offset_Scale_Bias_Exponent.x, 0.0001), g_vCubeFog_Offset_Scale_Bias_Exponent.w);
+    cubeFogComponents.y = pow(max(positionWS.z * g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.y + g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.x, 0.0001), g_vCubeFog_Height_Offset_Scale_Exponent_Log2Mip.z);
 
     float cubemapFogBlend = saturate(cubeFogComponents.x) * saturate(cubeFogComponents.y);
 
@@ -84,8 +84,8 @@ vec4 g_vSphericalVignetteColor_Opacity;
 
 void ApplySphericalVignette( inout vec3 pixelColor, vec3 worldPositionLightingOffset)
 {
-	float sphericalVignetteLinear = saturate(g_vSphericalVignetteBiasAndScale.y * distance(worldPositionLightingOffset, g_vSphericalVignetteOrigin_Exponent.xyz) + g_vSphericalVignetteBiasAndScale.x);
-	float sphericalVignetteBlend = SafePow(sphericalVignetteLinear, g_vSphericalVignetteOrigin_Exponent.w);
+	float sphericalVignetteLinear = clamp(g_vSphericalVignetteBiasAndScale.y * distance(worldPositionLightingOffset, g_vSphericalVignetteOrigin_Exponent.xyz) + g_vSphericalVignetteBiasAndScale.x, 0.0001, 1.0);
+	float sphericalVignetteBlend = pow(sphericalVignetteLinear, g_vSphericalVignetteOrigin_Exponent.w);
 	PixelColor = mix(pixelColor, g_vSphericalVignetteColor_Opacity.rgb, g_vSphericalVignetteColor_Opacity.a * sphericalVignetteBlend);
 }
 #endif

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -23,7 +23,7 @@ vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
 {
     float NoL = dot(vNormal, vLightVector);
     float diffuseWrapDenom = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
-    float DiffuseWrapLighting = pow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
+    float DiffuseWrapLighting = SafePow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
     return mix(vec3(saturate(NoL)), vec3(DiffuseWrapLighting), g_vDiffuseWrapColor.rgb);
 }
 #endif

--- a/Renderer/Shaders/common/pbr.slang
+++ b/Renderer/Shaders/common/pbr.slang
@@ -22,8 +22,8 @@ uniform vec3 g_vDiffuseWrapColor = vec3(1.0, 0.5, 0.3); // SrgbRead(true)
 vec3 diffuseWrapped(vec3 vNormal, vec3 vLightVector)
 {
     float NoL = dot(vNormal, vLightVector);
-    float diffuseWrapDenom = ClampToPositive((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap));
-    float DiffuseWrapLighting = SafePow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
+    float diffuseWrapDenom = max((NoL + g_flDiffuseWrap) / (1.0 + g_flDiffuseWrap), 0.0001);
+    float DiffuseWrapLighting = pow(diffuseWrapDenom, g_flDiffuseExponent) * (1.0 + g_flDiffuseExponent) / (2.0 + 2.0 * g_flDiffuseWrap);
     return mix(vec3(saturate(NoL)), vec3(DiffuseWrapLighting), g_vDiffuseWrapColor.rgb);
 }
 #endif

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -185,7 +185,7 @@ void SetDiffuseColorBleed(inout MaterialProperties_t mat)
 #if (F_SSS_MASK == 1)
     vAmbientOcclusionExponent = mix(vec3(1.0), vAmbientOcclusionExponent, mat.SSSMask);
 #endif
-    mat.DiffuseAO = pow(mat.DiffuseAO, vAmbientOcclusionExponent);
+    mat.DiffuseAO = SafePow(mat.DiffuseAO, vAmbientOcclusionExponent);
 }
 
 #endif
@@ -345,7 +345,7 @@ void applyDetailTexture(inout vec3 Albedo, inout vec3 NormalMap, vec2 detailMask
     vec4 GetGlassMaterial(MaterialProperties_t mat)
     {
         float viewDotNormalInv = saturate(1.0 - (dot(mat.ViewDir, mat.Normal) - g_flEdgeColorThickness));
-        float fresnel = saturate(pow(viewDotNormalInv, g_flEdgeColorFalloff)) * g_flEdgeColorMaxOpacity;
+        float fresnel = saturate(SafePow(viewDotNormalInv, g_flEdgeColorFalloff)) * g_flEdgeColorMaxOpacity;
         vec4 fresnelColor = vec4(g_vEdgeColor.xyz, g_bFresnel ? fresnel : 0.0);
 
         return mix(vec4(mat.Albedo, mat.Opacity), fresnelColor, g_flOpacityScale);

--- a/Renderer/Shaders/common/texturing.slang
+++ b/Renderer/Shaders/common/texturing.slang
@@ -344,8 +344,8 @@ void applyDetailTexture(inout vec3 Albedo, inout vec3 NormalMap, vec2 detailMask
     // todo2: inout mat properties
     vec4 GetGlassMaterial(MaterialProperties_t mat)
     {
-        float viewDotNormalInv = saturate(1.0 - (dot(mat.ViewDir, mat.Normal) - g_flEdgeColorThickness));
-        float fresnel = saturate(SafePow(viewDotNormalInv, g_flEdgeColorFalloff)) * g_flEdgeColorMaxOpacity;
+        float viewDotNormalInv = clamp(1.0 - (dot(mat.ViewDir, mat.Normal) - g_flEdgeColorThickness), 0.0001, 1.0);
+        float fresnel = saturate(pow(viewDotNormalInv, g_flEdgeColorFalloff)) * g_flEdgeColorMaxOpacity;
         vec4 fresnelColor = vec4(g_vEdgeColor.xyz, g_bFresnel ? fresnel : 0.0);
 
         return mix(vec4(mat.Albedo, mat.Opacity), fresnelColor, g_flOpacityScale);

--- a/Renderer/Shaders/common/utils.slang
+++ b/Renderer/Shaders/common/utils.slang
@@ -45,6 +45,20 @@ float pow5(float val)
     return pow(val, 5.0); // Should get optimized
 }
 
+// Guards against pow(0, 0) = NaN by clamping the base off zero.
+float SafePow(float base, float exponent)
+{
+    return pow(max(base, 1e-9), exponent);
+}
+vec2 SafePow(vec2 base, vec2 exponent)
+{
+    return pow(max(base, vec2(1e-9)), exponent);
+}
+vec3 SafePow(vec3 base, vec3 exponent)
+{
+    return pow(max(base, vec3(1e-9)), exponent);
+}
+
 float Random2D(vec2 Seed)
 {
     return fract(sin( dot(Seed, vec2(12.9898, 78.233)) ) * 43758.5469);
@@ -96,7 +110,7 @@ float LevelsAdjust(float component, vec3 L_BlackWhiteGamma)
         2.0 - L_BlackWhiteGamma.z
     );
 
-    return mix(levels.x, levels.y, pow(component, levels.z));
+    return mix(levels.x, levels.y, SafePow(component, levels.z));
 }
 
 float SrgbGammaToLinear(float color)

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -353,7 +353,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 
     // Emissive
     vec3 layer1Emissive = (layer1Color.rgb * g_vLayer1EmissiveTint * g_flLayer1EmissiveLevel) * tintFactor;
-    float emissiveFresnel = clamp(pow(NdotV, g_flLayer2EmissiveFresnel), 0.0, 1.0);
+    float emissiveFresnel = clamp(SafePow(NdotV, g_flLayer2EmissiveFresnel), 0.0, 1.0);
     vec3 layer2Emissive = (layer2Color * emissiveFresnel * g_vLayer2EmissiveTint * g_flLayer2EmissiveLevel) * tintFactor;
     mat.IllumColor = mix(layer2Emissive, layer1Emissive, layer1Color.a) * (1.0 - mask);
 
@@ -610,7 +610,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 
     #if defined(foliage_vfx_common)
         vec4 vFoliageParams = clamp(vFoliageParamsOut, vec4(0.001), vec4(1.0));
-        mat.AmbientOcclusion *= mix(1.0, pow(vFoliageParams.w, g_flVertexAmbientOcclusionPower), g_flVertexAmbientOcclusionAmount);
+        mat.AmbientOcclusion *= mix(1.0, SafePow(vFoliageParams.w, g_flVertexAmbientOcclusionPower), g_flVertexAmbientOcclusionAmount);
     #endif
 
     #if (F_TRANSMISSIVE_BACKFACE_NDOTL == 1) && (GameVfx_csgo_simple_3layer_parallax == 0)

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -323,7 +323,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
     // Parallax
     vec3 viewDirInv = -mat.ViewDir;
     float invDepth = 1.0 / dot(viewDirInv, mat.GeometricNormal);
-    float NdotV = clamp(dot(mat.ViewDir, mat.GeometricNormal), 0.0, 1.0);
+    float NdotV = clamp(dot(mat.ViewDir, mat.GeometricNormal), 0.0001, 1.0);
     float fresnel = clamp(pow(NdotV, 0.7), 0.0, 1.0);
     vec2 viewDirTs = vec2(dot(viewDirInv, mat.Tangent), dot(viewDirInv, mat.Bitangent));
     vec2 normalXY = vec2(mat.NormalMap.x, -mat.NormalMap.y);
@@ -353,7 +353,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 
     // Emissive
     vec3 layer1Emissive = (layer1Color.rgb * g_vLayer1EmissiveTint * g_flLayer1EmissiveLevel) * tintFactor;
-    float emissiveFresnel = clamp(SafePow(NdotV, g_flLayer2EmissiveFresnel), 0.0, 1.0);
+    float emissiveFresnel = clamp(pow(NdotV, g_flLayer2EmissiveFresnel), 0.0, 1.0);
     vec3 layer2Emissive = (layer2Color * emissiveFresnel * g_vLayer2EmissiveTint * g_flLayer2EmissiveLevel) * tintFactor;
     mat.IllumColor = mix(layer2Emissive, layer1Emissive, layer1Color.a) * (1.0 - mask);
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -610,7 +610,7 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 
     #if defined(foliage_vfx_common)
         vec4 vFoliageParams = clamp(vFoliageParamsOut, vec4(0.001), vec4(1.0));
-        mat.AmbientOcclusion *= mix(1.0, SafePow(vFoliageParams.w, g_flVertexAmbientOcclusionPower), g_flVertexAmbientOcclusionAmount);
+        mat.AmbientOcclusion *= mix(1.0, pow(vFoliageParams.w, g_flVertexAmbientOcclusionPower), g_flVertexAmbientOcclusionAmount);
     #endif
 
     #if (F_TRANSMISSIVE_BACKFACE_NDOTL == 1) && (GameVfx_csgo_simple_3layer_parallax == 0)

--- a/Renderer/Shaders/complex.vert.slang
+++ b/Renderer/Shaders/complex.vert.slang
@@ -218,7 +218,7 @@ vec4 GetTintColorLinear(vec4 vTint)
 #if F_NOTINT == 0
     TintFade.rgb = mix(vec3(1.0), SrgbGammaToLinear(vTint.rgb) * g_vColorTint.rgb, g_flModelTintAmount);
 #endif
-    TintFade.a = pow(vTint.a, g_flFadeExponent);
+    TintFade.a = SafePow(vTint.a, g_flFadeExponent);
     return TintFade;
 }
 
@@ -299,8 +299,8 @@ void main()
         // Calculate strengths
         animParams.swayStrength = 150.0 * g_flSwayAmount;
         animParams.flutterStrength = 25.0 * g_flFlutterAmount;
-        animParams.swayFalloff = pow(foliageParams.x, g_flSwayFalloff);
-        animParams.flutterFalloff = pow(foliageParams.z, g_flFlutterFalloff);
+        animParams.swayFalloff = SafePow(foliageParams.x, g_flSwayFalloff);
+        animParams.flutterFalloff = SafePow(foliageParams.z, g_flFlutterFalloff);
 
         // Calculate height blend and offset
         animParams.heightBlend = (2.0 * foliageParams.y) - 1.0;

--- a/Renderer/Shaders/complex.vert.slang
+++ b/Renderer/Shaders/complex.vert.slang
@@ -299,8 +299,8 @@ void main()
         // Calculate strengths
         animParams.swayStrength = 150.0 * g_flSwayAmount;
         animParams.flutterStrength = 25.0 * g_flFlutterAmount;
-        animParams.swayFalloff = SafePow(foliageParams.x, g_flSwayFalloff);
-        animParams.flutterFalloff = SafePow(foliageParams.z, g_flFlutterFalloff);
+        animParams.swayFalloff = pow(foliageParams.x, g_flSwayFalloff);
+        animParams.flutterFalloff = pow(foliageParams.z, g_flFlutterFalloff);
 
         // Calculate height blend and offset
         animParams.heightBlend = (2.0 * foliageParams.y) - 1.0;

--- a/Renderer/Shaders/csgo_effects.frag.slang
+++ b/Renderer/Shaders/csgo_effects.frag.slang
@@ -98,12 +98,12 @@ void main()
 
         float flFragmentToSceneDistance = distance(vFragPosition, vScenePosition);
 
-        feather = saturate(flFragmentToSceneDistance / g_flFeatherDistance);
-        feather = SafePow(feather, g_flFeatherFalloff);
+        feather = clamp(flFragmentToSceneDistance / g_flFeatherDistance, 0.0001, 1.0);
+        feather = pow(feather, g_flFeatherFalloff);
     #endif
 
-    float fresnel = saturate(dot(-normalize(vCameraRay), normalize(vGeometricNormal).xyz));
-    fresnel = SafePow(fresnel, g_flFresnelExponent) * g_flFresnelFalloff;
+    float fresnel = clamp(dot(-normalize(vCameraRay), normalize(vGeometricNormal).xyz), 0.0001, 1.0);
+    fresnel = pow(fresnel, g_flFresnelExponent) * g_flFresnelFalloff;
     fresnel = saturate(fresnel);
     fresnel = mix(g_flFresnelMin, g_flFresnelMax, fresnel);
 

--- a/Renderer/Shaders/csgo_effects.frag.slang
+++ b/Renderer/Shaders/csgo_effects.frag.slang
@@ -99,17 +99,17 @@ void main()
         float flFragmentToSceneDistance = distance(vFragPosition, vScenePosition);
 
         feather = saturate(flFragmentToSceneDistance / g_flFeatherDistance);
-        feather = pow(feather, g_flFeatherFalloff);
+        feather = SafePow(feather, g_flFeatherFalloff);
     #endif
 
     float fresnel = saturate(dot(-normalize(vCameraRay), normalize(vGeometricNormal).xyz));
-    fresnel = pow(fresnel, g_flFresnelExponent) * g_flFresnelFalloff;
+    fresnel = SafePow(fresnel, g_flFresnelExponent) * g_flFresnelFalloff;
     fresnel = saturate(fresnel);
     fresnel = mix(g_flFresnelMin, g_flFresnelMax, fresnel);
 
     float fade = saturate(length(vCameraRay / vec3(g_flFadeDistance)));
     fade = mix(g_flFadeMin, g_flFadeMax, fade);
-    fade = pow(fade, g_flFadeFalloff);
+    fade = SafePow(fade, g_flFadeFalloff);
 
     opacity *= fresnel;
     opacity *= feather;

--- a/Renderer/Shaders/csgo_environment.frag.slang
+++ b/Renderer/Shaders/csgo_environment.frag.slang
@@ -216,8 +216,8 @@ MaterialProperties_t GetMaterial(vec3 vertexNormals)
 
     #if (GameVfx_csgo_environment_blend != 0 && F_SHARED_COLOR_OVERLAY == 1)
         vec3 overlay = texture(g_tSharedColorOverlay, vTexCoord.zw).rgb * 2.0 - 1.0;
-        vec3 _15235 = (((vec3(1.0) - pow(vec3(1.0) - max(vec3(0.0), overlay), vec3(g_flOverlayBrightnessContrast))) * g_flOverlayBrightnessContrast)
-            + ((pow(vec3(1.0) + min(vec3(0.0), overlay), vec3(g_flOverlayDarknessContrast)) - vec3(1.0)) * g_flOverlayDarknessContrast)) + vec3(1.0);
+        vec3 _15235 = (((vec3(1.0) - SafePow(vec3(1.0) - max(vec3(0.0), overlay), vec3(g_flOverlayBrightnessContrast))) * g_flOverlayBrightnessContrast)
+            + ((SafePow(vec3(1.0) + min(vec3(0.0), overlay), vec3(g_flOverlayDarknessContrast)) - vec3(1.0)) * g_flOverlayDarknessContrast)) + vec3(1.0);
         overlayFactor = max(vec3(0.0), _15235);
     #endif
 

--- a/Renderer/Shaders/dota_hero.frag.slang
+++ b/Renderer/Shaders/dota_hero.frag.slang
@@ -128,7 +128,7 @@ void main()
 
 #if F_MASKS_2 && !F_SPECULAR_CUBE_MAP
     //Calculate final specular based on specular exponent - mask 2 channel A
-    float specular = pow(specularAngle, mask2.a * g_flSpecularExponent);
+    float specular = SafePow(specularAngle, mask2.a * g_flSpecularExponent);
     //Multiply by mapped specular intensity - mask 2 channel R
     specular = illumination * specular * mask2.r;
 

--- a/Renderer/Shaders/dota_hero.frag.slang
+++ b/Renderer/Shaders/dota_hero.frag.slang
@@ -124,11 +124,11 @@ void main()
 
     //Calculate Blinn specular based on reflected light
     vec3 halfDir = normalize(lightDirection + viewDirection);
-    float specularAngle = max(dot(halfDir, worldNormal), 0.0);
+    float specularAngle = max(dot(halfDir, worldNormal), 0.0001);
 
 #if F_MASKS_2 && !F_SPECULAR_CUBE_MAP
     //Calculate final specular based on specular exponent - mask 2 channel A
-    float specular = SafePow(specularAngle, mask2.a * g_flSpecularExponent);
+    float specular = pow(specularAngle, mask2.a * g_flSpecularExponent);
     //Multiply by mapped specular intensity - mask 2 channel R
     specular = illumination * specular * mask2.r;
 

--- a/Renderer/Shaders/msaa_resolve.comp.slang
+++ b/Renderer/Shaders/msaa_resolve.comp.slang
@@ -47,7 +47,10 @@ void main()
     for (int i = 0; i < D_MSAA_SAMPLES; i++)
     {
         vec4 texel = texelFetch(g_tSourceMsaa, sampleCoord, i);
-        vec3 s = clamp(texel.rgb, vec3(0.0), vec3(65504.0));
+        // Flush NaN/+Inf to 0; clamp(NaN/+Inf, ...) otherwise returns 65504 (white) on NVIDIA and blows up bloom.
+        // The range test catches both and survives the fast-math no-NaN folding that would defeat isnan().
+        bvec3 valid = lessThanEqual(texel.rgb, vec3(65504.0));
+        vec3 s = mix(vec3(0.0), clamp(texel.rgb, vec3(0.0), vec3(65504.0)), valid);
         // Karis average: weight by inverse luminance to reduce fireflies
         resolved += s * (invNumSamples / (max(s.r, max(s.g, s.b)) + 1.0));
 

--- a/Renderer/Shaders/water_csgo.frag.slang
+++ b/Renderer/Shaders/water_csgo.frag.slang
@@ -493,7 +493,7 @@ void main()
     vec3 sunDir = GetEnvLightDirection(0);
 
     float cosNormAngle = saturate(dot(viewDirInv, finalPerturbedSurfaceNormal.xyz));
-    float fresnel = pow(1.0 - cosNormAngle, g_flFresnelExponent);
+    float fresnel = SafePow(1.0 - cosNormAngle, g_flFresnelExponent);
     vec3 finalFoamColor = g_vFoamColor.rgb * fma(combinedfinalFoamIntensity, 0.5, 1.0);
 
     vec3 combinedRefractedColor = vec3(0);
@@ -636,7 +636,7 @@ void main()
                 float factor = clamp(mix(mix(fma(debrisDisturbanceForWaves, 0.1, g_flLowFreqWeight), g_flMedFreqWeight + debrisDisturbanceForWaves, saturate(causticIterProgress * 2.0)), fma(g_flHighFreqWeight, currentWaterRoughness, debrisDisturbanceForWaves), saturate(fma(causticIterProgress, 2.0, -1.0))), 0.1, 0.4);
 
                 float waveSampleCausticDepthFalloff = causticDepthFalloff * g_flCausticSharpness;
-                currWaveSampleSum1 += (((((pow(rawSample, exponent) * factor) * (vec3(1.0) + (currWaveSampleSum1 * 2.0))) * causticDepthFalloff) * waveSampleCausticDepthFalloff) * 2.0);
+                currWaveSampleSum1 += (((((SafePow(rawSample, exponent) * factor) * (vec3(1.0) + (currWaveSampleSum1 * 2.0))) * causticDepthFalloff) * waveSampleCausticDepthFalloff) * 2.0);
 
                 currWaveScale1 *= g_flWavesPhaseOffset;
                 currWaveDir += (3.5 / (i + 1));
@@ -688,7 +688,7 @@ void main()
     vec3 finalDirToCam = -normalize(finalSurfacePos.xyz - g_vCameraPositionWs.xyz);
     float specularCosAlpha = clamp(dot(-sunDir, reflect(finalDirToCam, normalize(mix(normalize(mat.GeometricNormal).xyz, finalPerturbedSurfaceNormal.xyz, vec3(g_flSpecularNormalMultiple * fma(distanceToFrag, 0.0005, 1.0)))))), 0.0, 1.0);
     float specularExponent = mix(g_flSpecularPower, g_flDebrisReflectance * 8.0, debrisEdgeFactor) * mix(2.0, 0.2, saturate(currentWaterRoughness));
-    float specularFactor = fma(pow(specularCosAlpha, specularExponent), 0.1, pow(specularCosAlpha, specularExponent * 10.0));
+    float specularFactor = fma(SafePow(specularCosAlpha, specularExponent), 0.1, SafePow(specularCosAlpha, specularExponent * 10.0));
 
     float inverseWaterFogAlpha = 1.0 - waterFogAlpha;
     float waterOpacity = (saturate((1.0 - debrisEdgeFactor) + noClue) * saturate(fma(-combinedfinalFoamIntensity, 4.0, 1.0))) * inverseWaterFogAlpha;

--- a/Renderer/Shaders/water_csgo.frag.slang
+++ b/Renderer/Shaders/water_csgo.frag.slang
@@ -686,9 +686,9 @@ void main()
     vec3 baseFogColor = mix(g_vWaterFogColor.rgb, finalFoamColor, vec3(foamDebrisForFogMix * 0.1)) * mix(waterDecayColorFactor, vec3(1.0), vec3(saturate(totalFogStrength * 0.04)));
 
     vec3 finalDirToCam = -normalize(finalSurfacePos.xyz - g_vCameraPositionWs.xyz);
-    float specularCosAlpha = clamp(dot(-sunDir, reflect(finalDirToCam, normalize(mix(normalize(mat.GeometricNormal).xyz, finalPerturbedSurfaceNormal.xyz, vec3(g_flSpecularNormalMultiple * fma(distanceToFrag, 0.0005, 1.0)))))), 0.0, 1.0);
+    float specularCosAlpha = clamp(dot(-sunDir, reflect(finalDirToCam, normalize(mix(normalize(mat.GeometricNormal).xyz, finalPerturbedSurfaceNormal.xyz, vec3(g_flSpecularNormalMultiple * fma(distanceToFrag, 0.0005, 1.0)))))), 0.0001, 1.0);
     float specularExponent = mix(g_flSpecularPower, g_flDebrisReflectance * 8.0, debrisEdgeFactor) * mix(2.0, 0.2, saturate(currentWaterRoughness));
-    float specularFactor = fma(SafePow(specularCosAlpha, specularExponent), 0.1, SafePow(specularCosAlpha, specularExponent * 10.0));
+    float specularFactor = fma(pow(specularCosAlpha, specularExponent), 0.1, pow(specularCosAlpha, specularExponent * 10.0));
 
     float inverseWaterFogAlpha = 1.0 - waterFogAlpha;
     float waterOpacity = (saturate((1.0 - debrisEdgeFactor) + noClue) * saturate(fma(-combinedfinalFoamIntensity, 4.0, 1.0))) * inverseWaterFogAlpha;


### PR DESCRIPTION
## Issue

In the model viewer I encountered this artifact:

<img width="2560" height="1440" alt="613935634-d6c634dc-c680-4ee9-af73-9b2b77062dc3" src="https://github.com/user-attachments/assets/a8fb2768-0455-46e1-9eb0-9aff2ac9738f" />

The reason it happens is that some shaders produce `NaN` pixels. The source in this case is a `pow(0, 0)` operation, which results in `NaN`. These `NaN`s later reach `clamp(s, vec3(0.0), vec3(65504.0))`, which returns `65504.0`, which is a max-brightness white pixel that the bloom pass amplifies into the orb in the picture.

## Fix

I added a `SafePow` helper that returns 0 for the `pow(0, 0)` case. All other `pow()` operations are unaffected. I routed all `pow()` operations through the new helper in case their exponent and base are both non-fixed and could theoretically result in `pow(0, 0)`. This is blanket fix over all shaders, because I don't know which exact shaders could cause this issue aswell. It least in dota it happens and @kristiker also said it happens when scaling a bone to 0 for firstperson viewmodels (different shader).

For the bloom artifact it happened in the MSAA resolve, which now checks whether the number is `<= 65504.0`, which returns false if the number is `+Inf` or `NaN` (instead of using `isnan()`, which doesn't return true for `+Inf`).

## Bloom Downsample

I added the Karis average (see the pptx from here: [Link](https://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare/)), which helps with reducing firefly effects. I initially thought this may be the issue, but it turned out not to be.

Also the 13-tap pattern was slightly wrong. It built four "crosses" instead of the 2x2 "boxes" from the pptx. Though this difference is negligible to the human eye.

## Verification

Look at `vpk:C:/Program Files (x86)/Steam/steamapps/common/dota 2 beta/game/dota/pak01_dir.vpk:models/heroes/axe/axe.vmdl_c` and move your camera until you encounter the bloom artifact. It is easiest to reproduce by running an animation such as `run_injured` and waiting for a frame showing the bloom artifact, then pulling the animation speed slider to 0 and navigating to the specific frame that causes the artifact.
