### PR TITLE
Show loading screen in file previews

### DIFF
--- a/GUI/Controls/LoadingFile.Designer.cs
+++ b/GUI/Controls/LoadingFile.Designer.cs
@@ -33,44 +33,45 @@ namespace GUI.Controls
             tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             tableLayoutPanel1.SuspendLayout();
             SuspendLayout();
-            // 
-            // progressBar1
-            // 
-            progressBar1.Dock = System.Windows.Forms.DockStyle.Fill;
-            progressBar1.Location = new System.Drawing.Point(4, 3);
-            progressBar1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            progressBar1.MarqueeAnimationSpeed = 30;
-            progressBar1.Name = "progressBar1";
-            progressBar1.Size = new System.Drawing.Size(192, 14);
-            progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
-            progressBar1.TabIndex = 0;
-            // 
+            //
             // label1
-            // 
+            //
+            label1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            label1.AutoEllipsis = true;
             label1.AutoSize = true;
-            label1.Dock = System.Windows.Forms.DockStyle.Fill;
-            label1.Location = new System.Drawing.Point(4, 20);
-            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 8);
+            label1.MaximumSize = new System.Drawing.Size(560, 0);
             label1.Name = "label1";
             label1.Size = new System.Drawing.Size(192, 20);
             label1.TabIndex = 1;
             label1.Text = "Loading file, please wait…";
             label1.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
+            //
+            // progressBar1
+            //
+            progressBar1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            progressBar1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            progressBar1.MarqueeAnimationSpeed = 30;
+            progressBar1.Name = "progressBar1";
+            progressBar1.Size = new System.Drawing.Size(300, 14);
+            progressBar1.Style = System.Windows.Forms.ProgressBarStyle.Marquee;
+            progressBar1.TabIndex = 0;
+            //
             // tableLayoutPanel1
             // 
             tableLayoutPanel1.Anchor = System.Windows.Forms.AnchorStyles.None;
+            tableLayoutPanel1.AutoSize = true;
+            tableLayoutPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             tableLayoutPanel1.ColumnCount = 1;
-            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            tableLayoutPanel1.Controls.Add(progressBar1, 0, 0);
-            tableLayoutPanel1.Controls.Add(label1, 0, 1);
-            tableLayoutPanel1.Location = new System.Drawing.Point(200, 130);
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.AutoSize));
+            tableLayoutPanel1.Controls.Add(label1, 0, 0);
+            tableLayoutPanel1.Controls.Add(progressBar1, 0, 1);
+            tableLayoutPanel1.Location = new System.Drawing.Point(150, 130);
+            tableLayoutPanel1.MinimumSize = new System.Drawing.Size(300, 0);
             tableLayoutPanel1.Name = "tableLayoutPanel1";
             tableLayoutPanel1.RowCount = 2;
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            tableLayoutPanel1.Size = new System.Drawing.Size(200, 40);
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.AutoSize));
             tableLayoutPanel1.TabIndex = 2;
             // 
             // LoadingFile
@@ -85,6 +86,7 @@ namespace GUI.Controls
             tableLayoutPanel1.ResumeLayout(false);
             tableLayoutPanel1.PerformLayout();
             ResumeLayout(false);
+            PerformLayout();
 
         }
 

--- a/GUI/Controls/LoadingFile.Designer.cs
+++ b/GUI/Controls/LoadingFile.Designer.cs
@@ -13,9 +13,10 @@ namespace GUI.Controls
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                components?.Dispose();
+                iconBitmap?.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/GUI/Controls/LoadingFile.cs
+++ b/GUI/Controls/LoadingFile.cs
@@ -10,6 +10,9 @@ namespace GUI.Controls
             InitializeComponent();
             Themer.ThemeControl(this);
 
+            // Show the wait cursor for the whole time the file is loading, but only when hovering this panel
+            Cursor = Cursors.WaitCursor;
+
             if (!string.IsNullOrEmpty(fileName))
             {
                 label1.Text = fileName;

--- a/GUI/Controls/LoadingFile.cs
+++ b/GUI/Controls/LoadingFile.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
+using GUI.Types.PackageViewer;
 using GUI.Utils;
 
 namespace GUI.Controls
 {
     partial class LoadingFile : UserControl
     {
+        private Bitmap? iconBitmap;
+
         public LoadingFile(string? fileName = null)
         {
             InitializeComponent();
@@ -18,6 +22,7 @@ namespace GUI.Controls
             if (!string.IsNullOrEmpty(fileName))
             {
                 label1.Text = fileName;
+                AddLargeIcon(fileName);
             }
 
             // The panel auto-sizes to fit the file name label. Anchor=None only keeps it centered when the
@@ -42,6 +47,28 @@ namespace GUI.Controls
             {
                 tableLayoutPanel1.Location = location;
             }
+        }
+
+        // Show the file-type icon large (the same SVG icon the grid view uses), above the file name.
+        private void AddLargeIcon(string fileName)
+        {
+            var typeName = Path.GetExtension(fileName).TrimStart('.').ToLowerInvariant();
+            iconBitmap = TreeViewWithSearchResults.GetTypeIconBitmap(typeName, this.AdjustForDPI(72));
+
+            var iconBox = new PictureBox
+            {
+                Image = iconBitmap,
+                SizeMode = PictureBoxSizeMode.AutoSize,
+                Anchor = AnchorStyles.None,
+                Margin = new Padding(4, 0, 4, 8),
+            };
+
+            // Insert a new top row for the icon and push the label/progress bar down into the rows below it.
+            tableLayoutPanel1.RowCount = 3;
+            tableLayoutPanel1.RowStyles.Insert(0, new RowStyle(SizeType.AutoSize));
+            tableLayoutPanel1.SetRow(label1, 1);
+            tableLayoutPanel1.SetRow(progressBar1, 2);
+            tableLayoutPanel1.Controls.Add(iconBox, 0, 0);
         }
 
         protected override void OnCreateControl()

--- a/GUI/Controls/LoadingFile.cs
+++ b/GUI/Controls/LoadingFile.cs
@@ -5,10 +5,15 @@ namespace GUI.Controls
 {
     partial class LoadingFile : UserControl
     {
-        public LoadingFile()
+        public LoadingFile(string? fileName = null)
         {
             InitializeComponent();
             Themer.ThemeControl(this);
+
+            if (!string.IsNullOrEmpty(fileName))
+            {
+                label1.Text = fileName;
+            }
         }
 
         protected override void OnCreateControl()

--- a/GUI/Controls/LoadingFile.cs
+++ b/GUI/Controls/LoadingFile.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Drawing;
 using System.Windows.Forms;
 using GUI.Utils;
 
@@ -16,6 +18,29 @@ namespace GUI.Controls
             if (!string.IsNullOrEmpty(fileName))
             {
                 label1.Text = fileName;
+            }
+
+            // The panel auto-sizes to fit the file name label. Anchor=None only keeps it centered when the
+            // parent resizes, not when the panel itself grows, so a long file name would push it off center.
+            // Re-center it ourselves whenever its size changes.
+            tableLayoutPanel1.SizeChanged += (_, _) => CenterContent();
+        }
+
+        protected override void OnLayout(LayoutEventArgs levent)
+        {
+            base.OnLayout(levent);
+            CenterContent();
+        }
+
+        private void CenterContent()
+        {
+            var location = new Point(
+                Math.Max(0, (ClientSize.Width - tableLayoutPanel1.Width) / 2),
+                Math.Max(0, (ClientSize.Height - tableLayoutPanel1.Height) / 2));
+
+            if (tableLayoutPanel1.Location != location)
+            {
+                tableLayoutPanel1.Location = location;
             }
         }
 

--- a/GUI/Controls/RendererControl.Designer.cs
+++ b/GUI/Controls/RendererControl.Designer.cs
@@ -21,6 +21,7 @@ partial class RendererControl
         if (disposing)
         {
             namedGroups.Clear();
+            splitContainer.SizeChanged -= PreviewControlsWidth_Init;
         }
 
         base.Dispose(disposing);

--- a/GUI/Controls/RendererControl.Designer.cs
+++ b/GUI/Controls/RendererControl.Designer.cs
@@ -21,7 +21,7 @@ partial class RendererControl
         if (disposing)
         {
             namedGroups.Clear();
-            splitContainer.SizeChanged -= PreviewControlsWidth_Init;
+            splitContainer.SizeChanged -= PreviewControls_HandleResize;
         }
 
         base.Dispose(disposing);

--- a/GUI/Controls/RendererControl.cs
+++ b/GUI/Controls/RendererControl.cs
@@ -70,6 +70,67 @@ partial class RendererControl : UserControl
         SetControlLocation(control);
     }
 
+    /// <summary>
+    /// Shows the previewed file's icon and name as the first item in the controls panel. Used in preview mode,
+    /// where there is no tab header to display the file name. Long names are ellipsized.
+    /// </summary>
+    public void AddPreviewFileName(string fileName, int imageIndex)
+    {
+        var header = new Panel
+        {
+            Dock = DockStyle.Top,
+            Height = this.AdjustForDPI(32),
+            Padding = new Padding(0, 0, splitContainer.SplitterWidth, 0),
+        };
+
+        var content = new Panel
+        {
+            Dock = DockStyle.Fill,
+            Padding = new Padding(0, this.AdjustForDPI(2), 0, this.AdjustForDPI(2)),
+        };
+
+        var nameLabel = new Label
+        {
+            Dock = DockStyle.Fill,
+            Text = fileName,
+            AutoEllipsis = true,
+            TextAlign = ContentAlignment.MiddleLeft,
+            Padding = new Padding(0, 0, this.AdjustForDPI(4), 0),
+        };
+
+        var iconLabel = new Label
+        {
+            Dock = DockStyle.Left,
+            Width = this.AdjustForDPI(28),
+            ImageList = MainForm.ImageList,
+            ImageAlign = ContentAlignment.MiddleCenter,
+        };
+
+        if (imageIndex >= 0 && imageIndex < MainForm.ImageList.Images.Count)
+        {
+            iconLabel.ImageIndex = imageIndex;
+        }
+
+        // Accent underline along the bottom, matching the selected tab's underline.
+        var underline = new UnstyledPanel
+        {
+            Dock = DockStyle.Bottom,
+            Height = this.AdjustForDPI(2),
+            BackColor = Themer.CurrentThemeColors.Accent,
+        };
+
+        content.Controls.Add(nameLabel);
+        content.Controls.Add(iconLabel);
+
+        header.Controls.Add(content);
+        header.Controls.Add(underline);
+
+        // Pin the header above the scrollable controls panel (in its non-scrolling parent)
+        var host = controlsPanel.Parent ?? controlsPanel;
+        host.Controls.Add(header);
+        header.SendToBack();
+    }
+
     public static GLViewerCheckboxControl CreateCheckBox(string name, bool defaultChecked, Action<bool> changeCallback)
     {
         var checkbox = new GLViewerCheckboxControl(name, defaultChecked);

--- a/GUI/Controls/RendererControl.cs
+++ b/GUI/Controls/RendererControl.cs
@@ -28,7 +28,36 @@ partial class RendererControl : UserControl
             splitContainer.Panel2.Controls.Add(controlsPanel);
             splitContainer.FixedPanel = FixedPanel.Panel2;
             splitContainer.ResumeLayout();
+
+            // The panels are swapped so the controls now live in Panel2, but the design SplitterDistance still
+            // sizes them as if they were Panel1, leaving the controls taking up most of the viewer. FixedPanel.Panel2
+            // then pins that width on the first layout pass, so the result depends on the size the control happens to
+            // have when first shown. Pin the controls to their intended width once we know a real size instead.
+            splitContainer.SizeChanged += PreviewControlsWidth_Init;
         }
+    }
+
+    private bool previewControlsWidthInitialized;
+
+    private void PreviewControlsWidth_Init(object? sender, EventArgs e)
+    {
+        if (previewControlsWidthInitialized)
+        {
+            return;
+        }
+
+        // Matches the non-preview sidebar width (design SplitterDistance / controlsPanel width).
+        var controlsWidth = this.AdjustForDPI(220);
+        var distance = splitContainer.Width - controlsWidth - splitContainer.SplitterWidth;
+
+        if (distance <= splitContainer.Panel1MinSize)
+        {
+            return; // not sized sensibly yet, try again on the next resize
+        }
+
+        splitContainer.SplitterDistance = distance;
+        previewControlsWidthInitialized = true;
+        splitContainer.SizeChanged -= PreviewControlsWidth_Init;
     }
 
     protected override void OnCreateControl()

--- a/GUI/Controls/RendererControl.cs
+++ b/GUI/Controls/RendererControl.cs
@@ -29,35 +29,32 @@ partial class RendererControl : UserControl
             splitContainer.FixedPanel = FixedPanel.Panel2;
             splitContainer.ResumeLayout();
 
-            // The panels are swapped so the controls now live in Panel2, but the design SplitterDistance still
-            // sizes them as if they were Panel1, leaving the controls taking up most of the viewer. FixedPanel.Panel2
-            // then pins that width on the first layout pass, so the result depends on the size the control happens to
-            // have when first shown. Pin the controls to their intended width once we know a real size instead.
-            splitContainer.SizeChanged += PreviewControlsWidth_Init;
+            splitContainer.SizeChanged += PreviewControls_HandleResize;
+            PreviewControls_HandleResize(splitContainer, EventArgs.Empty);
         }
     }
 
-    private bool previewControlsWidthInitialized;
-
-    private void PreviewControlsWidth_Init(object? sender, EventArgs e)
+    private void PreviewControls_HandleResize(object? sender, EventArgs e)
     {
-        if (previewControlsWidthInitialized)
+        // Respect an explicit HideSidebar() (e.g. node graph previews), which fixes the splitter and collapses it.
+        if (splitContainer.IsSplitterFixed)
         {
             return;
         }
 
         // Matches the non-preview sidebar width (design SplitterDistance / controlsPanel width).
         var controlsWidth = this.AdjustForDPI(220);
-        var distance = splitContainer.Width - controlsWidth - splitContainer.SplitterWidth;
+        var available = splitContainer.Width - splitContainer.SplitterWidth;
 
-        if (distance <= splitContainer.Panel1MinSize)
+        // Collapse the controls when the viewer (Panel1, left) would be narrower than the controls (Panel2, right).
+        if (available - controlsWidth < controlsWidth)
         {
-            return; // not sized sensibly yet, try again on the next resize
+            splitContainer.Panel2Collapsed = true;
+            return;
         }
 
-        splitContainer.SplitterDistance = distance;
-        previewControlsWidthInitialized = true;
-        splitContainer.SizeChanged -= PreviewControlsWidth_Init;
+        splitContainer.Panel2Collapsed = false;
+        splitContainer.SplitterDistance = available - controlsWidth;
     }
 
     protected override void OnCreateControl()

--- a/GUI/Controls/ThemedTabControl.cs
+++ b/GUI/Controls/ThemedTabControl.cs
@@ -67,6 +67,9 @@ namespace GUI.Controls
         [Description("Roundness of the corners of the top of tabs"), Category("Appearance")]
         public bool SelectionLine { get; set; } = true;
 
+        [Description("Hide the tab strip entirely and let the selected page fill the whole control"), Category("Appearance")]
+        public bool HideTabHeader { get; set; }
+
         private bool _endEllipsis;
         public bool EndEllipsis
         {
@@ -231,6 +234,12 @@ namespace GUI.Controls
         {
             get
             {
+                // No tab strip: let the selected page fill the entire control.
+                if (HideTabHeader)
+                {
+                    return new Rectangle(0, 0, Width, Height);
+                }
+
                 var rect = base.DisplayRectangle;
 
                 // extend the client area by 4 pixels, this makes the page inside the tab control flush with the edges
@@ -285,6 +294,11 @@ namespace GUI.Controls
             using (var bgBrush = new SolidBrush(BackColor))
             {
                 g.FillRectangle(bgBrush, ClientRectangle);
+            }
+
+            if (HideTabHeader)
+            {
+                return;
             }
 
             for (var i = 0; i < TabCount; i++)

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -849,29 +849,38 @@ namespace GUI
             {
                 BeginInvoke(() =>
                 {
-                    var viewer = t.Result;
+                    Cursor.Current = Cursors.WaitCursor;
 
-                    if (tab.IsDisposed)
+                    try
                     {
-                        viewer.Dispose();
-                        return; // closed tab before it loaded
+                        var viewer = t.Result;
+
+                        if (tab.IsDisposed)
+                        {
+                            viewer.Dispose();
+                            return; // closed tab before it loaded
+                        }
+
+                        if (tab.Tag is ExportData exportData)
+                        {
+                            exportData.DisposableContents = viewer;
+                        }
+                        else
+                        {
+                            Debug.Assert(false);
+                        }
+
+                        viewer.Create(tab);
+                        createdViewer = viewer;
+
+                        if (mainTabs.SelectedTab == tab)
+                        {
+                            UpdateBottomPanelKeybindings();
+                        }
                     }
-
-                    if (tab.Tag is ExportData exportData)
+                    finally
                     {
-                        exportData.DisposableContents = viewer;
-                    }
-                    else
-                    {
-                        Debug.Assert(false);
-                    }
-
-                    viewer.Create(tab);
-                    createdViewer = viewer;
-
-                    if (mainTabs.SelectedTab == tab)
-                    {
-                        UpdateBottomPanelKeybindings();
+                        Cursor.Current = Cursors.Default;
                     }
                 });
             },

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -494,18 +494,25 @@ namespace GUI
         private void OnMainSelectedTabChanged(object? sender, EventArgs e)
         {
 #if !SCREENSHOT_MODE
-            if (string.IsNullOrEmpty(mainTabs.SelectedTab?.ToolTipText))
-            {
-                Text = "Source 2 Viewer";
-            }
-            else
-            {
-                Text = $"Source 2 Viewer - {mainTabs.SelectedTab.ToolTipText}";
-            }
-
+            UpdateWindowTitle(mainTabs.SelectedTab?.ToolTipText);
             UpdateBottomPanelKeybindings();
 #endif
         }
+
+        private void UpdateWindowTitle(string? toolTipText)
+        {
+#if !SCREENSHOT_MODE
+            Text = string.IsNullOrEmpty(toolTipText)
+                ? "Source 2 Viewer"
+                : $"Source 2 Viewer - {toolTipText}";
+#endif
+        }
+
+        /// <summary>
+        /// Resets the window title to the selected tab. Called when a package preview is cleared (e.g. a folder is
+        /// shown) so the title stops reflecting the file that was being previewed.
+        /// </summary>
+        public void ResetPreviewTitle() => UpdateWindowTitle(mainTabs.SelectedTab?.ToolTipText);
 
         private void UpdateBottomPanelKeybindings()
         {
@@ -800,6 +807,12 @@ namespace GUI
             finally
             {
                 tabTemp?.Dispose();
+            }
+
+            if (isPreview)
+            {
+                // The preview tab is not in mainTabs, so update the window title to the previewed file ourselves.
+                UpdateWindowTitle(tab.ToolTipText);
             }
 
             // For a preview of the same type as the one already shown, keep that view frozen while the new file loads

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -811,6 +811,8 @@ namespace GUI
                 packageTreeView.ReplaceListViewWithControl(tab);
             }
 
+            Types.Viewers.IViewer? createdViewer = null;
+
             var taskLoad = Task.Run(() => ProcessFile(vrfGuiContext, file, viewMode));
 
             taskLoad.ContinueWith(t =>
@@ -853,6 +855,7 @@ namespace GUI
                     }
 
                     viewer.Create(tab);
+                    createdViewer = viewer;
 
                     if (mainTabs.SelectedTab == tab)
                     {
@@ -896,6 +899,10 @@ namespace GUI
                 BeginInvoke(() =>
                 {
                     loadingFile.Dispose();
+
+                    // Removing the loading panel that was covering the viewer does not reliably deliver a paint to
+                    // the underlying GL control, so tell the viewer to redraw now that it is visible.
+                    createdViewer?.NotifyVisible();
                 });
             });
         }

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -521,6 +521,20 @@ namespace GUI
             mainFormBottomPanel.UpdateKeybindings(keybindings);
         }
 
+        /// <summary>
+        /// Shows the keybindings for a previewed viewer
+        /// </summary>
+        public void ShowPreviewKeybindings(TabPage previewTab)
+        {
+            var keybindings = KeybindingRegistry.GetKeybindingsForViewer(KeybindingRegistry.GetViewerTypeFromTab(previewTab));
+            mainFormBottomPanel.UpdateKeybindings(keybindings);
+        }
+
+        /// <summary>
+        /// Shows the keybindings of the selected tab.
+        /// </summary>
+        public void ShowSelectedTabKeybindings() => UpdateBottomPanelKeybindings();
+
         private void CloseAndReOpenActiveTab()
         {
             var tab = mainTabs.SelectedTab;

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -802,13 +802,25 @@ namespace GUI
                 tabTemp?.Dispose();
             }
 
-            var loadingFile = new LoadingFile(vrfGuiContext.FileName);
-            tab.Controls.Add(loadingFile);
+            // For a preview of the same type as the one already shown, keep that view frozen while the new file loads
+            // and show no loading panel; the new viewer is swapped in once ready. Otherwise show the loading panel.
+            var keepFrozen = isPreview && packageTreeView!.IsSamePreviewType(file?.TypeName);
 
-            if (isPreview)
+            LoadingFile? loadingFile = null;
+
+            if (!keepFrozen)
             {
-                Debug.Assert(packageTreeView != null);
-                packageTreeView.ReplaceListViewWithControl(tab);
+#pragma warning disable CA2000 // Ownership is transferred to the tab, which disposes it
+                loadingFile = new LoadingFile(vrfGuiContext.FileName);
+#pragma warning restore CA2000
+                tab.Controls.Add(loadingFile);
+
+                if (isPreview)
+                {
+                    // Show the loading panel in the preview area right away (replacing the blank page).
+                    Debug.Assert(packageTreeView != null);
+                    packageTreeView.ReplaceListViewWithControl(tab, file?.TypeName);
+                }
             }
 
             Types.Viewers.IViewer? createdViewer = null;
@@ -898,10 +910,20 @@ namespace GUI
             {
                 BeginInvoke(() =>
                 {
-                    loadingFile.Dispose();
+                    if (keepFrozen)
+                    {
+                        // Same-type preview: swap the frozen previous view for the newly loaded viewer.
+                        Debug.Assert(packageTreeView != null);
+                        packageTreeView.ReplaceListViewWithControl(tab, file?.TypeName);
+                    }
+                    else
+                    {
+                        // The tab is already shown; disposing the loading panel reveals the viewer behind it.
+                        loadingFile?.Dispose();
+                    }
 
-                    // Removing the loading panel that was covering the viewer does not reliably deliver a paint to
-                    // the underlying GL control, so tell the viewer to redraw now that it is visible.
+                    // Revealing the viewer does not reliably deliver a paint to the underlying GL control, so tell
+                    // the viewer to redraw now that it is visible.
                     createdViewer?.NotifyVisible();
                 });
             });

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -835,37 +835,28 @@ namespace GUI
             {
                 BeginInvoke(() =>
                 {
-                    Cursor.Current = Cursors.WaitCursor;
+                    var viewer = t.Result;
 
-                    try
+                    if (tab.IsDisposed)
                     {
-                        var viewer = t.Result;
-
-                        if (tab.IsDisposed)
-                        {
-                            viewer.Dispose();
-                            return; // closed tab before it loaded
-                        }
-
-                        if (tab.Tag is ExportData exportData)
-                        {
-                            exportData.DisposableContents = viewer;
-                        }
-                        else
-                        {
-                            Debug.Assert(false);
-                        }
-
-                        viewer.Create(tab);
-
-                        if (mainTabs.SelectedTab == tab)
-                        {
-                            UpdateBottomPanelKeybindings();
-                        }
+                        viewer.Dispose();
+                        return; // closed tab before it loaded
                     }
-                    finally
+
+                    if (tab.Tag is ExportData exportData)
                     {
-                        Cursor.Current = Cursors.Default;
+                        exportData.DisposableContents = viewer;
+                    }
+                    else
+                    {
+                        Debug.Assert(false);
+                    }
+
+                    viewer.Create(tab);
+
+                    if (mainTabs.SelectedTab == tab)
+                    {
+                        UpdateBottomPanelKeybindings();
                     }
                 });
             },

--- a/GUI/MainForm.cs
+++ b/GUI/MainForm.cs
@@ -802,16 +802,13 @@ namespace GUI
                 tabTemp?.Dispose();
             }
 
-            Control? loadingFile = null;
+            var loadingFile = new LoadingFile(vrfGuiContext.FileName);
+            tab.Controls.Add(loadingFile);
 
-            if (!isPreview)
+            if (isPreview)
             {
-                loadingFile = new LoadingFile();
-                tab.Controls.Add(loadingFile);
-            }
-            else
-            {
-                Cursor.Current = Cursors.WaitCursor;
+                Debug.Assert(packageTreeView != null);
+                packageTreeView.ReplaceListViewWithControl(tab);
             }
 
             var taskLoad = Task.Run(() => ProcessFile(vrfGuiContext, file, viewMode));
@@ -824,11 +821,6 @@ namespace GUI
                 {
                     BeginInvoke(() =>
                     {
-                        if (isPreview)
-                        {
-                            Cursor.Current = Cursors.Default;
-                        }
-
                         var control = CodeTextBox.CreateFromException(ex, tab.ToolTipText);
 
                         tab.Controls.Add(control);
@@ -912,13 +904,7 @@ namespace GUI
             {
                 BeginInvoke(() =>
                 {
-                    loadingFile?.Dispose();
-
-                    if (isPreview)
-                    {
-                        Debug.Assert(packageTreeView != null);
-                        packageTreeView.ReplaceListViewWithControl(tab);
-                    }
+                    loadingFile.Dispose();
                 });
             });
         }

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -149,6 +149,15 @@ internal abstract class GLBaseControl : IDisposable
         }
     }
 
+    /// <summary>
+    /// Force the GL control to redraw. Used when the viewer becomes visible after being obscured (e.g. by a
+    /// loading panel), which does not reliably deliver a paint message to the underlying GL control on its own.
+    /// </summary>
+    public virtual void NotifyVisible()
+    {
+        GLControl?.Invalidate();
+    }
+
     protected virtual void AddUiControls()
     {
         // Implemented in derived classes

--- a/GUI/Types/GLViewers/GLTextureViewer.cs
+++ b/GUI/Types/GLViewers/GLTextureViewer.cs
@@ -559,6 +559,14 @@ namespace GUI.Types.GLViewers
             }
         }
 
+        public override void NotifyVisible()
+        {
+            if (GLControl?.Visible == true)
+            {
+                InvalidateRender();
+            }
+        }
+
         private void SetInitialDecodeFlagsState(CheckedListBox listBox)
         {
             listBox.Items.Clear();

--- a/GUI/Types/PackageViewer/PackageViewer.cs
+++ b/GUI/Types/PackageViewer/PackageViewer.cs
@@ -611,16 +611,8 @@ namespace GUI.Types.PackageViewer
                 return;
             }
 
-            if (((Settings.QuickPreviewFlags)Settings.Config.QuickFilePreview & Settings.QuickPreviewFlags.Enabled) == 0)
+            if (!TreeViewWithSearchResults.CanQuickPreviewFile(entry))
             {
-                return;
-            }
-
-            var extension = entry.TypeName;
-
-            if (extension is "vpk" or "vmap_c")
-            {
-                // Not ideal to check by file extension, but do not nest vpk previewss
                 return;
             }
 

--- a/GUI/Types/PackageViewer/PackageViewer.cs
+++ b/GUI/Types/PackageViewer/PackageViewer.cs
@@ -111,6 +111,8 @@ namespace GUI.Types.PackageViewer
             TreeView.OpenContextMenu += VPK_OnContextMenu;
             TreeView.PreviewFile += VPK_PreviewFile;
             TreeView.PreviewCleared += VPK_PreviewCleared;
+            TreeView.PreviewFocused += VPK_PreviewFocused;
+            TreeView.PreviewBlurred += VPK_PreviewBlurred;
             TreeView.Disposed += VPK_Disposed;
         }
 
@@ -589,6 +591,8 @@ namespace GUI.Types.PackageViewer
                 treeViewWithSearch.OpenContextMenu -= VPK_OnContextMenu;
                 treeViewWithSearch.PreviewFile -= VPK_PreviewFile;
                 treeViewWithSearch.PreviewCleared -= VPK_PreviewCleared;
+                treeViewWithSearch.PreviewFocused -= VPK_PreviewFocused;
+                treeViewWithSearch.PreviewBlurred -= VPK_PreviewBlurred;
                 treeViewWithSearch.Disposed -= VPK_Disposed;
                 TreeView = null;
                 LastContextTreeNode = null;
@@ -610,6 +614,16 @@ namespace GUI.Types.PackageViewer
         {
             // A folder is shown instead of a file preview, so the window title should no longer reflect a file.
             Program.MainForm.ResetPreviewTitle();
+        }
+
+        private void VPK_PreviewFocused(object? sender, TabPage previewTab)
+        {
+            Program.MainForm.ShowPreviewKeybindings(previewTab);
+        }
+
+        private void VPK_PreviewBlurred(object? sender, EventArgs e)
+        {
+            Program.MainForm.ShowSelectedTabKeybindings();
         }
 
         private void VPK_PreviewFile(object? sender, PackageEntry entry)

--- a/GUI/Types/PackageViewer/PackageViewer.cs
+++ b/GUI/Types/PackageViewer/PackageViewer.cs
@@ -110,6 +110,7 @@ namespace GUI.Types.PackageViewer
             TreeView.OpenPackageEntry += VPK_OpenFile;
             TreeView.OpenContextMenu += VPK_OnContextMenu;
             TreeView.PreviewFile += VPK_PreviewFile;
+            TreeView.PreviewCleared += VPK_PreviewCleared;
             TreeView.Disposed += VPK_Disposed;
         }
 
@@ -587,6 +588,7 @@ namespace GUI.Types.PackageViewer
                 treeViewWithSearch.OpenPackageEntry -= VPK_OpenFile;
                 treeViewWithSearch.OpenContextMenu -= VPK_OnContextMenu;
                 treeViewWithSearch.PreviewFile -= VPK_PreviewFile;
+                treeViewWithSearch.PreviewCleared -= VPK_PreviewCleared;
                 treeViewWithSearch.Disposed -= VPK_Disposed;
                 TreeView = null;
                 LastContextTreeNode = null;
@@ -602,6 +604,12 @@ namespace GUI.Types.PackageViewer
         {
             var newVrfGuiContext = new VrfGuiContext(entry.GetFullPath(), vrfGuiContext);
             Program.MainForm.OpenFile(newVrfGuiContext, entry);
+        }
+
+        private void VPK_PreviewCleared(object? sender, EventArgs e)
+        {
+            // A folder is shown instead of a file preview, so the window title should no longer reflect a file.
+            Program.MainForm.ResetPreviewTitle();
         }
 
         private void VPK_PreviewFile(object? sender, PackageEntry entry)

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -1954,6 +1954,7 @@ namespace GUI.Types.PackageViewer
                 ThumbnailRenderQueue.CompleteAdding();
                 ThumbnailRenderQueue.Dispose();
                 RenderLoopCancelationTokenSource.Dispose();
+                PreviewTokenSource?.Dispose();
 
                 foreach (var renderer in ThumbnailRenderers.Values)
                 {

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -244,6 +244,8 @@ namespace GUI.Types.PackageViewer
             {
                 OpenPackageEntry?.Invoke(sender, node.PackageEntry);
             }
+
+            DisplayMainListView();
         }
 
         private void MainTreeView_AfterSelect(object? sender, TreeViewEventArgs e)
@@ -252,6 +254,15 @@ namespace GUI.Types.PackageViewer
             {
                 return;
             }
+
+            if (PreviewTokenSource is not null)
+            {
+                PreviewTokenSource.Cancel();
+                PreviewTokenSource.Dispose();
+            }
+
+            PreviewTokenSource = new CancellationTokenSource();
+            var token = PreviewTokenSource.Token;
 
             var realNode = (BetterTreeNode)e.Node;
 
@@ -264,31 +275,24 @@ namespace GUI.Types.PackageViewer
                 {
                     MainListView_DisplayNodes(realNode.PkgNode);
                 }
+
+                return;
             }
-            else
+
+            if (realNode.PackageEntry != null)
             {
-                PreviewTokenSource?.Dispose();
-                PreviewTokenSource = new CancellationTokenSource();
+                // Blank the list view right away on a mouse click to minimize flashing
+                if (CanQuickPreviewFile(realNode.PackageEntry))
+                {
+                    ShowPreviewPlaceholder();
+                }
 
                 Task.Run(async () =>
                 {
-                    var token = PreviewTokenSource.Token;
-
                     // The default double-click time in windows (500) is too long to wait entirely.
-                    var mouseDoubleClickIntervalMs = 200;
-                    await Task.Delay(mouseDoubleClickIntervalMs).ConfigureAwait(false);
-
-                    // double-clicked or started previewing a different file
-                    if (token.IsCancellationRequested)
-                    {
-                        return;
-                    }
-
-                    if (realNode.PackageEntry != null)
-                    {
-                        await InvokeAsync(() => PreviewFile?.Invoke(sender, realNode.PackageEntry)).ConfigureAwait(false);
-                    }
-                });
+                    await Task.Delay(200, token).ConfigureAwait(false);
+                    await InvokeAsync(() => PreviewFile?.Invoke(sender, realNode.PackageEntry), token).ConfigureAwait(false);
+                }, token);
             }
         }
 
@@ -1511,6 +1515,58 @@ namespace GUI.Types.PackageViewer
             foreach (Control old in parentControl.Controls)
             {
                 if (old == tabs || old == mainListView) // TODO: dumb
+                {
+                    continue;
+                }
+
+                old.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Whether a quick file preview should be shown for the given entry: quick preview must be enabled, and
+        /// the file must not be one we deliberately don't preview inline (vpk to avoid nesting, vmap_c).
+        /// </summary>
+        public static bool CanQuickPreviewFile(PackageEntry entry)
+        {
+            if (((Settings.QuickPreviewFlags)Settings.Config.QuickFilePreview & Settings.QuickPreviewFlags.Enabled) == 0)
+            {
+                return false;
+            }
+
+            // Not ideal to check by file extension, but do not nest vpk previews
+            return entry.TypeName is not ("vpk" or "vmap_c");
+        }
+
+        /// <summary>
+        /// Immediately blanks the list view area with an empty themed panel. Used to give a preview instant
+        /// visual feedback on click, before the double-click debounce elapses and the real loading panel is shown.
+        /// The blank panel matches the loading panel background so the later swap is seamless. It is disposed by
+        /// <see cref="ReplaceListViewWithControl"/> when the preview loads, or by <see cref="DisplayMainListView"/>.
+        /// </summary>
+        private void ShowPreviewPlaceholder()
+        {
+            var parentControl = mainListView.Parent;
+
+            if (parentControl == null)
+            {
+                return;
+            }
+
+            mainListView.Visible = false;
+            SetGridModeToolbarVisible(false);
+
+            var placeholder = new Panel
+            {
+                Dock = DockStyle.Fill,
+                BackColor = Themer.CurrentThemeColors.AppMiddle,
+            };
+
+            parentControl.Controls.Add(placeholder);
+
+            foreach (Control old in parentControl.Controls)
+            {
+                if (old == placeholder || old == mainListView)
                 {
                     continue;
                 }

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -281,8 +281,9 @@ namespace GUI.Types.PackageViewer
 
             if (realNode.PackageEntry != null)
             {
-                // Blank the list view right away on a mouse click to minimize flashing
-                if (CanQuickPreviewFile(realNode.PackageEntry))
+                // Blank the list view right away on a mouse click to minimize flashing, but if the next file is the
+                // same type as the one currently shown, keep that view as the background instead of flashing to blank.
+                if (CanQuickPreviewFile(realNode.PackageEntry) && realNode.PackageEntry.TypeName != currentPreviewType)
                 {
                     ShowPreviewPlaceholder();
                 }
@@ -1501,7 +1502,11 @@ namespace GUI.Types.PackageViewer
             ListViewItems.Add(item);
         }
 
-        public void ReplaceListViewWithControl(TabPage tab)
+        // The file type currently shown in the preview area, so a same-type preview can keep the previous view frozen
+        // instead of flashing to a blank page. Null when the area shows a blank page or the list.
+        private string? currentPreviewType;
+
+        public void ReplaceListViewWithControl(TabPage tab, string? typeName = null)
         {
             var parentControl = mainListView.Parent;
 
@@ -1524,6 +1529,8 @@ namespace GUI.Types.PackageViewer
             tabs.Controls.Add(tab);
             parentControl.Controls.Add(tabs);
 
+            currentPreviewType = typeName;
+
             foreach (Control old in parentControl.Controls)
             {
                 if (old == tabs || old == mainListView)
@@ -1534,6 +1541,12 @@ namespace GUI.Types.PackageViewer
                 old.Dispose();
             }
         }
+
+        /// <summary>
+        /// Whether the given file type is the one currently shown in the preview area, in which case the previous view
+        /// can be kept frozen while the next file of the same type loads.
+        /// </summary>
+        public bool IsSamePreviewType(string? typeName) => typeName != null && typeName == currentPreviewType;
 
         /// <summary>
         /// Whether a quick file preview should be shown for the given entry: quick preview must be enabled, and
@@ -1576,6 +1589,8 @@ namespace GUI.Types.PackageViewer
 
             parentControl.Controls.Add(placeholder);
 
+            currentPreviewType = null;
+
             foreach (Control old in parentControl.Controls)
             {
                 if (old == placeholder || old == mainListView)
@@ -1599,6 +1614,8 @@ namespace GUI.Types.PackageViewer
             {
                 return;
             }
+
+            currentPreviewType = null;
 
             foreach (Control old in mainListView.Parent.Controls)
             {

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -74,6 +74,8 @@ namespace GUI.Types.PackageViewer
 
         // Raised when the file list (a folder) is shown, i.e. no file is being previewed anymore.
         public event EventHandler? PreviewCleared;
+        public event EventHandler<TabPage>? PreviewFocused;
+        public event EventHandler? PreviewBlurred;
 
         private readonly NavigationHistory navigationHistory = new();
         private bool suppressHistoryRecording;
@@ -1532,6 +1534,9 @@ namespace GUI.Types.PackageViewer
             tabs.Controls.Add(tab);
             parentControl.Controls.Add(tabs);
 
+            tabs.Enter += PreviewControl_Enter;
+            tabs.Leave += PreviewControl_Leave;
+
             currentPreviewType = typeName;
 
             foreach (Control old in parentControl.Controls)
@@ -1544,6 +1549,16 @@ namespace GUI.Types.PackageViewer
                 old.Dispose();
             }
         }
+
+        private void PreviewControl_Enter(object? sender, EventArgs e)
+        {
+            if (sender is TabControl { SelectedTab: { } tab })
+            {
+                PreviewFocused?.Invoke(this, tab);
+            }
+        }
+
+        private void PreviewControl_Leave(object? sender, EventArgs e) => PreviewBlurred?.Invoke(this, EventArgs.Empty);
 
         /// <summary>
         /// Whether the given file type is the one currently shown in the preview area, in which case the previous view

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -1492,29 +1492,30 @@ namespace GUI.Types.PackageViewer
 
         public void ReplaceListViewWithControl(TabPage tab)
         {
-            mainListView.Visible = false;
-            SetGridModeToolbarVisible(false);
-
-            var tabs = new ThemedTabControl
-            {
-                ImageList = MainForm.ImageList,
-                Dock = DockStyle.Fill
-            };
-            tabs.Controls.Add(tab);
-
             var parentControl = mainListView.Parent;
 
             if (parentControl == null)
             {
-                tabs.Dispose();
                 return;
             }
 
+            mainListView.Visible = false;
+            SetGridModeToolbarVisible(false);
+
+            // A TabPage can only render inside a TabControl, so host it in one with the tab strip hidden. There is
+            // no visible tab header; the file name is shown in the viewer's side control panel instead
+            // (see RendererControl.AddPreviewFileName).
+            var tabs = new ThemedTabControl
+            {
+                Dock = DockStyle.Fill,
+                HideTabHeader = true,
+            };
+            tabs.Controls.Add(tab);
             parentControl.Controls.Add(tabs);
 
             foreach (Control old in parentControl.Controls)
             {
-                if (old == tabs || old == mainListView) // TODO: dumb
+                if (old == tabs || old == mainListView)
                 {
                     continue;
                 }

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -689,6 +689,17 @@ namespace GUI.Types.PackageViewer
             return "File";
         }
 
+        /// <summary>
+        /// Renders the file-type SVG icon at the given size — the same icon the grid view falls back to when a
+        /// file has no rendered thumbnail.
+        /// </summary>
+        internal static Bitmap GetTypeIconBitmap(string typeName, int size)
+        {
+            var svg = MainForm.ExtensionSVGS.GetValueOrDefault(ResolveExtension(typeName))
+                ?? MainForm.ExtensionSVGS.GetValueOrDefault("File");
+            return Themer.SvgToBitmap(svg!, size, size);
+        }
+
         private ImageList InitThumbnailImageList()
         {
             var currentThumbnailSize = (int)CurrentThumbnailSizes;
@@ -1756,11 +1767,8 @@ namespace GUI.Types.PackageViewer
 
                 if (!BigIconImageCache.TryGetValue(extension, out var iconImageCacheEntry) || iconImageCacheEntry == null)
                 {
-                    MainForm.ExtensionSVGS.TryGetValue(extension, out var svgFile);
-                    svgFile ??= MainForm.ExtensionSVGS.GetValueOrDefault("File");
-
 #pragma warning disable CA2000 // Bitmap lifetime is managed by ImageList, when ImageList is disposed it disposes all images too
-                    var bitmap = Themer.SvgToBitmap(svgFile!, currentThumbnailSizeInt, currentThumbnailSizeInt);
+                    var bitmap = GetTypeIconBitmap(entry.TypeName, currentThumbnailSizeInt);
 
                     lock (ImageListLock)
                     {

--- a/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
+++ b/GUI/Types/PackageViewer/TreeViewWithSearchResults.cs
@@ -72,6 +72,9 @@ namespace GUI.Types.PackageViewer
         public event EventHandler<PackageContextMenuEventArgs>? OpenContextMenu;
         public event EventHandler<PackageEntry>? PreviewFile;
 
+        // Raised when the file list (a folder) is shown, i.e. no file is being previewed anymore.
+        public event EventHandler? PreviewCleared;
+
         private readonly NavigationHistory navigationHistory = new();
         private bool suppressHistoryRecording;
 
@@ -1627,6 +1630,8 @@ namespace GUI.Types.PackageViewer
 
             SetGridModeToolbarVisible(true);
             mainListView.Visible = true;
+
+            PreviewCleared?.Invoke(this, EventArgs.Empty);
         }
 
         private void UpdateSearchTextBoxToCurrentPath(VirtualPackageNode node)

--- a/GUI/Types/Viewers/IViewer.cs
+++ b/GUI/Types/Viewers/IViewer.cs
@@ -11,6 +11,12 @@ namespace GUI.Types.Viewers
         public Task LoadAsync(Stream? stream);
         public void Create(TabPage containerTabPage);
 
+        /// <summary>
+        /// Called after the viewer has been made visible (the loading panel was removed). Viewers that render
+        /// lazily (e.g. GL viewers) use this to force their first draw. No-op by default.
+        /// </summary>
+        public void NotifyVisible() { }
+
         public static TabPage AddContentTab<T>(ThemedTabControl resTabs, string name, T content, bool preSelect = false, HighlightLanguage highlightSyntax = HighlightLanguage.Default)
         {
             var extract = string.Empty;

--- a/GUI/Types/Viewers/Image.cs
+++ b/GUI/Types/Viewers/Image.cs
@@ -53,6 +53,8 @@ namespace GUI.Types.Viewers
             glViewer.InitializeRenderLoop();
         }
 
+        public void NotifyVisible() => glViewer?.NotifyVisible();
+
         public void Dispose()
         {
             bitmap?.Dispose();

--- a/GUI/Types/Viewers/ImageVector.cs
+++ b/GUI/Types/Viewers/ImageVector.cs
@@ -51,6 +51,8 @@ namespace GUI.Types.Viewers
             textureControl.InitializeRenderLoop();
         }
 
+        public void NotifyVisible() => textureControl?.NotifyVisible();
+
         public void Dispose()
         {
             svg?.Dispose();

--- a/GUI/Types/Viewers/NavView.cs
+++ b/GUI/Types/Viewers/NavView.cs
@@ -93,6 +93,8 @@ namespace GUI.Types.Viewers
             }
         }
 
+        public void NotifyVisible() => glViewer?.NotifyVisible();
+
         public void Dispose()
         {
             glViewer?.Dispose();

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -235,6 +235,8 @@ namespace GUI.Types.Viewers
             GLViewer?.InitializeLoad();
         }
 
+        public void NotifyVisible() => GLViewer?.NotifyVisible();
+
         public void Create(TabPage containerTabPage)
         {
             Debug.Assert(resource is not null);

--- a/GUI/Types/Viewers/Resource.cs
+++ b/GUI/Types/Viewers/Resource.cs
@@ -428,6 +428,18 @@ namespace GUI.Types.Viewers
 
                 var glViewerControl = GLViewer.InitializeUiControls(isPreview);
 
+                if (isPreview && glViewerControl is RendererControl rendererControl)
+                {
+                    // No tab header in preview, so show the file name (and icon) at the top of the side control panel.
+                    var iconExtension = Path.GetExtension(vrfGuiContext.FileName.AsSpan());
+                    if (iconExtension.Length > 0)
+                    {
+                        iconExtension = iconExtension[1..];
+                    }
+
+                    rendererControl.AddPreviewFileName(Path.GetFileName(vrfGuiContext.FileName), MainForm.GetImageIndexForExtension(iconExtension));
+                }
+
                 var specialTabPage = new ThemedTabPage(GLViewerTabName);
                 resTabs.TabPages.Add(specialTabPage);
                 specialTabPage.Controls.Add(glViewerControl);


### PR DESCRIPTION
* The preview panel now shows a proper loading screen
  * When changing to previews of same file type, keep previous behavior to minimize flashing
* Hide controls/sidebar when renderer panel gets small
* Move file name to the right side panel for resources with special viewer
* Update window text when opening a preview tab. Another place to show full file name.
* Refresh keybindings when focusing a preview tab