### PR TITLE
Particle renderer fixes

### DIFF
--- a/Renderer/ParticleRenderer/AttributeMapping.cs
+++ b/Renderer/ParticleRenderer/AttributeMapping.cs
@@ -40,10 +40,28 @@ namespace ValveResourceFormat.Renderer.Particles
             Curve,
             /// <summary>Returns one of two output values depending on whether the input is within a range.</summary>
             Notched,
+            /// <summary>Rounds the input value using the configured rounding mode.</summary>
+            Round,
         };
+
+        /// <summary>
+        /// Rounding modes for <see cref="PfMapType.Round"/>.
+        /// </summary>
+        public enum PfRoundType
+        {
+            /// <summary>Invalid rounding mode.</summary>
+            Invalid = -1,
+            /// <summary>Round to the nearest integer.</summary>
+            Nearest,
+            /// <summary>Round down.</summary>
+            Floor,
+            /// <summary>Round up.</summary>
+            Ceil,
+        }
 
         private readonly PfMapType MapType;
         private readonly PfInputMode InputMode = PfInputMode.Clamped;
+        private readonly PfRoundType roundType = PfRoundType.Nearest;
 
         private readonly float multFactor;
 
@@ -51,6 +69,11 @@ namespace ValveResourceFormat.Renderer.Particles
         private readonly float input1;
         private readonly float output0;
         private readonly float output1;
+
+        private readonly float notchedRangeMin;
+        private readonly float notchedRangeMax;
+        private readonly float notchedOutputOutside;
+        private readonly float notchedOutputInside;
 
         //private readonly ParticleFloatBiasType biasType;
         //private readonly float biasParameter;
@@ -79,8 +102,8 @@ namespace ValveResourceFormat.Renderer.Particles
                     output0 = parse.Float("m_flOutput0");
                     output1 = parse.Float("m_flOutput1");
 
-                    // Sort the input range, swapping the outputs with it so inverting
-                    // remaps (e.g. output 1 -> 0) keep their direction
+                    // Sort the input range, swapping the outputs with it so the authored
+                    // input->output pairing (which may deliberately descend) is preserved
                     if (input0 > input1)
                     {
                         (input0, input1) = (input1, input0);
@@ -95,12 +118,14 @@ namespace ValveResourceFormat.Renderer.Particles
                     break;
 
                 case PfMapType.Notched:
-                    /* NOTCHED PARAMS:
-                    * m_flNotchedRangeMin
-                    * m_flNotchedRangeMax
-                    * m_flNotchedOutputOutside
-                    * m_flNotchedOutputInside
-                    */
+                    notchedRangeMin = parse.Float("m_flNotchedRangeMin");
+                    notchedRangeMax = parse.Float("m_flNotchedRangeMax");
+                    notchedOutputOutside = parse.Float("m_flNotchedOutputOutside");
+                    notchedOutputInside = parse.Float("m_flNotchedOutputInside");
+                    break;
+
+                case PfMapType.Round:
+                    roundType = parse.EnumNormalized<PfRoundType>("m_nRoundType", roundType);
                     break;
 
                 default:
@@ -147,6 +172,19 @@ namespace ValveResourceFormat.Renderer.Particles
 
                 case PfMapType.Curve:
                     return curve!.Evaluate(value);
+
+                case PfMapType.Notched:
+                    return value >= notchedRangeMin && value <= notchedRangeMax
+                        ? notchedOutputInside
+                        : notchedOutputOutside;
+
+                case PfMapType.Round:
+                    return roundType switch
+                    {
+                        PfRoundType.Floor => MathF.Floor(value),
+                        PfRoundType.Ceil => MathF.Ceiling(value),
+                        _ => MathF.Round(value),
+                    };
 
                 default:
                     return value;

--- a/Renderer/ParticleRenderer/AttributeMapping.cs
+++ b/Renderer/ParticleRenderer/AttributeMapping.cs
@@ -40,28 +40,10 @@ namespace ValveResourceFormat.Renderer.Particles
             Curve,
             /// <summary>Returns one of two output values depending on whether the input is within a range.</summary>
             Notched,
-            /// <summary>Rounds the input value using the configured rounding mode.</summary>
-            Round,
         };
-
-        /// <summary>
-        /// Rounding modes for <see cref="PfMapType.Round"/>.
-        /// </summary>
-        public enum PfRoundType
-        {
-            /// <summary>Invalid rounding mode.</summary>
-            Invalid = -1,
-            /// <summary>Round to the nearest integer.</summary>
-            Nearest,
-            /// <summary>Round down.</summary>
-            Floor,
-            /// <summary>Round up.</summary>
-            Ceil,
-        }
 
         private readonly PfMapType MapType;
         private readonly PfInputMode InputMode = PfInputMode.Clamped;
-        private readonly PfRoundType roundType = PfRoundType.Nearest;
 
         private readonly float multFactor;
 
@@ -69,11 +51,6 @@ namespace ValveResourceFormat.Renderer.Particles
         private readonly float input1;
         private readonly float output0;
         private readonly float output1;
-
-        private readonly float notchedRangeMin;
-        private readonly float notchedRangeMax;
-        private readonly float notchedOutputOutside;
-        private readonly float notchedOutputInside;
 
         //private readonly ParticleFloatBiasType biasType;
         //private readonly float biasParameter;
@@ -102,9 +79,13 @@ namespace ValveResourceFormat.Renderer.Particles
                     output0 = parse.Float("m_flOutput0");
                     output1 = parse.Float("m_flOutput1");
 
-                    // Only the input range is ordered; the outputs are lerp endpoints and may
-                    // deliberately descend (e.g. an emit rate ramping down over the system age).
-                    MathUtils.MinMaxFixUp(ref input0, ref input1);
+                    // Sort the input range, swapping the outputs with it so inverting
+                    // remaps (e.g. output 1 -> 0) keep their direction
+                    if (input0 > input1)
+                    {
+                        (input0, input1) = (input1, input0);
+                        (output0, output1) = (output1, output0);
+                    }
 
                     break;
 
@@ -114,14 +95,12 @@ namespace ValveResourceFormat.Renderer.Particles
                     break;
 
                 case PfMapType.Notched:
-                    notchedRangeMin = parse.Float("m_flNotchedRangeMin");
-                    notchedRangeMax = parse.Float("m_flNotchedRangeMax");
-                    notchedOutputOutside = parse.Float("m_flNotchedOutputOutside");
-                    notchedOutputInside = parse.Float("m_flNotchedOutputInside");
-                    break;
-
-                case PfMapType.Round:
-                    roundType = parse.EnumNormalized<PfRoundType>("m_nRoundType", roundType);
+                    /* NOTCHED PARAMS:
+                    * m_flNotchedRangeMin
+                    * m_flNotchedRangeMax
+                    * m_flNotchedOutputOutside
+                    * m_flNotchedOutputInside
+                    */
                     break;
 
                 default:
@@ -158,7 +137,9 @@ namespace ValveResourceFormat.Renderer.Particles
                 case PfMapType.RemapBiased:
                     var remappedTo0_1RangeBiased = MathUtils.Remap(value, input0, input1);
 
-                    if (InputMode == PfInputMode.Looped) { remappedTo0_1RangeBiased = MathUtils.Fract(remappedTo0_1RangeBiased); }
+                    remappedTo0_1RangeBiased = InputMode == PfInputMode.Looped
+                        ? MathUtils.Fract(remappedTo0_1RangeBiased)
+                        : MathUtils.Saturate(remappedTo0_1RangeBiased);
 
                     // TODO: Insert bias processing here. Shared with randombiased mode in INumberProvider
 
@@ -166,19 +147,6 @@ namespace ValveResourceFormat.Renderer.Particles
 
                 case PfMapType.Curve:
                     return curve!.Evaluate(value);
-
-                case PfMapType.Notched:
-                    return value >= notchedRangeMin && value <= notchedRangeMax
-                        ? notchedOutputInside
-                        : notchedOutputOutside;
-
-                case PfMapType.Round:
-                    return roundType switch
-                    {
-                        PfRoundType.Floor => MathF.Floor(value),
-                        PfRoundType.Ceil => MathF.Ceiling(value),
-                        _ => MathF.Round(value),
-                    };
 
                 default:
                     return value;

--- a/Renderer/ParticleRenderer/Emitters/ContinuousEmitter.cs
+++ b/Renderer/ParticleRenderer/Emitters/ContinuousEmitter.cs
@@ -1,15 +1,21 @@
 namespace ValveResourceFormat.Renderer.Particles.Emitters
 {
     /// <summary>
-    /// Emits particles continuously at a fixed rate over an optional duration window.
+    /// Emits particles at the specified rate over time. By default (a duration of 0), the emitter
+    /// continues to emit forever.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_ContinuousEmitter">C_OP_ContinuousEmitter</seealso>
     class ContinuousEmitter : ParticleFunctionEmitter
     {
         public override bool IsFinished { get; protected set; }
 
+        /// <summary>Length of time to continue emitting particles (seconds).</summary>
         private readonly INumberProvider emissionDuration = new LiteralNumberProvider(0);
+
+        /// <summary>Time at which to begin emitting particles (seconds).</summary>
         private readonly INumberProvider startTime = new LiteralNumberProvider(0);
+
+        /// <summary>Number of particles to spawn (per second).</summary>
         private readonly INumberProvider emitRate = new LiteralNumberProvider(100);
 
         private Action? particleEmitCallback;

--- a/Renderer/ParticleRenderer/Emitters/ContinuousEmitter.cs
+++ b/Renderer/ParticleRenderer/Emitters/ContinuousEmitter.cs
@@ -59,6 +59,13 @@ namespace ValveResourceFormat.Renderer.Particles.Emitters
                 var rate = emitRate.NextNumber(particleSystemState);
                 if (rate > 0f)
                 {
+                    // Don't count time before the start time as pending emission,
+                    // otherwise the first emitting frame bursts all of it at once
+                    if (lastEmissionTime < nextStartTime)
+                    {
+                        lastEmissionTime = nextStartTime;
+                    }
+
                     var emitInterval = 1.0f / rate;
                     var numToEmit = (int)MathF.Floor((time - lastEmissionTime) / emitInterval);
                     for (var i = 0; i < numToEmit; i++)

--- a/Renderer/ParticleRenderer/Emitters/NoiseEmitter.cs
+++ b/Renderer/ParticleRenderer/Emitters/NoiseEmitter.cs
@@ -38,7 +38,8 @@ namespace ValveResourceFormat.Renderer.Particles.Emitters
             this.particleEmitCallback = particleEmitCallback;
 
             time = 0f;
-            particlesToEmit = 0f;
+            // Source 2 starts the accumulator at 1 so short or slow emitters (rate * duration <= 1) still emit
+            particlesToEmit = 1f;
 
             IsFinished = false;
         }
@@ -63,15 +64,15 @@ namespace ValveResourceFormat.Renderer.Particles.Emitters
 
             if (time >= nextStartTime && (nextEmissionDuration == 0f || time <= nextStartTime + nextEmissionDuration))
             {
-                // Calculate current emission rate based on noise
-                var noise = Noise.Simplex1D(time * noiseScale.NextNumber(particleSystemState));
+                // Calculate current emission rate based on noise, remapped from [-1, 1] to [0, 1]
+                var noise = (Noise.Simplex1D(time * noiseScale.NextNumber(particleSystemState)) * 0.5f) + 0.5f;
                 var emissionMinValue = emissionMin.NextNumber(particleSystemState);
                 var emissionMaxValue = emissionMax.NextNumber(particleSystemState);
                 var emissionRate = emissionMinValue + noise * (emissionMaxValue - emissionMinValue);
 
-                // Aggregate emission into num of particles to emit.
-                // Min/Max instead of Clamp because a negative m_flOutputMax must not throw.
-                particlesToEmit += Math.Max(0f, Math.Min(emissionRate, emissionMaxValue)) * frameTime; // Limit the amount of particles to emit at once in case of refocus
+                // Aggregate emission into num of particles to emit. The noise remap already targets
+                // the min/max range, so no upper clamp (an inverted range must not kill the emitter).
+                particlesToEmit += Math.Max(0f, emissionRate) * frameTime;
 
                 // If nr of particles to emit is > 0, emit it
                 while (particlesToEmit > 1.0f)

--- a/Renderer/ParticleRenderer/Emitters/NoiseEmitter.cs
+++ b/Renderer/ParticleRenderer/Emitters/NoiseEmitter.cs
@@ -38,6 +38,7 @@ namespace ValveResourceFormat.Renderer.Particles.Emitters
             this.particleEmitCallback = particleEmitCallback;
 
             time = 0f;
+            particlesToEmit = 0f;
 
             IsFinished = false;
         }
@@ -68,8 +69,9 @@ namespace ValveResourceFormat.Renderer.Particles.Emitters
                 var emissionMaxValue = emissionMax.NextNumber(particleSystemState);
                 var emissionRate = emissionMinValue + noise * (emissionMaxValue - emissionMinValue);
 
-                // Aggregate emission into num of particles to emit
-                particlesToEmit += Math.Clamp(emissionRate, 0, emissionMaxValue) * frameTime; // Limit the amount of particles to emit at once in case of refocus
+                // Aggregate emission into num of particles to emit.
+                // Min/Max instead of Clamp because a negative m_flOutputMax must not throw.
+                particlesToEmit += Math.Max(0f, Math.Min(emissionRate, emissionMaxValue)) * frameTime; // Limit the amount of particles to emit at once in case of refocus
 
                 // If nr of particles to emit is > 0, emit it
                 while (particlesToEmit > 1.0f)

--- a/Renderer/ParticleRenderer/ForceGenerators/AttractToControlPoint.cs
+++ b/Renderer/ParticleRenderer/ForceGenerators/AttractToControlPoint.cs
@@ -4,6 +4,10 @@ namespace ValveResourceFormat.Renderer.Particles.ForceGenerators;
 /// Applies a gravitational pull force toward a control point, with configurable strength
 /// and distance-based falloff power.
 /// </summary>
+/// <remarks>
+/// "Pull Towards Control Point" in the particle editor. Can also be used to repel particles
+/// by using negative values for the amount of force.
+/// </remarks>
 /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_AttractToControlPoint">C_OP_AttractToControlPoint</seealso>
 class AttractToControlPoint : ParticleFunctionForceGenerator
 {

--- a/Renderer/ParticleRenderer/ForceGenerators/CurlNoiseForce.cs
+++ b/Renderer/ParticleRenderer/ForceGenerators/CurlNoiseForce.cs
@@ -70,12 +70,46 @@ class CurlNoiseForce : ParticleFunctionForceGenerator
 
     private static Vector3 NoiseField(Vector3 pos)
     {
-        // Simple 3D noise vector field using the existing pseudo-random function
-        // Each component uses different frequency combinations for variation
-        var fx = Utils.Noise.Simplex1D(pos.X * 0.01f + pos.Y * 0.005f + pos.Z * 0.002f);
-        var fy = Utils.Noise.Simplex1D(pos.X * 0.007f + pos.Y * 0.01f + pos.Z * 0.003f);
-        var fz = Utils.Noise.Simplex1D(pos.X * 0.004f + pos.Y * 0.008f + pos.Z * 0.01f);
+        // Three decorrelated samples of the 3D value-noise lattice form the vector field.
+        return new Vector3(
+            Noise3D(pos),
+            Noise3D(pos + new Vector3(31.416f, 0f, 0f)),
+            Noise3D(pos + new Vector3(0f, 0f, 47.853f))
+        );
+    }
 
-        return new Vector3(fx, fy, fz);
+    // Trilinear value noise over an integer lattice, returning [-1, 1] to match Source's DNoiseSIMD.
+    private static float Noise3D(Vector3 pos)
+    {
+        var ix = (int)MathF.Floor(pos.X);
+        var iy = (int)MathF.Floor(pos.Y);
+        var iz = (int)MathF.Floor(pos.Z);
+
+        var u = Fade(pos.X - ix);
+        var v = Fade(pos.Y - iy);
+        var w = Fade(pos.Z - iz);
+
+        var c00 = float.Lerp(Hash(ix, iy, iz), Hash(ix + 1, iy, iz), u);
+        var c10 = float.Lerp(Hash(ix, iy + 1, iz), Hash(ix + 1, iy + 1, iz), u);
+        var c01 = float.Lerp(Hash(ix, iy, iz + 1), Hash(ix + 1, iy, iz + 1), u);
+        var c11 = float.Lerp(Hash(ix, iy + 1, iz + 1), Hash(ix + 1, iy + 1, iz + 1), u);
+
+        var c0 = float.Lerp(c00, c10, v);
+        var c1 = float.Lerp(c01, c11, v);
+
+        return (2f * float.Lerp(c0, c1, w)) - 1f;
+    }
+
+    private static float Fade(float t) => t * t * t * (t * ((t * 6f) - 15f) + 10f);
+
+    private static float Hash(int x, int y, int z)
+    {
+        unchecked
+        {
+            var h = (x * 374761393) + (y * 668265263) + (z * 1274126177);
+            h = (h ^ (h >> 13)) * 1274126177;
+            h ^= h >> 16;
+            return (h & 0x7fffffff) / (float)int.MaxValue;
+        }
     }
 }

--- a/Renderer/ParticleRenderer/ForceGenerators/CurlNoiseForce.cs
+++ b/Renderer/ParticleRenderer/ForceGenerators/CurlNoiseForce.cs
@@ -8,6 +8,8 @@ namespace ValveResourceFormat.Renderer.Particles.ForceGenerators;
 class CurlNoiseForce : ParticleFunctionForceGenerator
 {
     private readonly IVectorProvider NoiseFrequency = new LiteralVectorProvider(new Vector3(0.02f));
+
+    /// <summary>Amplitude of the noise.</summary>
     private readonly IVectorProvider NoiseScale = new LiteralVectorProvider(new Vector3(1000f));
     private readonly INumberProvider Strength = new LiteralNumberProvider(1.0f);
 

--- a/Renderer/ParticleRenderer/ForceGenerators/RandomForce.cs
+++ b/Renderer/ParticleRenderer/ForceGenerators/RandomForce.cs
@@ -21,7 +21,7 @@ class RandomForce : ParticleFunctionForceGenerator
     {
         foreach (ref var particle in particles.Current)
         {
-            var force = ParticleCollection.RandomBetweenPerComponent(Random.Shared.Next(), Min, Max);
+            var force = ParticleCollection.RandomBetweenPerComponent(Min, Max);
             particle.ForceAccumulator += force * strength;
         }
     }

--- a/Renderer/ParticleRenderer/ForceGenerators/RandomForce.cs
+++ b/Renderer/ParticleRenderer/ForceGenerators/RandomForce.cs
@@ -1,8 +1,8 @@
 namespace ValveResourceFormat.Renderer.Particles.ForceGenerators;
 
 /// <summary>
-/// Applies a per-particle random force vector chosen uniformly between a minimum and maximum bound
-/// each frame.
+/// Generates a random force within the specified range that's applied uniformly to all
+/// particles within the effect.
 /// </summary>
 /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RandomForce">C_OP_RandomForce</seealso>
 class RandomForce : ParticleFunctionForceGenerator
@@ -19,10 +19,12 @@ class RandomForce : ParticleFunctionForceGenerator
 
     public override void GenerateForces(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState, float strength)
     {
+        // One force is chosen per frame and applied uniformly to every particle
+        var force = ParticleCollection.RandomBetweenPerComponent(Min, Max) * strength;
+
         foreach (ref var particle in particles.Current)
         {
-            var force = ParticleCollection.RandomBetweenPerComponent(Min, Max);
-            particle.ForceAccumulator += force * strength;
+            particle.ForceAccumulator += force;
         }
     }
 }

--- a/Renderer/ParticleRenderer/INumberProvider.cs
+++ b/Renderer/ParticleRenderer/INumberProvider.cs
@@ -211,7 +211,8 @@ namespace ValveResourceFormat.Renderer.Particles
         public PerParticleCountNormalizedNumberProvider(ParticleDefinitionParser parse) { attributeMapping = new AttributeMapping(parse); }
         public float NextNumber(ref Particle particle, ParticleSystemRenderState renderState)
         {
-            return attributeMapping.ApplyMapping(particle.ParticleID) / Math.Max(renderState.ParticleCount, 1);
+            // Mapping input ranges for this provider type are authored in normalized 0-1 space
+            return attributeMapping.ApplyMapping(particle.ParticleID / (float)Math.Max(renderState.ParticleCount, 1));
         }
     }
 

--- a/Renderer/ParticleRenderer/INumberProvider.cs
+++ b/Renderer/ParticleRenderer/INumberProvider.cs
@@ -211,8 +211,9 @@ namespace ValveResourceFormat.Renderer.Particles
         public PerParticleCountNormalizedNumberProvider(ParticleDefinitionParser parse) { attributeMapping = new AttributeMapping(parse); }
         public float NextNumber(ref Particle particle, ParticleSystemRenderState renderState)
         {
-            // Mapping input ranges for this provider type are authored in normalized 0-1 space
-            return attributeMapping.ApplyMapping(particle.ParticleID / (float)Math.Max(renderState.ParticleCount, 1));
+            // Mapping input ranges for this provider type are authored in normalized 0-1 space.
+            // Index is the slot in the alive list; ParticleID is a lifetime spawn counter and would exceed the count.
+            return attributeMapping.ApplyMapping(particle.Index / (float)Math.Max(renderState.ParticleCount, 1));
         }
     }
 

--- a/Renderer/ParticleRenderer/IVectorProvider.cs
+++ b/Renderer/ParticleRenderer/IVectorProvider.cs
@@ -39,7 +39,8 @@ namespace ValveResourceFormat.Renderer.Particles
 
         public LiteralColorVectorProvider(Vector3 value)
         {
-            this.value = value;
+            // Literal colors are authored as 0-255; providers return normalized 0-1 colors
+            this.value = value / 255.0f;
         }
 
         public LiteralColorVectorProvider(int[] value)

--- a/Renderer/ParticleRenderer/IVectorProvider.cs
+++ b/Renderer/ParticleRenderer/IVectorProvider.cs
@@ -190,7 +190,7 @@ namespace ValveResourceFormat.Renderer.Particles
             max = parse.Vector3("m_vRandomMax");
         }
 
-        public Vector3 NextVector(ref Particle particle, ParticleSystemRenderState renderState)
+        public virtual Vector3 NextVector(ref Particle particle, ParticleSystemRenderState renderState)
         {
             return new Vector3(
                 ParticleSystemRenderState.RandomFloat(min.X, max.X),
@@ -210,7 +210,7 @@ namespace ValveResourceFormat.Renderer.Particles
             VectorAttributeScale = parse.Vector3("m_vVectorAttributeScale", VectorAttributeScale);
         }
 
-        public new Vector3 NextVector(ref Particle particle, ParticleSystemRenderState renderState)
+        public override Vector3 NextVector(ref Particle particle, ParticleSystemRenderState renderState)
         {
             var baseValue = VectorAttributeScale * particle.GetVector(VectorAttribute);
             return baseValue + base.NextVector(ref particle, renderState);

--- a/Renderer/ParticleRenderer/Initializers/CreateAlongPath.cs
+++ b/Renderer/ParticleRenderer/Initializers/CreateAlongPath.cs
@@ -37,36 +37,23 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             EndOffset = parse.Vector3("m_vEndOffset", EndOffset);
         }
 
-        private Vector3 GetParticlePosition(ParticleSystemRenderState particleSystem)
+        private Vector3 GetParticlePosition(ParticleSystemRenderState particleSystem, int particleId)
         {
-            var progress = Random.Shared.NextSingle();
+            var startCp = StartControlPointNumber;
+            var endCp = EndControlPointNumber;
+
             if (UseRandomCPs)
             {
-                Vector3 cpPos0;
-                Vector3 cpPos1;
-                for (var cp = StartControlPointNumber; cp <= EndControlPointNumber - 1; cp++)
-                {
-                    cpPos0 = particleSystem.GetControlPoint(cp).Position;
-                    cpPos1 = particleSystem.GetControlPoint(cp + 1).Position;
-
-                    var startProgression = MathUtils.Remap(cp, StartControlPointNumber, EndControlPointNumber);
-                    var endProgression = MathUtils.Remap(cp + 1, StartControlPointNumber, EndControlPointNumber);
-
-                    if (progress < startProgression || progress > endProgression)
-                    {
-                        continue;
-                    }
-
-                    var localProgress = MathUtils.Remap(progress, startProgression, endProgression);
-                    return InterpolatePositions(localProgress, cpPos0, cpPos1);
-                }
-            }
-            else
-            {
-                return InterpolatePositions(progress, particleSystem.GetControlPoint(StartControlPointNumber).Position, particleSystem.GetControlPoint(EndControlPointNumber).Position);
+                endCp = startCp + 1 + (int)(Random.Shared.NextSingle() * (endCp - startCp));
+                startCp = endCp - 1;
             }
 
-            throw new NotImplementedException($"Invalid path progression {progress}");
+            var progress = Random.Shared.NextSingle();
+            var position = InterpolatePositions(progress, particleSystem.GetControlPoint(startCp).Position, particleSystem.GetControlPoint(endCp).Position);
+
+            position += ParticleCollection.RandomBetweenPerComponent(particleId, new Vector3(-MaxDistance), new Vector3(MaxDistance));
+
+            return position;
         }
 
         private Vector3 InterpolatePositions(float relativeProgression, Vector3 position0, Vector3 position1)
@@ -77,7 +64,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
 
         public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemRenderState particleSystemState)
         {
-            var particlePosition = GetParticlePosition(particleSystemState);
+            var particlePosition = GetParticlePosition(particleSystemState, particle.ParticleID);
 
             particle.SetVector(ParticleField.Position, particlePosition);
 

--- a/Renderer/ParticleRenderer/Initializers/CreateWithinSphere.cs
+++ b/Renderer/ParticleRenderer/Initializers/CreateWithinSphere.cs
@@ -7,11 +7,22 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
     /// </summary>
     class CreateWithinSphere : ParticleFunctionInitializer
     {
+        /// <summary>Minimum distance to spawn from the center of the sphere.</summary>
         protected readonly INumberProvider radiusMin = new LiteralNumberProvider(0);
+
+        /// <summary>Maximum distance to spawn from the center of the sphere.</summary>
         protected readonly INumberProvider radiusMax = new LiteralNumberProvider(0);
+
+        /// <summary>Minimum initial speed of the particle emitted outward from the sphere.</summary>
         protected readonly INumberProvider speedMin = new LiteralNumberProvider(0);
+
+        /// <summary>Maximum initial speed of the particle emitted outward from the sphere.</summary>
         protected readonly INumberProvider speedMax = new LiteralNumberProvider(0);
+
+        /// <summary>Local space minimum initial speed of the particle in x y z.</summary>
         protected readonly IVectorProvider localCoordinateSystemSpeedMin = new LiteralVectorProvider(Vector3.Zero);
+
+        /// <summary>Local space maximum initial speed of the particle in x y z.</summary>
         protected readonly IVectorProvider localCoordinateSystemSpeedMax = new LiteralVectorProvider(Vector3.Zero);
 
         public CreateWithinSphere(ParticleDefinitionParser parse) : base(parse)

--- a/Renderer/ParticleRenderer/Initializers/CreateWithinSphereTransform.cs
+++ b/Renderer/ParticleRenderer/Initializers/CreateWithinSphereTransform.cs
@@ -32,24 +32,23 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
                 new Vector3(-1),
                 new Vector3(1));
 
-            var direction = Vector3.Normalize(randomVector);
+            // Absolute value per axis folds the sphere into a hemisphere/ovoid.
+            if (distanceBiasAbs.X != 0)
+            {
+                randomVector.X = MathF.Abs(randomVector.X);
+            }
+            if (distanceBiasAbs.Y != 0)
+            {
+                randomVector.Y = MathF.Abs(randomVector.Y);
+            }
+            if (distanceBiasAbs.Z != 0)
+            {
+                randomVector.Z = MathF.Abs(randomVector.Z);
+            }
 
             var bias = distanceBias.NextVector(ref particle, particleSystemState);
 
-            if (distanceBiasAbs != Vector3.Zero)
-            {
-                bias = new Vector3(
-                    Math.Abs(bias.X) * (distanceBiasAbs.X != 0 ? Math.Sign(distanceBiasAbs.X) : 1),
-                    Math.Abs(bias.Y) * (distanceBiasAbs.Y != 0 ? Math.Sign(distanceBiasAbs.Y) : 1),
-                    Math.Abs(bias.Z) * (distanceBiasAbs.Z != 0 ? Math.Sign(distanceBiasAbs.Z) : 1)
-                );
-            }
-
-            var biasedDirection = direction * bias;
-            if (bias != Vector3.One)
-            {
-                biasedDirection = Vector3.Normalize(biasedDirection);
-            }
+            var biasedDirection = Vector3.Normalize(randomVector * bias);
 
             var distance = ParticleCollection.RandomBetween(
                 particle.ParticleID,

--- a/Renderer/ParticleRenderer/Initializers/CreationNoise.cs
+++ b/Renderer/ParticleRenderer/Initializers/CreationNoise.cs
@@ -44,16 +44,18 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             var sampleTime = (particleSystemState.Age + offset) * noiseScale;
             var noise = Noise.Simplex1D((samplePosition.X * 0.7f) + (samplePosition.Y * 1.3f) + (samplePosition.Z * 2.1f) + sampleTime);
 
-            var normalized = absVal || absValInv
-                ? MathF.Abs(noise)
-                : (noise * 0.5f) + 0.5f;
+            // abs folds the signed noise into the full output range; otherwise the half-span
+            // scale centers it in the range. absValInv inverts either way.
+            var absScale = absVal ? 1f : 0.5f;
+            var normalized = absVal ? MathF.Abs(noise) : noise;
 
             if (absValInv)
             {
                 normalized = 1f - normalized;
             }
 
-            particle.SetScalar(fieldOutput, float.Lerp(outputMin, outputMax, normalized));
+            var span = outputMax - outputMin;
+            particle.SetScalar(fieldOutput, outputMin + ((1f - absScale) * span) + (absScale * span * normalized));
 
             return particle;
         }

--- a/Renderer/ParticleRenderer/Initializers/NormalOffset.cs
+++ b/Renderer/ParticleRenderer/Initializers/NormalOffset.cs
@@ -1,7 +1,7 @@
 namespace ValveResourceFormat.Renderer.Particles.Initializers
 {
     /// <summary>
-    /// Initializes particle normals from a control point orientation with an added random offset.
+    /// Adds a random offset to a particle's existing normal, optionally rotated into control point local space.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_INIT_NormalOffset">C_INIT_NormalOffset</seealso>
     class NormalOffset : ParticleFunctionInitializer
@@ -10,7 +10,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         private readonly Vector3 offsetMax = Vector3.Zero;
         private readonly int controlPointNumber;
         private readonly bool localCoords;
-        private readonly bool normalize = true;
+        private readonly bool normalize;
 
         public NormalOffset(ParticleDefinitionParser parse) : base(parse)
         {
@@ -24,23 +24,13 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemRenderState particleSystemState)
         {
             var offset = ParticleCollection.RandomBetweenPerComponent(particle.ParticleID, offsetMin, offsetMax);
-            var controlPoint = particleSystemState.GetControlPoint(controlPointNumber);
-            var baseNormal = controlPoint.Orientation;
 
-            Vector3 normal;
-            if (localCoords && baseNormal != Vector3.Zero)
+            if (localCoords)
             {
-                normal = TransformLocalOffset(offset, baseNormal);
-                normal += baseNormal;
+                offset = ControlPointTransformProvider.TransformDirection(particleSystemState, controlPointNumber, offset);
             }
-            else if (baseNormal != Vector3.Zero)
-            {
-                normal = baseNormal + offset;
-            }
-            else
-            {
-                normal = offset;
-            }
+
+            var normal = particle.GetVector(ParticleField.Normal) + offset;
 
             if (normalize && normal != Vector3.Zero)
             {
@@ -49,16 +39,6 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
 
             particle.SetVector(ParticleField.Normal, normal);
             return particle;
-        }
-
-        private static Vector3 TransformLocalOffset(Vector3 offset, Vector3 forward)
-        {
-            var z = Vector3.Normalize(forward);
-            var reference = Math.Abs(z.X) < 0.9f ? Vector3.UnitX : Vector3.UnitY;
-            var x = Vector3.Normalize(Vector3.Cross(reference, z));
-            var y = Vector3.Cross(z, x);
-
-            return (offset.X * x) + (offset.Y * y) + (offset.Z * z);
         }
     }
 }

--- a/Renderer/ParticleRenderer/Initializers/PointList.cs
+++ b/Renderer/ParticleRenderer/Initializers/PointList.cs
@@ -67,28 +67,53 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
 
             if (usePath)
             {
-                var relativeParticleNumber = currentNumber++ % numPointsOnPath;
+                var pointCount = pointList.Count;
 
                 // An open path interpolates across Count - 1 segments; a closed loop has one
                 // extra segment wrapping back to the first point
-                var numPathSegments = closedLoop
-                    ? pointList.Count
-                    : pointList.Count - 1;
+                var numPathSegments = closedLoop ? pointCount : pointCount - 1;
 
-                // Percentage of path completed
-                var pathCompletion = relativeParticleNumber / (float)numPointsOnPath;
+                if (numPathSegments < 1)
+                {
+                    return pointList[0].GetPosition(particleSystem);
+                }
 
-                var scaledCompletion = pathCompletion * numPathSegments;
+                // An open path must place the last particle on the final point; a closed loop
+                // wraps, so full completion is one step past the last particle
+                var divisor = closedLoop ? numPointsOnPath : Math.Max(1, numPointsOnPath - 1);
+                var pathCompletion = (currentNumber++ % numPointsOnPath) / (float)divisor;
 
-                // Get the ID of the first of the two points we're interpolating between
-                var firstPointID = (int)MathF.Floor(scaledCompletion);
+                // Particles are spaced by arc length so unequal segments don't clump them
+                Span<float> segmentLengths = numPathSegments <= 64 ? stackalloc float[numPathSegments] : new float[numPathSegments];
+                var totalLength = 0f;
 
-                var pos1 = pointList[firstPointID].GetPosition(particleSystem);
-                var pos2 = pointList[(firstPointID + 1) % pointList.Count].GetPosition(particleSystem);
+                for (var i = 0; i < numPathSegments; i++)
+                {
+                    var a = pointList[i].GetPosition(particleSystem);
+                    var b = pointList[(i + 1) % pointCount].GetPosition(particleSystem);
+                    segmentLengths[i] = Vector3.Distance(a, b);
+                    totalLength += segmentLengths[i];
+                }
 
-                var relativeBlend = scaledCompletion - firstPointID;
+                if (totalLength <= 0f)
+                {
+                    return pointList[0].GetPosition(particleSystem);
+                }
 
-                return Vector3.Lerp(pos1, pos2, relativeBlend);
+                var targetLength = pathCompletion * totalLength;
+                var segment = 0;
+
+                while (segment < numPathSegments - 1 && targetLength > segmentLengths[segment])
+                {
+                    targetLength -= segmentLengths[segment];
+                    segment++;
+                }
+
+                var pos1 = pointList[segment].GetPosition(particleSystem);
+                var pos2 = pointList[(segment + 1) % pointCount].GetPosition(particleSystem);
+                var blend = segmentLengths[segment] > 0f ? targetLength / segmentLengths[segment] : 0f;
+
+                return Vector3.Lerp(pos1, pos2, blend);
             }
             else
             {

--- a/Renderer/ParticleRenderer/Initializers/PointList.cs
+++ b/Renderer/ParticleRenderer/Initializers/PointList.cs
@@ -69,30 +69,24 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             {
                 var relativeParticleNumber = currentNumber++ % numPointsOnPath;
 
-                var numPathNodes = closedLoop
-                    ? pointList.Count + 1
-                    : pointList.Count;
+                // An open path interpolates across Count - 1 segments; a closed loop has one
+                // extra segment wrapping back to the first point
+                var numPathSegments = closedLoop
+                    ? pointList.Count
+                    : pointList.Count - 1;
 
-                // Percentage of path completed / 100
+                // Percentage of path completed
                 var pathCompletion = relativeParticleNumber / (float)numPointsOnPath;
 
-                // Get the ID of the first of the two points we're interpolating between. A closed loop
-                // treats the segment past the last node as wrapping back to node 0; an open path clamps.
-                var firstPointID = (int)MathF.Floor(pathCompletion * numPathNodes);
+                var scaledCompletion = pathCompletion * numPathSegments;
 
-                var pos1 = closedLoop
-                    ? pointList[firstPointID % pointList.Count].GetPosition(particleSystem)
-                    : pointList[Math.Min(firstPointID, pointList.Count - 1)].GetPosition(particleSystem);
+                // Get the ID of the first of the two points we're interpolating between
+                var firstPointID = (int)MathF.Floor(scaledCompletion);
 
-                var pos2 = closedLoop
-                    ? pointList[(firstPointID + 1) % pointList.Count].GetPosition(particleSystem)
-                    : pointList[Math.Min(firstPointID + 1, pointList.Count - 1)].GetPosition(particleSystem);
+                var pos1 = pointList[firstPointID].GetPosition(particleSystem);
+                var pos2 = pointList[(firstPointID + 1) % pointList.Count].GetPosition(particleSystem);
 
-                // I think this is right?
-                var point1Percent = (float)firstPointID / numPathNodes;
-                var point2Percent = (float)(firstPointID + 1) / numPathNodes;
-
-                var relativeBlend = MathUtils.Remap(pathCompletion, point1Percent, point2Percent);
+                var relativeBlend = scaledCompletion - firstPointID;
 
                 return Vector3.Lerp(pos1, pos2, relativeBlend);
             }

--- a/Renderer/ParticleRenderer/Initializers/RandomSequence.cs
+++ b/Renderer/ParticleRenderer/Initializers/RandomSequence.cs
@@ -1,8 +1,8 @@
 namespace ValveResourceFormat.Renderer.Particles.Initializers
 {
     /// <summary>
-    /// Initializes the particle animation sequence to a random value between a min and max sequence index.
-    /// Supports sequential (linear), shuffled (random), or weighted distribution modes.
+    /// Initializes the particle animation sequence to a value between a min and max sequence index.
+    /// Supports sequential (linear), shuffled, or pure-random selection modes.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_INIT_RandomSequence">C_INIT_RandomSequence</seealso>
     class RandomSequence : ParticleFunctionInitializer
@@ -10,8 +10,10 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         private readonly int sequenceMin;
         private readonly int sequenceMax;
         private readonly bool shuffle;
+        private readonly bool linear;
 
-        private int counter;
+        private readonly int[] list = [];
+        private int current;
 
         // In Behavior Ver 12+ there is a "weight list" that weights the randomness
         public RandomSequence(ParticleDefinitionParser parse) : base(parse)
@@ -19,20 +21,56 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             sequenceMin = parse.Int32("m_nSequenceMin", sequenceMin);
             sequenceMax = parse.Int32("m_nSequenceMax", sequenceMax);
             shuffle = parse.Boolean("m_bShuffle", shuffle);
+            linear = parse.Boolean("m_bLinear", linear);
+
+            if (shuffle || linear)
+            {
+                var count = Math.Max(sequenceMax - sequenceMin + 1, 1);
+                list = new int[count];
+                for (var i = 0; i < count; i++)
+                {
+                    list[i] = sequenceMin + i;
+                }
+
+                if (shuffle)
+                {
+                    Shuffle();
+                }
+            }
         }
 
         public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemRenderState particleSystemState)
         {
-            if (shuffle)
+            if (shuffle || linear)
             {
-                particle.Sequence = Random.Shared.Next(sequenceMin, sequenceMax + 1);
+                if (current >= list.Length)
+                {
+                    if (shuffle)
+                    {
+                        Shuffle();
+                    }
+
+                    current = 0;
+                }
+
+                particle.Sequence = list[current];
+                current++;
             }
             else
             {
-                particle.Sequence = sequenceMin + (sequenceMax > sequenceMin ? (counter++ % (sequenceMax - sequenceMin + 1)) : 0);
+                particle.Sequence = sequenceMax > sequenceMin ? Random.Shared.Next(sequenceMin, sequenceMax + 1) : sequenceMin;
             }
 
             return particle;
+        }
+
+        private void Shuffle()
+        {
+            for (var i = list.Length - 1; i > 0; i--)
+            {
+                var j = Random.Shared.Next(0, i + 1);
+                (list[i], list[j]) = (list[j], list[i]);
+            }
         }
     }
 }

--- a/Renderer/ParticleRenderer/Initializers/RandomYawFlip.cs
+++ b/Renderer/ParticleRenderer/Initializers/RandomYawFlip.cs
@@ -15,7 +15,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
 
         public override Particle Initialize(ref Particle particle, ParticleCollection particles, ParticleSystemRenderState particleSystemState)
         {
-            if (Random.Shared.NextSingle() > percent)
+            if (Random.Shared.NextSingle() < percent)
             {
                 particle.SetScalar(ParticleField.Yaw, particle.GetScalar(ParticleField.Yaw) + MathF.PI);
             }

--- a/Renderer/ParticleRenderer/Initializers/RemapScalar.cs
+++ b/Renderer/ParticleRenderer/Initializers/RemapScalar.cs
@@ -27,7 +27,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         {
             var value = particle.GetScalar(FieldInput);
 
-            value = MathUtils.RemapRange(value, inputMin, inputMax, outputMin, outputMax);
+            value = MathUtils.RemapValClamped(value, inputMin, inputMax, outputMin, outputMax);
 
             particle.SetScalar(FieldOutput, value);
 

--- a/Renderer/ParticleRenderer/Initializers/RemapSpeedToScalar.cs
+++ b/Renderer/ParticleRenderer/Initializers/RemapSpeedToScalar.cs
@@ -47,8 +47,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
                 speed = particleSystemState.GetControlPoint(controlPointNumber).GetVelocity(frameTime).Length();
             }
 
-            speed = Math.Clamp(speed, inputMin, inputMax);
-            var output = MathUtils.RemapRange(speed, inputMin, inputMax, outputMin, outputMax);
+            var output = MathUtils.RemapValClamped(speed, inputMin, inputMax, outputMin, outputMax);
 
             output = particle.ModifyScalarBySetMethod(particles, FieldOutput, output, setMethod);
             particle.SetScalar(FieldOutput, output);

--- a/Renderer/ParticleRenderer/Initializers/RingWave.cs
+++ b/Renderer/ParticleRenderer/Initializers/RingWave.cs
@@ -54,8 +54,8 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         {
             if (evenDistribution)
             {
-                // Unset (-1) or invalid counts fall back to the collection's maximum particle count.
-                var perOrbit = Math.Max(1, particlesPerOrbit <= 0 ? maxParticles : particlesPerOrbit);
+                // -1 is the sentinel for using the collection's maximum particle count.
+                var perOrbit = Math.Max(1, particlesPerOrbit == -1 ? maxParticles : particlesPerOrbit);
 
                 var offset = orbitCount / perOrbit;
 

--- a/Renderer/ParticleRenderer/Initializers/RingWave.cs
+++ b/Renderer/ParticleRenderer/Initializers/RingWave.cs
@@ -54,8 +54,8 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         {
             if (evenDistribution)
             {
-                // -1 falls back to the collection's maximum particle count.
-                var perOrbit = Math.Max(1, particlesPerOrbit == -1 ? maxParticles : particlesPerOrbit);
+                // Unset (-1) or invalid counts fall back to the collection's maximum particle count.
+                var perOrbit = Math.Max(1, particlesPerOrbit <= 0 ? maxParticles : particlesPerOrbit);
 
                 var offset = orbitCount / perOrbit;
 

--- a/Renderer/ParticleRenderer/Initializers/RingWave.cs
+++ b/Renderer/ParticleRenderer/Initializers/RingWave.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
     /// <summary>
     /// Positions particles in a ring pattern around a transform, with configurable initial radius, thickness, and even or random angular distribution.
     /// </summary>
+    /// <remarks>
+    /// "Position Along Ring" in the particle editor. Like "Position Within Sphere Random", it can
+    /// also impart radial force to particles via the min/max initial speed.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_INIT_RingWave">C_INIT_RingWave</seealso>
     class RingWave : ParticleFunctionInitializer
     {

--- a/Renderer/ParticleRenderer/Initializers/VelocityRadialRandom.cs
+++ b/Renderer/ParticleRenderer/Initializers/VelocityRadialRandom.cs
@@ -8,7 +8,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
     class VelocityRadialRandom : ParticleFunctionInitializer
     {
         // unsure if this is actually a vector provider
-        private readonly IVectorProvider vectorScale = new LiteralVectorProvider(Vector3.Zero);
+        private readonly IVectorProvider vectorScale = new LiteralVectorProvider(Vector3.One);
         private readonly INumberProvider speedMin = new LiteralNumberProvider(0.1f);
         private readonly INumberProvider speedMax = new LiteralNumberProvider(0.1f);
 
@@ -29,7 +29,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             var speedmin = speedMin.NextNumber(ref particle, particleSystemState);
             var speedmax = speedMax.NextNumber(ref particle, particleSystemState);
 
-            var speed = Math.Max(1.0f, ParticleCollection.RandomBetween(particle.ParticleID, speedmin, speedmax));
+            var speed = ParticleCollection.RandomBetween(particle.ParticleID, speedmin, speedmax);
 
             // With the flag set the authored value is a raw per-step displacement, not units/second.
             if (ignoreDelta)

--- a/Renderer/ParticleRenderer/Initializers/VelocityRandom.cs
+++ b/Renderer/ParticleRenderer/Initializers/VelocityRandom.cs
@@ -10,6 +10,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
         private readonly IVectorProvider vectorMax = new LiteralVectorProvider(Vector3.Zero);
         private readonly INumberProvider speedMin = new LiteralNumberProvider(0.1f);
         private readonly INumberProvider speedMax = new LiteralNumberProvider(0.1f);
+        private readonly int controlPoint;
         private readonly bool ignoreDT;
 
         public VelocityRandom(ParticleDefinitionParser parse) : base(parse)
@@ -18,6 +19,7 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             vectorMax = parse.VectorProvider("m_LocalCoordinateSystemSpeedMax", vectorMax);
             speedMin = parse.NumberProvider("m_fSpeedMin", speedMin);
             speedMax = parse.NumberProvider("m_fSpeedMax", speedMax);
+            controlPoint = parse.Int32("m_nControlPointNumber", controlPoint);
             ignoreDT = parse.Boolean("m_bIgnoreDT", ignoreDT);
         }
 
@@ -32,7 +34,10 @@ namespace ValveResourceFormat.Renderer.Particles.Initializers
             var vecMin = vectorMin.NextVector(ref particle, particleSystemState);
             var vecMax = vectorMax.NextVector(ref particle, particleSystemState);
 
-            var velocity = ParticleCollection.RandomBetweenPerComponent(particle.ParticleID, vecMin, vecMax) * speed;
+            var localSpeed = ParticleCollection.RandomBetweenPerComponent(particle.ParticleID, vecMin, vecMax);
+
+            // The authored speed vector is expressed in the control point's local coordinate system.
+            var velocity = ControlPointTransformProvider.TransformDirection(particleSystemState, controlPoint, localSpeed) * speed;
 
             // With the flag set the authored value is a raw per-step displacement, not units/second.
             if (ignoreDT)

--- a/Renderer/ParticleRenderer/Operators/BasicMovement.cs
+++ b/Renderer/ParticleRenderer/Operators/BasicMovement.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Moves particles each frame by integrating velocity, applying a gravity vector and an exponential drag factor.
     /// </summary>
+    /// <remarks>
+    /// "Movement Basic" in the particle editor — "basic" in the sense of fundamental rather than
+    /// simplistic: without it (or another movement operator) particles are spatially static.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_BasicMovement">C_OP_BasicMovement</seealso>
     class BasicMovement : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/CGeneralRandomFade.cs
+++ b/Renderer/ParticleRenderer/Operators/CGeneralRandomFade.cs
@@ -1,0 +1,33 @@
+namespace ValveResourceFormat.Renderer.Particles.Operators
+{
+    /// <summary>
+    /// Base class for fade operators whose fade duration is drawn per particle from a min/max
+    /// range with an exponent bias.
+    /// </summary>
+    abstract class CGeneralRandomFade : ParticleFunctionOperator
+    {
+        private readonly float fadeTimeMin = 0.25f;
+        private readonly float fadeTimeMax = 0.25f;
+        private readonly float randomExponent = 1f;
+
+        /// <summary>Whether times are expressed as a fraction of the particle's lifetime rather than seconds.</summary>
+        protected readonly bool proportional = true;
+
+        protected CGeneralRandomFade(ParticleDefinitionParser parse, string fadeTimeKeyPrefix) : base(parse)
+        {
+            fadeTimeMin = parse.Float(fadeTimeKeyPrefix + "Min", fadeTimeMin);
+            fadeTimeMax = parse.Float(fadeTimeKeyPrefix + "Max", fadeTimeMax);
+            randomExponent = parse.Float(fadeTimeKeyPrefix + "Exp", randomExponent);
+            proportional = parse.Boolean("m_bProportional", proportional);
+        }
+
+        /// <summary>
+        /// The fade duration for this particle, in normalized lifetime or seconds depending on
+        /// <see cref="proportional"/>.
+        /// </summary>
+        protected float GetFadeTime(ref Particle particle)
+            => fadeTimeMin == fadeTimeMax
+                ? fadeTimeMin
+                : ParticleCollection.RandomWithExponentBetween(particle.ParticleID, randomExponent, fadeTimeMin, fadeTimeMax);
+    }
+}

--- a/Renderer/ParticleRenderer/Operators/ColorInterpolateRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/ColorInterpolateRandom.cs
@@ -41,7 +41,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                     }
 
                     // Interpolate from constant color to fade color
-                    particle.SetVector(FieldOutput, Vector3.Lerp(particle.GetInitialVector(particles, ParticleField.Color), newColor, t));
+                    particle.SetVector(FieldOutput, Vector3.Lerp(particle.GetInitialVector(particles, FieldOutput), newColor, t));
                 }
             }
         }

--- a/Renderer/ParticleRenderer/Operators/Decay.cs
+++ b/Renderer/ParticleRenderer/Operators/Decay.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Kills a particle once its age exceeds its lifetime.
     /// </summary>
+    /// <remarks>
+    /// "Lifespan Decay" in the particle editor. All effects should have a decay operator
+    /// unless the particles are certain to be destroyed by some other means (usually code).
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_Decay">C_OP_Decay</seealso>
     class Decay : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/FadeAndKill.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeAndKill.cs
@@ -29,14 +29,15 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             foreach (ref var particle in particles.Current)
             {
                 var time = particle.NormalizedAge;
+                var initialAlpha = particle.GetInitialScalar(particles, ParticleField.Alpha);
 
                 // If fading in
                 if (time >= startFadeInTime && time <= endFadeInTime)
                 {
                     var blend = MathUtils.Remap(time, startFadeInTime, endFadeInTime);
 
-                    // Interpolate from startAlpha to constantAlpha
-                    particle.Alpha = float.Lerp(startAlpha, particle.GetInitialScalar(particles, ParticleField.Alpha), blend);
+                    // Interpolate from initialAlpha * startAlpha up to initialAlpha
+                    particle.Alpha = float.Lerp(initialAlpha * startAlpha, initialAlpha, blend);
                 }
 
                 // If fading out
@@ -44,8 +45,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 {
                     var blend = MathUtils.Remap(time, startFadeOutTime, endFadeOutTime);
 
-                    // Interpolate from constantAlpha to end alpha
-                    particle.Alpha = float.Lerp(particle.GetInitialScalar(particles, ParticleField.Alpha), endAlpha, blend);
+                    // Interpolate from initialAlpha down to initialAlpha * endAlpha
+                    particle.Alpha = float.Lerp(initialAlpha, initialAlpha * endAlpha, blend);
                 }
 
                 if (time >= endFadeOutTime)

--- a/Renderer/ParticleRenderer/Operators/FadeAndKill.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeAndKill.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha in over a configurable time window and then fades it out, killing the particle at the end of the fade-out.
     /// </summary>
+    /// <remarks>
+    /// "Alpha Fade and Decay" in the particle editor: essentially combines the operators
+    /// "Lifespan Decay", "Alpha Fade In Simple" and "Alpha Fade Out Simple".
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeAndKill">C_OP_FadeAndKill</seealso>
     class FadeAndKill : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/FadeInRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeInRandom.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha in over a per-particle randomly chosen duration drawn from a min/max range with an optional exponent bias.
     /// </summary>
+    /// <remarks>
+    /// "Alpha Fade In Random" in the particle editor. Unlike "Alpha Fade In Simple", the range
+    /// can be defined in seconds rather than a fraction of the lifespan by turning proportional off.
+    /// </remarks>
     class FadeInRandom : CGeneralRandomFade
     {
         public FadeInRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeInTime")

--- a/Renderer/ParticleRenderer/Operators/FadeInRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeInRandom.cs
@@ -3,26 +3,17 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha in over a per-particle randomly chosen duration drawn from a min/max range with an optional exponent bias.
     /// </summary>
-    class FadeInRandom : ParticleFunctionOperator
+    class FadeInRandom : CGeneralRandomFade
     {
-        private readonly float fadeInTimeMin = 0.25f;
-        private readonly float fadeInTimeMax = 0.25f;
-        private readonly float randomExponent = 1f;
-        private readonly bool proportional = true;
-
-        public FadeInRandom(ParticleDefinitionParser parse) : base(parse)
+        public FadeInRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeInTime")
         {
-            fadeInTimeMin = parse.Float("m_flFadeInTimeMin", fadeInTimeMin);
-            fadeInTimeMax = parse.Float("m_flFadeInTimeMax", fadeInTimeMax);
-            randomExponent = parse.Float("m_flFadeInTimeExp", randomExponent);
-            proportional = parse.Boolean("m_bProportional", proportional);
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)
         {
             foreach (ref var particle in particles.Current)
             {
-                var fadeInTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, randomExponent, fadeInTimeMin, fadeInTimeMax);
+                var fadeInTime = GetFadeTime(ref particle);
 
                 var time = proportional
                     ? particle.NormalizedAge
@@ -30,8 +21,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 
                 if (time <= fadeInTime)
                 {
-                    var newAlpha = (time / fadeInTime) * particle.GetInitialScalar(particles, ParticleField.Alpha);
-                    particle.Alpha = newAlpha;
+                    particle.Alpha = (time / fadeInTime) * particle.GetInitialScalar(particles, ParticleField.Alpha);
                 }
             }
         }

--- a/Renderer/ParticleRenderer/Operators/FadeInSimple.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeInSimple.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha field in linearly over a proportional fade-in time at the start of the particle's life.
     /// </summary>
+    /// <remarks>
+    /// The fade-in time is a fraction of the particle's lifetime in the 0–1 range: a setting of
+    /// 0.5 on a particle with a 4-second lifetime takes 2 seconds to fade in completely.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeInSimple">C_OP_FadeInSimple</seealso>
     class FadeInSimple : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
@@ -3,6 +3,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha out over a per-particle randomly chosen duration drawn from a min/max range, with an optional bias curve applied to the fade.
     /// </summary>
+    /// <remarks>
+    /// "Alpha Fade Out Random" in the particle editor. Unlike "Alpha Fade Out Simple", the range
+    /// can be defined in seconds rather than a fraction of the lifespan by turning proportional off.
+    /// </remarks>
     class FadeOutRandom : CGeneralRandomFade
     {
         private readonly float fadeBias = 0.5f;

--- a/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
@@ -48,16 +48,14 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 
                 if (timeLeft <= fadeOutTime)
                 {
-                    var fadeFraction = timeLeft / fadeOutTime;
+                    var elapsedFraction = Math.Clamp(1f - timeLeft / fadeOutTime, 0f, 1f);
 
-                    // Bias the fade curve before scaling by the spawn alpha,
-                    // so the fade starts exactly at the spawn alpha
                     if (fadeBias != 0.5f)
                     {
-                        fadeFraction /= ((1f / fadeBias - 2f) * (1 - fadeFraction) + 1f);
+                        elapsedFraction /= ((1f / fadeBias - 2f) * (1f - elapsedFraction) + 1f);
                     }
 
-                    particle.Alpha = fadeFraction * particle.GetInitialScalar(particles, ParticleField.Alpha);
+                    particle.Alpha = (1f - elapsedFraction) * particle.GetInitialScalar(particles, ParticleField.Alpha);
                 }
             }
         }

--- a/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
@@ -48,14 +48,16 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 
                 if (timeLeft <= fadeOutTime)
                 {
-                    var newAlpha = (timeLeft / fadeOutTime) * particle.GetInitialScalar(particles, ParticleField.Alpha);
+                    var fadeFraction = timeLeft / fadeOutTime;
 
+                    // Bias the fade curve before scaling by the spawn alpha,
+                    // so the fade starts exactly at the spawn alpha
                     if (fadeBias != 0.5f)
                     {
-                        newAlpha /= ((1f / fadeBias - 2f) * (1 - newAlpha) + 1f);
+                        fadeFraction /= ((1f / fadeBias - 2f) * (1 - fadeFraction) + 1f);
                     }
 
-                    particle.Alpha = newAlpha;
+                    particle.Alpha = fadeFraction * particle.GetInitialScalar(particles, ParticleField.Alpha);
                 }
             }
         }

--- a/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeOutRandom.cs
@@ -3,21 +3,12 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha out over a per-particle randomly chosen duration drawn from a min/max range, with an optional bias curve applied to the fade.
     /// </summary>
-    class FadeOutRandom : ParticleFunctionOperator
+    class FadeOutRandom : CGeneralRandomFade
     {
-        private readonly float fadeOutTimeMin = 0.25f;
-        private readonly float fadeOutTimeMax = 0.25f;
         private readonly float fadeBias = 0.5f;
-        private readonly float randomExponent = 1f;
-        private readonly bool proportional = true;
 
-        public FadeOutRandom(ParticleDefinitionParser parse) : base(parse)
+        public FadeOutRandom(ParticleDefinitionParser parse) : base(parse, "m_flFadeOutTime")
         {
-            fadeOutTimeMin = parse.Float("m_flFadeOutTimeMin", fadeOutTimeMin);
-            fadeOutTimeMax = parse.Float("m_flFadeOutTimeMax", fadeOutTimeMax);
-            randomExponent = parse.Float("m_flFadeOutTimeExp", randomExponent);
-            proportional = parse.Boolean("m_bProportional", proportional);
-
             var bias = parse.Float("m_flFadeBias", fadeBias);
 
             if (bias == 0.0f)
@@ -35,12 +26,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                var fadeOutTime = fadeOutTimeMin;
-
-                if (fadeOutTimeMin != fadeOutTimeMax)
-                {
-                    fadeOutTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, randomExponent, fadeOutTimeMin, fadeOutTimeMax);
-                }
+                var fadeOutTime = GetFadeTime(ref particle);
 
                 var timeLeft = proportional
                     ? 1.0f - particle.NormalizedAge

--- a/Renderer/ParticleRenderer/Operators/FadeOutSimple.cs
+++ b/Renderer/ParticleRenderer/Operators/FadeOutSimple.cs
@@ -3,6 +3,11 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// <summary>
     /// Fades a particle's alpha field out linearly over a proportional fade-out time at the end of the particle's life.
     /// </summary>
+    /// <remarks>
+    /// The fade-out time is a fraction of the particle's lifetime in the 0–1 range: a setting of
+    /// 0.25 on a particle with a 4-second lifetime starts fading 3 seconds after emission and
+    /// takes 1 second to fade out completely.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_FadeOutSimple">C_OP_FadeOutSimple</seealso>
     class FadeOutSimple : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/InterpolateRadius.cs
+++ b/Renderer/ParticleRenderer/Operators/InterpolateRadius.cs
@@ -5,6 +5,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// specified time window of the particle's normalized lifetime, with an optional bias applied
     /// to the interpolation curve.
     /// </summary>
+    /// <remarks>
+    /// "Radius Scale" in the particle editor. Multiple instances can be used in one effect as
+    /// long as their time windows don't overlap.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_InterpolateRadius">C_OP_InterpolateRadius</seealso>
     class InterpolateRadius : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/LerpScalar.cs
+++ b/Renderer/ParticleRenderer/Operators/LerpScalar.cs
@@ -2,7 +2,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 {
     /// <summary>
     /// Lerps a scalar particle attribute from its initial value toward a target value over a
-    /// specified time window of the particle's absolute age.
+    /// specified time window of the particle's normalized lifetime.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_LerpScalar">C_OP_LerpScalar</seealso>
     class LerpScalar : ParticleFunctionOperator
@@ -25,7 +25,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             {
                 var lerpTarget = output.NextNumber(ref particle, particleSystemState);
 
-                var lerpWeight = MathUtils.Saturate(MathUtils.Remap(particle.Age, startTime, endTime));
+                var lerpWeight = MathUtils.Saturate(MathUtils.Remap(particle.NormalizedAge, startTime, endTime));
 
                 var scalarOutput = float.Lerp(particle.GetInitialScalar(particles, FieldOutput), lerpTarget, lerpWeight);
 

--- a/Renderer/ParticleRenderer/Operators/LerpVector.cs
+++ b/Renderer/ParticleRenderer/Operators/LerpVector.cs
@@ -2,7 +2,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 {
     /// <summary>
     /// Lerps a vector particle attribute from its initial value toward a target vector over a
-    /// specified time window of the particle's absolute age.
+    /// specified time window of the particle's normalized lifetime age.
     /// </summary>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_LerpVector">C_OP_LerpVector</seealso>
     class LerpVector : ParticleFunctionOperator
@@ -29,7 +29,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 // The set method affects the value the vector is interpolating to, instead of the current interpolated value.
                 var lerpTarget = particle.ModifyVectorBySetMethod(particles, FieldOutput, output, setMethod);
 
-                var lerpWeight = MathUtils.Saturate(MathUtils.Remap(particle.Age, startTime, endTime));
+                var lerpWeight = MathUtils.Saturate(MathUtils.Remap(particle.NormalizedAge, startTime, endTime));
 
                 var scalarOutput = Vector3.Lerp(particle.GetInitialVector(particles, FieldOutput), lerpTarget, lerpWeight);
 

--- a/Renderer/ParticleRenderer/Operators/MaxVelocity.cs
+++ b/Renderer/ParticleRenderer/Operators/MaxVelocity.cs
@@ -32,11 +32,11 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 var speed = particle.Velocity.Length();
                 if (speed > maxVelocity)
                 {
-                    particle.Velocity = Vector3.Normalize(particle.Velocity) * maxVelocity;
+                    particle.Velocity *= maxVelocity / speed;
                 }
-                else if (speed < minVelocity)
+                else if (speed > 0f && speed < minVelocity)
                 {
-                    particle.Velocity = Vector3.Normalize(particle.Velocity) * minVelocity;
+                    particle.Velocity *= minVelocity / speed;
                 }
                 else
                 {

--- a/Renderer/ParticleRenderer/Operators/NormalizeVector.cs
+++ b/Renderer/ParticleRenderer/Operators/NormalizeVector.cs
@@ -20,6 +20,13 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             foreach (ref var particle in particles.Current)
             {
                 var vector = particle.GetVector(OutputField);
+
+                // A zero vector has no direction to normalize
+                if (vector == Vector3.Zero)
+                {
+                    continue;
+                }
+
                 vector = Vector3.Normalize(vector) * Scale;
 
                 particle.SetVector(OutputField, vector);

--- a/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
+++ b/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
@@ -25,7 +25,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             frequencyMax = parse.Float("m_FrequencyMax", frequencyMax);
             oscillationMultiplier = parse.Float("m_flOscMult", oscillationMultiplier);
             oscillationOffset = parse.Float("m_flOscAdd", oscillationOffset);
-            proportional = parse.Boolean("m_bProportional", proportional);
+            proportional = parse.Boolean("m_bProportionalOp", proportional);
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)

--- a/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
+++ b/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
@@ -25,7 +25,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             frequencyMax = parse.Float("m_FrequencyMax", frequencyMax);
             oscillationMultiplier = parse.Float("m_flOscMult", oscillationMultiplier);
             oscillationOffset = parse.Float("m_flOscAdd", oscillationOffset);
-            proportional = parse.Boolean("m_bProportionalOp", proportional);
+            proportional = parse.Boolean("m_bProportional", proportional);
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)
@@ -59,6 +59,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         private readonly float frequency = 1f;
         private readonly float oscillationMultiplier = 2f;
         private readonly float oscillationOffset = 0.5f;
+        private readonly float clampMin;
+        private readonly float clampMax;
 
         public OscillateScalarSimple(ParticleDefinitionParser parse) : base(parse)
         {
@@ -67,6 +69,13 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             frequency = parse.Float("m_Frequency", frequency);
             oscillationMultiplier = parse.Float("m_flOscMult", oscillationMultiplier);
             oscillationOffset = parse.Float("m_flOscAdd", oscillationOffset);
+
+            (clampMin, clampMax) = outputField switch
+            {
+                ParticleField.Alpha or ParticleField.AlphaAlternate => (0f, 1f),
+                ParticleField.Radius or ParticleField.TrailLength => (0f, float.MaxValue),
+                _ => (-float.MaxValue, float.MaxValue),
+            };
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)
@@ -78,7 +87,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 
                 var finalScalar = delta * rate * frameTime;
 
-                particle.SetScalar(outputField, particle.GetScalar(outputField) + finalScalar);
+                var oscillated = particle.GetScalar(outputField) + finalScalar;
+                particle.SetScalar(outputField, Math.Clamp(oscillated, clampMin, clampMax));
             }
         }
     }

--- a/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
+++ b/Renderer/ParticleRenderer/Operators/OscillateScalar.cs
@@ -25,7 +25,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             frequencyMax = parse.Float("m_FrequencyMax", frequencyMax);
             oscillationMultiplier = parse.Float("m_flOscMult", oscillationMultiplier);
             oscillationOffset = parse.Float("m_flOscAdd", oscillationOffset);
-            proportional = parse.Boolean("m_bProportionalOp", proportional);
+            proportional = parse.Boolean("m_bProportional", proportional);
         }
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)

--- a/Renderer/ParticleRenderer/Operators/PositionLock.cs
+++ b/Renderer/ParticleRenderer/Operators/PositionLock.cs
@@ -1,9 +1,12 @@
 namespace ValveResourceFormat.Renderer.Particles.Operators
 {
     /// <summary>
-    /// Locks particle positions to follow a transform input, optionally updating a previous position
-    /// output field and locking orientation to the transform.
+    /// Causes particles to inherit the movement (and optionally rotation) of a transform input,
+    /// optionally updating a previous position output field.
     /// </summary>
+    /// <remarks>
+    /// "Movement Lock to Control Point" in the particle editor.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_PositionLock">C_OP_PositionLock</seealso>
     class PositionLock : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/PositionLock.cs
+++ b/Renderer/ParticleRenderer/Operators/PositionLock.cs
@@ -46,57 +46,68 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
 
         public override void Operate(ParticleCollection particles, float frameTime, ParticleSystemRenderState particleSystemState)
         {
+            // The transform delta must be computed once per frame, not per particle,
+            // otherwise only the first particle ever observes the transform moving
+            var transform = transformInput.NextTransform(particleSystemState);
+            var transformPosition = Vector3.Multiply(transform.Translation, componentScale.NextVector(particleSystemState));
+
+            if (previousTransformPosition.X == float.MaxValue)
+            {
+                previousTransformPosition = transformPosition;
+            }
+
+            var delta = transformPosition - previousTransformPosition;
+            previousTransformPosition = transformPosition;
+
+            // A jump beyond the threshold teleports particles with the transform at full strength
+            var instantJump = delta.Length() > instantJumpThreshold;
+
+            if (delta == Vector3.Zero && !lockRotation)
+            {
+                return;
+            }
+
             foreach (ref var particle in particles.Current)
             {
-                var transform = transformInput.NextTransform(ref particle, particleSystemState);
-                var transformPosition = Vector3.Multiply(transform.Translation, componentScale.NextVector(ref particle, particleSystemState));
+                var startTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, startTimeExp, startTimeMin, startTimeMax);
+                var endTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, endTimeExp, endTimeMin, endTimeMax);
 
-                if (previousTransformPosition.X == float.MaxValue)
+                // Fully locked until startTime, fading the lock out until endTime
+                var lockStrength = particle.Age <= startTime
+                    ? 1f
+                    : 1f - MathUtils.Saturate(MathUtils.Remap(particle.Age, startTime, endTime));
+
+                if (instantJump)
                 {
-                    previousTransformPosition = transformPosition;
+                    lockStrength = 1f;
                 }
 
-                var delta = (transformPosition - previousTransformPosition) * prevPosScale;
-                var targetPosition = transformPosition + delta;
+                if (lockStrength <= 0f)
+                {
+                    continue;
+                }
+
+                var currentPosition = particle.GetVector(outputField);
 
                 if (fadeRange > 0f)
                 {
-                    var currentPosition = particle.GetVector(outputField);
                     var distance = Vector3.Distance(transformPosition, currentPosition);
                     var normalizedDistance = MathUtils.Saturate(distance / fadeRange);
                     var bias = rangeBias.NextNumber(ref particle, particleSystemState);
                     var remapped = bias <= 0f
                         ? normalizedDistance
                         : MathF.Pow(normalizedDistance, 1f / MathF.Max(0.0001f, bias));
-                    var fadeWeight = 1f - remapped;
-                    targetPosition = Vector3.Lerp(currentPosition, targetPosition, fadeWeight);
+                    lockStrength *= 1f - remapped;
                 }
 
-                if (Vector3.Distance(transformPosition, previousTransformPosition) > instantJumpThreshold)
-                {
-                    targetPosition = transformPosition;
-                }
-
-                var startTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, startTimeExp, startTimeMin, startTimeMax);
-                var endTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, endTimeExp, endTimeMin, endTimeMax);
-
-                if (particle.Age < startTime || particle.Age > endTime)
-                {
-                    previousTransformPosition = transformPosition;
-                    continue;
-                }
-
-                var previousOutput = particle.GetVector(outputField);
-                particle.SetVector(outputFieldPrev, previousOutput);
-                particle.SetVector(outputField, targetPosition);
+                // Translate the particle with the transform, preserving its offset from it
+                particle.SetVector(outputFieldPrev, particle.GetVector(outputFieldPrev) + delta * (lockStrength * prevPosScale));
+                particle.SetVector(outputField, currentPosition + delta * lockStrength);
 
                 if (lockRotation)
                 {
-                    var orientation = transformInput.GetOrientation(ref particle, particleSystemState);
-                    particle.Normal = orientation;
+                    particle.Normal = transformInput.GetOrientation(ref particle, particleSystemState);
                 }
-
-                previousTransformPosition = transformPosition;
             }
         }
     }

--- a/Renderer/ParticleRenderer/Operators/PositionLock.cs
+++ b/Renderer/ParticleRenderer/Operators/PositionLock.cs
@@ -24,6 +24,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         private readonly ParticleField outputFieldPrev = ParticleField.PositionPrevious;
 
         private Vector3 previousTransformPosition = new(float.MaxValue);
+        private Matrix4x4 previousTransform = Matrix4x4.Identity;
 
         public PositionLock(ParticleDefinitionParser parse) : base(parse)
         {
@@ -54,10 +55,21 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
             if (previousTransformPosition.X == float.MaxValue)
             {
                 previousTransformPosition = transformPosition;
+                previousTransform = transform;
             }
 
             var delta = transformPosition - previousTransformPosition;
+
+            // When locking rotation, particles are moved by the change in the transform (current * inverse(previous))
+            // so they orbit the control point; otherwise they are translated by the raw position delta
+            var rotationLock = Matrix4x4.Identity;
+            if (lockRotation && Matrix4x4.Invert(previousTransform, out var previousInverse))
+            {
+                rotationLock = previousInverse * transform;
+            }
+
             previousTransformPosition = transformPosition;
+            previousTransform = transform;
 
             // A jump beyond the threshold teleports particles with the transform at full strength
             var instantJump = delta.Length() > instantJumpThreshold;
@@ -67,15 +79,23 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 return;
             }
 
+            // A start fadeout of 1 (the default) means the lock never fades and is applied every frame
+            var alwaysLocked = startTimeMin >= 1f;
+
             foreach (ref var particle in particles.Current)
             {
-                var startTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, startTimeExp, startTimeMin, startTimeMax);
-                var endTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, endTimeExp, endTimeMin, endTimeMax);
+                var lockStrength = 1f;
 
-                // Fully locked until startTime, fading the lock out until endTime
-                var lockStrength = particle.Age <= startTime
-                    ? 1f
-                    : 1f - MathUtils.Saturate(MathUtils.Remap(particle.Age, startTime, endTime));
+                if (!alwaysLocked)
+                {
+                    var startTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, startTimeExp, startTimeMin, startTimeMax);
+                    var endTime = ParticleCollection.RandomWithExponentBetween(particle.ParticleID, endTimeExp, endTimeMin, endTimeMax);
+
+                    // Fully locked until startTime, fading the lock out until endTime, using normalized lifetime
+                    lockStrength = particle.NormalizedAge <= startTime
+                        ? 1f
+                        : 1f - MathUtils.Saturate(MathUtils.Remap(particle.NormalizedAge, startTime, endTime));
+                }
 
                 if (instantJump)
                 {
@@ -100,13 +120,22 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                     lockStrength *= 1f - remapped;
                 }
 
-                // Translate the particle with the transform, preserving its offset from it
-                particle.SetVector(outputFieldPrev, particle.GetVector(outputFieldPrev) + delta * (lockStrength * prevPosScale));
-                particle.SetVector(outputField, currentPosition + delta * lockStrength);
-
                 if (lockRotation)
                 {
+                    // Move both positions by the transform delta so particles follow the control point's rotation
+                    var currentPrevious = particle.GetVector(outputFieldPrev);
+                    var rotatedPosition = Vector3.Transform(currentPosition, rotationLock);
+                    var rotatedPrevious = Vector3.Transform(currentPrevious, rotationLock);
+
+                    particle.SetVector(outputFieldPrev, currentPrevious + (rotatedPrevious - currentPrevious) * (lockStrength * prevPosScale));
+                    particle.SetVector(outputField, currentPosition + (rotatedPosition - currentPosition) * lockStrength);
                     particle.Normal = transformInput.GetOrientation(ref particle, particleSystemState);
+                }
+                else
+                {
+                    // Translate the particle with the transform, preserving its offset from it
+                    particle.SetVector(outputFieldPrev, particle.GetVector(outputFieldPrev) + delta * (lockStrength * prevPosScale));
+                    particle.SetVector(outputField, currentPosition + delta * lockStrength);
                 }
             }
         }

--- a/Renderer/ParticleRenderer/Operators/RemapSpeed.cs
+++ b/Renderer/ParticleRenderer/Operators/RemapSpeed.cs
@@ -34,7 +34,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 var outputMin = this.outputMin.NextNumber(ref particle, particleSystemState);
                 var outputMax = this.outputMax.NextNumber(ref particle, particleSystemState);
 
-                var finalValue = MathUtils.RemapRange(particle.Speed, inputMin, inputMax, outputMin, outputMax);
+                var remap = MathUtils.Saturate(MathUtils.Remap(particle.Speed, inputMin, inputMax));
+                var finalValue = float.Lerp(outputMin, outputMax, remap);
                 finalValue = particle.ModifyScalarBySetMethod(particles, OutputField, finalValue, setMethod);
 
                 particle.SetScalar(OutputField, finalValue);

--- a/Renderer/ParticleRenderer/Operators/RemapSpeed.cs
+++ b/Renderer/ParticleRenderer/Operators/RemapSpeed.cs
@@ -34,8 +34,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 var outputMin = this.outputMin.NextNumber(ref particle, particleSystemState);
                 var outputMax = this.outputMax.NextNumber(ref particle, particleSystemState);
 
-                var remap = MathUtils.Saturate(MathUtils.Remap(particle.Speed, inputMin, inputMax));
-                var finalValue = float.Lerp(outputMin, outputMax, remap);
+                var finalValue = MathUtils.RemapValClamped(particle.Speed, inputMin, inputMax, outputMin, outputMax);
                 finalValue = particle.ModifyScalarBySetMethod(particles, OutputField, finalValue, setMethod);
 
                 particle.SetScalar(OutputField, finalValue);

--- a/Renderer/ParticleRenderer/Operators/Spin.cs
+++ b/Renderer/ParticleRenderer/Operators/Spin.cs
@@ -21,7 +21,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         /// Spin rate in degrees per second at the given particle age: the rate decays linearly from
         /// the main rate to the min floor over the stop time; a stop time of 0 means no decay.
         /// </summary>
-        protected float GetSpinRate(float age)
+        private float GetSpinRate(float age)
         {
             if (spinRateStopTime == 0f)
             {
@@ -34,6 +34,14 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
                 ? MathF.Max(decayed, spinRateMinDegrees)
                 : MathF.Min(decayed, spinRateMinDegrees);
         }
+
+        /// <summary>
+        /// This frame's rotation increment in radians. Rotation is stored in radians, the spin rate
+        /// in degrees per second; the engine scales the converted rate by an extra 2*pi, inherited
+        /// from S1 CGeneralSpin (57 deg/s spins roughly one full turn per second).
+        /// </summary>
+        protected float GetSpinDelta(float age, float frameTime)
+            => float.DegreesToRadians(GetSpinRate(age)) * MathF.Tau * frameTime;
     }
 
     /// <summary>
@@ -51,10 +59,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                // Rotation is stored in radians, the spin rate in degrees per second.
-                // The engine scales the converted rate by an extra 2*pi, inherited from S1 CGeneralSpin
-                // (57 deg/s spins roughly one full turn per second).
-                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + float.DegreesToRadians(GetSpinRate(particle.Age)) * MathF.Tau * frameTime);
+                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + GetSpinDelta(particle.Age, frameTime));
             }
         }
     }
@@ -74,10 +79,7 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                // Rotation is stored in radians, the spin rate in degrees per second.
-                // The engine scales the converted rate by an extra 2*pi, inherited from S1 CGeneralSpin
-                // (57 deg/s spins roughly one full turn per second).
-                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + float.DegreesToRadians(GetSpinRate(particle.Age)) * MathF.Tau * frameTime);
+                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + GetSpinDelta(particle.Age, frameTime));
             }
         }
     }

--- a/Renderer/ParticleRenderer/Operators/Spin.cs
+++ b/Renderer/ParticleRenderer/Operators/Spin.cs
@@ -51,7 +51,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + GetSpinRate(particle.Age) * frameTime);
+                // Rotation is stored in radians, the spin rate in degrees per second
+                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + float.DegreesToRadians(GetSpinRate(particle.Age)) * frameTime);
             }
         }
     }
@@ -71,7 +72,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + GetSpinRate(particle.Age) * frameTime);
+                // Rotation is stored in radians, the spin rate in degrees per second
+                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + float.DegreesToRadians(GetSpinRate(particle.Age)) * frameTime);
             }
         }
     }

--- a/Renderer/ParticleRenderer/Operators/Spin.cs
+++ b/Renderer/ParticleRenderer/Operators/Spin.cs
@@ -51,8 +51,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                // Rotation is stored in radians, the spin rate in degrees per second
-                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + float.DegreesToRadians(GetSpinRate(particle.Age)) * frameTime);
+                // Rotation is stored in radians, the spin rate in degrees per second.
+                // The engine scales the converted rate by an extra 2*pi, inherited from S1 CGeneralSpin
+                // (57 deg/s spins roughly one full turn per second).
+                particle.SetScalar(ParticleField.Roll, particle.Rotation.Z + float.DegreesToRadians(GetSpinRate(particle.Age)) * MathF.Tau * frameTime);
             }
         }
     }
@@ -72,8 +74,10 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                // Rotation is stored in radians, the spin rate in degrees per second
-                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + float.DegreesToRadians(GetSpinRate(particle.Age)) * frameTime);
+                // Rotation is stored in radians, the spin rate in degrees per second.
+                // The engine scales the converted rate by an extra 2*pi, inherited from S1 CGeneralSpin
+                // (57 deg/s spins roughly one full turn per second).
+                particle.SetScalar(ParticleField.Yaw, particle.Rotation.X + float.DegreesToRadians(GetSpinRate(particle.Age)) * MathF.Tau * frameTime);
             }
         }
     }

--- a/Renderer/ParticleRenderer/Operators/SpinUpdate.cs
+++ b/Renderer/ParticleRenderer/Operators/SpinUpdate.cs
@@ -4,6 +4,11 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
     /// Integrates each particle's rotation speed into its rotation each frame. This is the only
     /// operator that advances rotation based on the rotation speed attribute.
     /// </summary>
+    /// <remarks>
+    /// "Rotation Basic" in the particle editor: it enables rotation authored through the effect's
+    /// base <c>rotation_speed</c> property or the "Rotation Speed Random" initializer. The
+    /// "Rotation Spin Roll"/"Rotation Spin Yaw" operators rotate on their own and do not require it.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_SpinUpdate">C_OP_SpinUpdate</seealso>
     class SpinUpdate : ParticleFunctionOperator
     {

--- a/Renderer/ParticleRenderer/Operators/SpinUpdate.cs
+++ b/Renderer/ParticleRenderer/Operators/SpinUpdate.cs
@@ -16,8 +16,8 @@ namespace ValveResourceFormat.Renderer.Particles.Operators
         {
             foreach (ref var particle in particles.Current)
             {
-                var rotationRadians = Vector3.DegreesToRadians(particle.RotationSpeed);
-                particle.Rotation += rotationRadians * frameTime;
+                // RotationSpeed is stored in radians per second by everything that writes it
+                particle.Rotation += particle.RotationSpeed * frameTime;
             }
         }
     }

--- a/Renderer/ParticleRenderer/Particle.cs
+++ b/Renderer/ParticleRenderer/Particle.cs
@@ -45,7 +45,7 @@ namespace ValveResourceFormat.Renderer.Particles
         public float ForceScale { get; set; } = 1.0f;
 
         /// <summary>
-        /// Gets or sets (Yaw, Pitch, Roll) Euler angles.
+        /// Gets or sets (Yaw, Pitch, Roll) Euler angles in radians.
         /// </summary>
         public Vector3 Rotation { get; set; } = Vector3.Zero;
 
@@ -53,6 +53,7 @@ namespace ValveResourceFormat.Renderer.Particles
         /// Gets or sets (Yaw, Pitch, Roll) Euler angles rotation speed.
         /// </summary>
         public Vector3 RotationSpeed { get; set; } = Vector3.Zero;
+
         /// <summary>Gets or sets the current velocity of the particle.</summary>
         public Vector3 Velocity { get; set; } = Vector3.Zero;
 
@@ -138,8 +139,9 @@ namespace ValveResourceFormat.Renderer.Particles
 
             Radius = parse.Float("m_flConstantRadius", Radius);
             Lifetime = parse.Float("m_flConstantLifespan", Lifetime);
-            Rotation = Rotation with { Z = parse.Float("m_flConstantRotation", Rotation.Z) };
-            RotationSpeed = RotationSpeed with { Z = parse.Float("m_flConstantRotationSpeed", RotationSpeed.Z) };
+            // Rotation fields are stored in radians, but the constants are authored in degrees
+            Rotation = Rotation with { Z = float.DegreesToRadians(parse.Float("m_flConstantRotation", 0f)) };
+            RotationSpeed = RotationSpeed with { Z = float.DegreesToRadians(parse.Float("m_flConstantRotationSpeed", 0f)) };
             Normal = parse.Vector3("m_ConstantNormal", Normal);
             Sequence = parse.Int32("m_nConstantSequenceNumber", Sequence);
             Sequence2 = parse.Int32("m_nConstantSequenceNumber1", Sequence2);

--- a/Renderer/ParticleRenderer/Particle.cs
+++ b/Renderer/ParticleRenderer/Particle.cs
@@ -35,8 +35,8 @@ namespace ValveResourceFormat.Renderer.Particles
         /// <summary>Gets or sets the radius of the particle.</summary>
         public float Radius { get; set; } = 1.0f;
 
-        /// <summary>Gets or sets the trail length multiplier for trail-based renderers.</summary>
-        public float TrailLength { get; set; } = 0f;
+        /// <summary>Gets or sets the trail length multiplier for trail-based renderers. The engine seeds this attribute with 0.1.</summary>
+        public float TrailLength { get; set; } = 0.1f;
 
         /// <summary>
         /// Gets or sets the scale factor applied to forces acting on this particle. 1 = full force,

--- a/Renderer/ParticleRenderer/Particle.cs
+++ b/Renderer/ParticleRenderer/Particle.cs
@@ -64,12 +64,12 @@ namespace ValveResourceFormat.Renderer.Particles
             readonly get => Vector3.Transform(new Vector3(0, 0, 1), GetRotationMatrix());
             set
             {
-                var normal = Vector3.Normalize(value);
-
-                if (normal == Vector3.Zero)
+                if (value == Vector3.Zero)
                 {
                     return;
                 }
+
+                var normal = Vector3.Normalize(value);
 
                 var yaw = MathF.Atan2(normal.X, normal.Z);
                 var pitch = MathF.Asin(Math.Clamp(normal.Y, -1f, 1f));

--- a/Renderer/ParticleRenderer/Particle.cs
+++ b/Renderer/ParticleRenderer/Particle.cs
@@ -142,7 +142,7 @@ namespace ValveResourceFormat.Renderer.Particles
             RotationSpeed = RotationSpeed with { Z = parse.Float("m_flConstantRotationSpeed", RotationSpeed.Z) };
             Normal = parse.Vector3("m_ConstantNormal", Normal);
             Sequence = parse.Int32("m_nConstantSequenceNumber", Sequence);
-            Sequence2 = parse.Int32("m_nConstantSequenceNumber1", Sequence);
+            Sequence2 = parse.Int32("m_nConstantSequenceNumber1", Sequence2);
         }
 
         /// <summary>

--- a/Renderer/ParticleRenderer/Particle.cs
+++ b/Renderer/ParticleRenderer/Particle.cs
@@ -73,7 +73,8 @@ namespace ValveResourceFormat.Renderer.Particles
                 var normal = Vector3.Normalize(value);
 
                 var yaw = MathF.Atan2(normal.X, normal.Z);
-                var pitch = MathF.Asin(Math.Clamp(normal.Y, -1f, 1f));
+                // The getter yields Y = -sin(pitch), so the pitch must be negated here for get/set round trips
+                var pitch = MathF.Asin(-Math.Clamp(normal.Y, -1f, 1f));
                 Rotation = new Vector3(yaw, pitch, Rotation.Z);
             }
         }

--- a/Renderer/ParticleRenderer/ParticleCollection.cs
+++ b/Renderer/ParticleRenderer/ParticleCollection.cs
@@ -124,6 +124,14 @@ namespace ValveResourceFormat.Renderer.Particles
         }
 
         /// <summary>
+        /// Returns a non-deterministic random vector with each component independently interpolated between the corresponding components of <paramref name="min"/> and <paramref name="max"/>.
+        /// </summary>
+        public static Vector3 RandomBetweenPerComponent(Vector3 min, Vector3 max)
+        {
+            return RandomBetweenPerComponent(Random.Shared.Next(), min, max);
+        }
+
+        /// <summary>
         /// Returns a deterministic pseudo-random float in [<paramref name="min"/>, <paramref name="max"/>] biased by raising the random value to <paramref name="exponent"/>.
         /// </summary>
         public static float RandomWithExponentBetween(int particleId, float exponent, float min, float max)

--- a/Renderer/ParticleRenderer/ParticleCollection.cs
+++ b/Renderer/ParticleRenderer/ParticleCollection.cs
@@ -92,7 +92,8 @@ namespace ValveResourceFormat.Renderer.Particles
         /// </summary>
         public static float RandomSingle(int particleId)
         {
-            return RandomFloats.List[particleId % RandomFloats.List.Length]; // TODO: Add seed
+            // Unsigned modulo keeps the index valid for any id, including ids that wrapped negative
+            return RandomFloats.List[(uint)particleId % RandomFloats.List.Length]; // TODO: Add seed
         }
 
         /// <summary>

--- a/Renderer/ParticleRenderer/ParticleRenderer.cs
+++ b/Renderer/ParticleRenderer/ParticleRenderer.cs
@@ -604,7 +604,7 @@ namespace ValveResourceFormat.Renderer.Particles
                 var pos = particle.Position - worldCenter;
                 var radius = new Vector3(particle.Radius);
 
-                var particleBounds = new AABB(pos - radius - additionalBounds.Min, pos + radius + additionalBounds.Max);
+                var particleBounds = new AABB(pos + additionalBounds.Min - radius, pos + additionalBounds.Max + radius);
                 newBounds = hasBounds ? newBounds.Union(particleBounds) : particleBounds;
                 hasBounds = true;
             }

--- a/Renderer/ParticleRenderer/ParticleSystemRenderState.cs
+++ b/Renderer/ParticleRenderer/ParticleSystemRenderState.cs
@@ -135,6 +135,18 @@ namespace ValveResourceFormat.Renderer.Particles
         }
 
         /// <summary>
+        /// Set the full rotation of a control point, keeping its forward direction in sync.
+        /// </summary>
+        /// <param name="cp">Control point index.</param>
+        /// <param name="rotation">Full rotation to assign.</param>
+        public void SetControlPointRotation(int cp, Quaternion rotation)
+        {
+            var point = GetControlPoint(cp);
+            point.Rotation = rotation;
+            point.Orientation = Vector3.Transform(Vector3.UnitZ, rotation);
+        }
+
+        /// <summary>
         /// Return a random float in the range [flLow, flHigh). The distribution is uniform.
         /// </summary>
         internal static float RandomFloat(float flLow, float flHigh)
@@ -180,6 +192,36 @@ namespace ValveResourceFormat.Renderer.Particles
         /// </summary>
         public Quaternion? Rotation { get; set; }
 
+        /// <summary>
+        /// The control point's full rotation, using <see cref="Rotation"/> when present and otherwise
+        /// synthesizing a frame from the forward <see cref="Orientation"/> direction.
+        /// </summary>
+        public Quaternion GetRotation()
+        {
+            if (Rotation is { } rotation)
+            {
+                return rotation;
+            }
+
+            if (Orientation == Vector3.Zero)
+            {
+                return Quaternion.Identity;
+            }
+
+            var forward = Vector3.Normalize(Orientation);
+            var up = MathF.Abs(forward.Y) < 0.999f ? Vector3.UnitY : Vector3.UnitZ;
+            var right = Vector3.Normalize(Vector3.Cross(up, forward));
+            up = Vector3.Cross(forward, right);
+
+            var matrix = new Matrix4x4(
+                right.X, right.Y, right.Z, 0,
+                up.X, up.Y, up.Z, 0,
+                forward.X, forward.Y, forward.Z, 0,
+                0, 0, 0, 1
+            );
+
+            return Quaternion.CreateFromRotationMatrix(matrix);
+        }
 
         /// <summary>
         /// Different attachment styles.

--- a/Renderer/ParticleRenderer/PreEmissionOperators/RampCPLinearRandom.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/RampCPLinearRandom.cs
@@ -16,7 +16,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             var rateMin = parse.Vector3("m_vecRateMin", Vector3.Zero);
             var rateMax = parse.Vector3("m_vecRateMax", Vector3.Zero);
 
-            rampRate = ParticleCollection.RandomBetweenPerComponent(Random.Shared.Next(), rateMin, rateMax);
+            rampRate = ParticleCollection.RandomBetweenPerComponent(rateMin, rateMax);
         }
 
         public override void Operate(ref ParticleSystemRenderState particleSystemState, float frameTime)

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointOrientation.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointOrientation.cs
@@ -37,7 +37,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             }
 
             var targetRotation = randomize
-                ? ParticleCollection.RandomBetweenPerComponent(Random.Shared.Next(), rotation, rotationB)
+                ? ParticleCollection.RandomBetweenPerComponent(rotation, rotationB)
                 : rotation;
 
             var targetOrientation = EntityTransformHelper.QAngleToForwardDirection(targetRotation);

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointPositions.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointPositions.cs
@@ -12,7 +12,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
         private readonly int CP3 = 3;
         private readonly int CP4 = 4;
         private readonly Vector3 CP1Pos = new(128, 0, 0);
-        private readonly Vector3 CP2Pos = new(0, -128, 0);
+        private readonly Vector3 CP2Pos = new(0, 128, 0);
         private readonly Vector3 CP3Pos = new(-128, 0, 0);
         private readonly Vector3 CP4Pos = new(0, -128, 0);
 

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointPositions.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointPositions.cs
@@ -41,15 +41,15 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
         {
             if (!(setOnce && HasRunBefore))
             {
-                // not fully accurate, as it is still in local space, but it's closer to correct
-                var controlPointOffset = useWorldLocation
-                    ? Vector3.Zero
-                    : particleSystemState.GetControlPoint(CPOffset).Position;
+                // Object-space positions are rotated and translated by the head control point
+                var headTransform = useWorldLocation
+                    ? Matrix4x4.Identity
+                    : new ControlPointTransformProvider(CPOffset, true).NextTransform(ref Particle.Default, particleSystemState);
 
-                particleSystemState.SetControlPointValue(CP1, CP1Pos + controlPointOffset);
-                particleSystemState.SetControlPointValue(CP2, CP2Pos + controlPointOffset);
-                particleSystemState.SetControlPointValue(CP3, CP3Pos + controlPointOffset);
-                particleSystemState.SetControlPointValue(CP4, CP4Pos + controlPointOffset);
+                particleSystemState.SetControlPointValue(CP1, Vector3.Transform(CP1Pos, headTransform));
+                particleSystemState.SetControlPointValue(CP2, Vector3.Transform(CP2Pos, headTransform));
+                particleSystemState.SetControlPointValue(CP3, Vector3.Transform(CP3Pos, headTransform));
+                particleSystemState.SetControlPointValue(CP4, Vector3.Transform(CP4Pos, headTransform));
 
                 HasRunBefore = true;
             }

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
@@ -45,7 +45,8 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             // Rotate the current orientation by this frame's increment so the rotation accumulates
             var rotatedVector = MatrixMul(orientation, Matrix4x4.CreateFromAxisAngle(axis, rotationRate * frameTime));
 
-            controlPoint.Orientation = Vector3.Normalize(rotatedVector);
+            // Goes through the state setter to keep the control point's full rotation in sync
+            particleSystemState.SetControlPointOrientation(cp, Vector3.Normalize(rotatedVector));
         }
     }
 }

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
@@ -8,7 +8,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
     {
         private readonly IVectorProvider axis = new LiteralVectorProvider(new Vector3(0, 0, 1));
         private readonly int cp;
-        private readonly int localCP = -1; // ??
+        private readonly int localCP = -1;
         private readonly INumberProvider rotationRate = new LiteralNumberProvider(180);
 
         public SetControlPointRotation(ParticleDefinitionParser parse) : base(parse)

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
@@ -8,7 +8,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
     {
         private readonly IVectorProvider axis = new LiteralVectorProvider(new Vector3(0, 0, 1));
         private readonly int cp;
-        private readonly int localCP = -1;
+        private readonly int localCP = -1; // ??
         private readonly INumberProvider rotationRate = new LiteralNumberProvider(180);
 
         public SetControlPointRotation(ParticleDefinitionParser parse) : base(parse)
@@ -28,10 +28,24 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
         public override void Operate(ref ParticleSystemRenderState particleSystemState, float frameTime)
         {
             var axis = this.axis.NextVector(particleSystemState);
-            var rotationRate = this.rotationRate.NextNumber(particleSystemState);
-            var rotatedVector = MatrixMul(new Vector3(1, 0, 0), Matrix4x4.CreateFromAxisAngle(axis, rotationRate * frameTime));
 
-            particleSystemState.SetControlPointOrientation(cp, Vector3.Normalize(rotatedVector));
+            if (axis == Vector3.Zero)
+            {
+                return;
+            }
+
+            axis = Vector3.Normalize(axis);
+            var rotationRate = float.DegreesToRadians(this.rotationRate.NextNumber(particleSystemState));
+
+            var controlPoint = particleSystemState.GetControlPoint(cp);
+            var orientation = controlPoint.Orientation == Vector3.Zero
+                ? new Vector3(1, 0, 0)
+                : controlPoint.Orientation;
+
+            // Rotate the current orientation by this frame's increment so the rotation accumulates
+            var rotatedVector = MatrixMul(orientation, Matrix4x4.CreateFromAxisAngle(axis, rotationRate * frameTime));
+
+            controlPoint.Orientation = Vector3.Normalize(rotatedVector);
         }
     }
 }

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetControlPointRotation.cs
@@ -18,12 +18,6 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             cp = parse.Int32("m_nCP", cp);
             localCP = parse.Int32("m_nLocalCP", localCP);
         }
-        private static Vector3 MatrixMul(Vector3 vector, Matrix4x4 rotatedMatrix)
-        {
-            return vector.X * new Vector3(rotatedMatrix.M11, rotatedMatrix.M12, rotatedMatrix.M13) +
-                vector.Y * new Vector3(rotatedMatrix.M21, rotatedMatrix.M22, rotatedMatrix.M23) +
-                vector.Z * new Vector3(rotatedMatrix.M31, rotatedMatrix.M32, rotatedMatrix.M33);
-        }
 
         public override void Operate(ref ParticleSystemRenderState particleSystemState, float frameTime)
         {
@@ -35,18 +29,20 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             }
 
             axis = Vector3.Normalize(axis);
-            var rotationRate = float.DegreesToRadians(this.rotationRate.NextNumber(particleSystemState));
 
+            if (localCP > -1)
+            {
+                axis = Vector3.Transform(axis, particleSystemState.GetControlPoint(localCP).GetRotation());
+            }
+
+            var angle = float.DegreesToRadians(rotationRate.NextNumber(particleSystemState)) * frameTime;
+
+            // Accumulate this frame's increment onto the control point's current rotation so it spins continuously
             var controlPoint = particleSystemState.GetControlPoint(cp);
-            var orientation = controlPoint.Orientation == Vector3.Zero
-                ? new Vector3(1, 0, 0)
-                : controlPoint.Orientation;
+            var increment = Quaternion.CreateFromAxisAngle(axis, angle);
+            var rotation = Quaternion.Normalize(controlPoint.GetRotation() * increment);
 
-            // Rotate the current orientation by this frame's increment so the rotation accumulates
-            var rotatedVector = MatrixMul(orientation, Matrix4x4.CreateFromAxisAngle(axis, rotationRate * frameTime));
-
-            // Goes through the state setter to keep the control point's full rotation in sync
-            particleSystemState.SetControlPointOrientation(cp, Vector3.Normalize(rotatedVector));
+            particleSystemState.SetControlPointRotation(cp, rotation);
         }
     }
 }

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
@@ -57,7 +57,12 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
                 GenerateNewPosition();
 
                 particleSystemState.SetControlPointValue(cp, currentPosition + controlPointOffset);
-                particleSystemState.SetControlPointOrientation(cp, orientation);
+
+                if (orient)
+                {
+                    particleSystemState.SetControlPointOrientation(cp, orientation);
+                }
+
                 HasRunBefore = true;
             }
 
@@ -75,7 +80,11 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
                 // orientation doesn't lerp in the same way that position does
 
                 particleSystemState.SetControlPointValue(cp, positionBlended);
-                particleSystemState.SetControlPointOrientation(cp, orientation);
+
+                if (orient)
+                {
+                    particleSystemState.SetControlPointOrientation(cp, orientation);
+                }
 
                 // If we need to generate a new position
                 if (timeSinceLastRun > reRandomRate)

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
@@ -37,7 +37,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
 
         private void GenerateNewPosition()
         {
-            currentPosition = ParticleCollection.RandomBetweenPerComponent(Random.Shared.Next(), minPos, maxPos);
+            currentPosition = ParticleCollection.RandomBetweenPerComponent(minPos, maxPos);
         }
 
         /// <summary>

--- a/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
+++ b/Renderer/ParticleRenderer/PreEmissionOperators/SetRandomControlPointPosition.cs
@@ -39,24 +39,26 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
         {
             currentPosition = ParticleCollection.RandomBetweenPerComponent(Random.Shared.Next(), minPos, maxPos);
         }
+
+        /// <summary>
+        /// The current object-space position rotated and translated by the head control point.
+        /// </summary>
+        private Vector3 GetTargetPosition(ParticleSystemRenderState particleSystemState) => useWorldLocation
+            ? currentPosition
+            : ControlPointTransformProvider.TransformPosition(particleSystemState, offsetCP, currentPosition);
+
         public override void Operate(ref ParticleSystemRenderState particleSystemState, float frameTime)
         {
-            // not fully accurate, as it is still in local space, but it's closer to correct
-            var controlPointOffset = useWorldLocation
-                ? Vector3.Zero
-                : particleSystemState.GetControlPoint(offsetCP).Position;
-
             var orientation = orient
                 ? particleSystemState.GetControlPoint(offsetCP).Orientation
                 : Vector3.Zero;
-
 
             // We need to start off with an initial value, regardless of interpolation
             if (!HasRunBefore)
             {
                 GenerateNewPosition();
 
-                particleSystemState.SetControlPointValue(cp, currentPosition + controlPointOffset);
+                particleSystemState.SetControlPointValue(cp, GetTargetPosition(particleSystemState));
 
                 if (orient)
                 {
@@ -72,7 +74,7 @@ namespace ValveResourceFormat.Renderer.Particles.PreEmissionOperators
             if (reRandomRate > 0f)
             {
                 var lerpOld = particleSystemState.GetControlPoint(cp).Position;
-                var lerpNew = currentPosition + controlPointOffset;
+                var lerpNew = GetTargetPosition(particleSystemState);
 
                 // exponential fade like all the other lerps
                 var positionBlended = Vector3.Lerp(lerpOld, lerpNew, interpolation.NextNumber(particleSystemState));

--- a/Renderer/ParticleRenderer/Renderers/RenderOmni2Light.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderOmni2Light.cs
@@ -104,7 +104,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         private void UpdateLight(SceneLight light, ref Particle particle, ParticleSystemRenderState systemRenderState)
         {
-            var baseColor = colorBlend.NextVector(ref particle, systemRenderState) / 255f;
+            var baseColor = colorBlend.NextVector(ref particle, systemRenderState);
             var color = Vector3.Clamp(baseColor, Vector3.Zero, Vector3.One);
 
             var brightness = brightnessUnit switch
@@ -118,7 +118,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             light.Color = color;
             light.Brightness = MathF.Max(0f, brightness);
-            light.BrightnessScale = 1 - particle.NormalizedAge;
+            light.BrightnessScale = MathF.Max(0f, 1 - particle.NormalizedAge);
             light.Range = lightRange;
             light.FallOff = skirtValue;
             light.Position = particle.Position;

--- a/Renderer/ParticleRenderer/Renderers/RenderSprites.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderSprites.cs
@@ -8,6 +8,10 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// Renders particles as camera-facing or orientation-aligned textured quads (sprites),
     /// with support for sprite sheet animation, blend modes, and per-particle color and alpha.
     /// </summary>
+    /// <remarks>
+    /// The workhorse renderer used by most effects. Multi-frame sequences can be animated or
+    /// used to provide visual variation.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderSprites">C_OP_RenderSprites</seealso>
     internal class RenderSprites : ParticleFunctionRenderer
     {

--- a/Renderer/ParticleRenderer/Renderers/RenderStandardLight.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderStandardLight.cs
@@ -68,7 +68,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         private void UpdateLight(SceneLight light, ref Particle particle, ParticleSystemRenderState systemRenderState)
         {
             // Should we use the particle color?
-            var color = colorScale.NextVector(ref particle, systemRenderState) / 255f;
+            var color = colorScale.NextVector(ref particle, systemRenderState);
             var radius = particle.Radius;
             var range = radius * radiusMultiplier.NextNumber(ref particle, systemRenderState);
             var brightness = MathF.Max(0f, intensity.NextNumber(ref particle, systemRenderState));

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -31,6 +31,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
         private readonly float maxLength = 2000f;
         private readonly float lengthFadeInTime;
+        private readonly bool ignoreDeltaTime;
 
         public RenderTrails(ParticleDefinitionParser parse, RendererContext rendererContext) : base(parse)
         {
@@ -93,6 +94,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             finalTextureScaleV = parse.Float("m_flFinalTextureScaleV", finalTextureScaleV);
             maxLength = parse.Float("m_flMaxLength", maxLength);
             lengthFadeInTime = parse.Float("m_flLengthFadeInTime", lengthFadeInTime);
+            ignoreDeltaTime = parse.Boolean("m_bIgnoreDT", ignoreDeltaTime);
             animationType = parse.Enum<ParticleAnimationType>("m_nAnimationType", animationType);
             prevPositionSource = parse.ParticleField("m_nPrevPntSource", prevPositionSource);
         }
@@ -156,6 +158,12 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             // also todo: pass all of these as vertex parameters (probably just color/alpha combined)
             shader.SetUniform1("uOverbrightFactor", (float)overbrightFactor.NextNumber(systemRenderState));
 
+            // The moved distance is converted back to a velocity (distance / dt) before scaling by
+            // the trail-length attribute, unless the operator opts out of the delta-time division.
+            var oneOverDt = ignoreDeltaTime || particleBag.PreviousFrameTime == 0f
+                ? 1f
+                : 1f / particleBag.PreviousFrameTime;
+
             // Todo: this could be adapted into renderropes without much difficulty
             foreach (ref var particle in particles)
             {
@@ -166,7 +174,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
                 // Trail width = radius
                 // Trail length = distance between current and previous times trail length divided by 2 (because the base particle is 2 wide)
-                var length = Math.Min(maxLength, particle.TrailLength * difference.Length() / 2f);
+                var length = Math.Min(maxLength, particle.TrailLength * difference.Length() * oneOverDt / 2f);
                 var t = particle.Age; // Fade-in time is in seconds
                 var animatedLength = t >= lengthFadeInTime
                     ? length

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -168,7 +168,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 var position = particle.Position;
                 var previousPosition = particle.GetVector(prevPositionSource);
                 var difference = previousPosition - position;
-                var direction = Vector3.Normalize(difference);
+                var direction = difference == Vector3.Zero ? Vector3.UnitY : Vector3.Normalize(difference);
 
                 var midPoint = position + (0.5f * difference);
 
@@ -184,11 +184,12 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 // Center the particle at the midpoint between the two points
                 var translationMatrix = Matrix4x4.CreateTranslation(Vector3.UnitY * animatedLength);
 
-                // Calculate rotation matrix
-
-                var axis = Vector3.Normalize(Vector3.Cross(Vector3.UnitY, direction));
-                var angle = MathF.Acos(direction.Y);
-                var rotationMatrix = Matrix4x4.CreateFromAxisAngle(axis, angle);
+                // Rotate the quad from its default +Y orientation to the trail direction. When they
+                // are parallel the cross product is zero and there is no unique rotation axis.
+                var cross = Vector3.Cross(Vector3.UnitY, direction);
+                var rotationMatrix = cross == Vector3.Zero
+                    ? (direction.Y < 0f ? Matrix4x4.CreateFromAxisAngle(Vector3.UnitX, MathF.PI) : Matrix4x4.Identity)
+                    : Matrix4x4.CreateFromAxisAngle(Vector3.Normalize(cross), MathF.Acos(Math.Clamp(direction.Y, -1f, 1f)));
 
                 var modelMatrix = orientationType == ParticleOrientation.PARTICLE_ORIENTATION_SCREEN_ALIGNED
                     ? Matrix4x4.Multiply(scaleMatrix, Matrix4x4.Multiply(translationMatrix, rotationMatrix))

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -30,6 +30,8 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
         private readonly float finalTextureScaleV = 1f;
 
         private readonly float maxLength = 2000f;
+        private readonly float minLength;
+        private readonly float lengthScale = 1f;
         private readonly float lengthFadeInTime;
         private readonly bool ignoreDeltaTime;
 
@@ -93,6 +95,8 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             finalTextureScaleU = parse.Float("m_flFinalTextureScaleU", finalTextureScaleU);
             finalTextureScaleV = parse.Float("m_flFinalTextureScaleV", finalTextureScaleV);
             maxLength = parse.Float("m_flMaxLength", maxLength);
+            minLength = parse.Float("m_flMinLength", minLength);
+            lengthScale = parse.Float("m_flLengthScale", lengthScale);
             lengthFadeInTime = parse.Float("m_flLengthFadeInTime", lengthFadeInTime);
             ignoreDeltaTime = parse.Boolean("m_bIgnoreDT", ignoreDeltaTime);
             animationType = parse.Enum<ParticleAnimationType>("m_nAnimationType", animationType);
@@ -169,31 +173,52 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             {
                 var position = particle.Position;
                 var previousPosition = particle.GetVector(prevPositionSource);
+                // The trail extends from the particle back toward its previous position
                 var difference = previousPosition - position;
                 var direction = difference == Vector3.Zero ? Vector3.UnitY : Vector3.Normalize(difference);
 
-                // Trail width = radius
-                // Trail length = distance between current and previous times trail length divided by 2 (because the base particle is 2 wide)
-                var length = Math.Min(maxLength, particle.TrailLength * difference.Length() * oneOverDt / 2f);
-                var t = particle.Age; // Fade-in time is in seconds
-                var animatedLength = t >= lengthFadeInTime
-                    ? length
-                    : t * length / lengthFadeInTime;
-                var scaleMatrix = Matrix4x4.CreateScale(particle.Radius, animatedLength, 1);
+                var length = lengthScale * particle.TrailLength * difference.Length() * oneOverDt;
 
-                // Center the particle at the midpoint between the two points
-                var translationMatrix = Matrix4x4.CreateTranslation(Vector3.UnitY * animatedLength);
+                // The length fades in before clamping so clamped trails still reach full length on time
+                if (particle.Age < lengthFadeInTime)
+                {
+                    length *= particle.Age / lengthFadeInTime;
+                }
 
-                // Rotate the quad from its default +Y orientation to the trail direction. When they
-                // are parallel the cross product is zero and there is no unique rotation axis.
-                var cross = Vector3.Cross(Vector3.UnitY, direction);
-                var rotationMatrix = cross == Vector3.Zero
-                    ? (direction.Y < 0f ? Matrix4x4.CreateFromAxisAngle(Vector3.UnitX, MathF.PI) : Matrix4x4.Identity)
-                    : Matrix4x4.CreateFromAxisAngle(Vector3.Normalize(cross), MathF.Acos(Math.Clamp(direction.Y, -1f, 1f)));
+                if (length <= 0f)
+                {
+                    continue;
+                }
 
-                var modelMatrix = orientationType == ParticleOrientation.PARTICLE_ORIENTATION_SCREEN_ALIGNED
-                    ? scaleMatrix * translationMatrix * rotationMatrix * Matrix4x4.CreateTranslation(position)
-                    : particle.GetTransformationMatrix();
+                // The engine clamps the full extent of the trail
+                length = Math.Clamp(length, minLength, maxLength);
+
+                Matrix4x4 modelMatrix;
+                if (orientationType == ParticleOrientation.PARTICLE_ORIENTATION_SCREEN_ALIGNED)
+                {
+                    // The quad's width axis stays perpendicular to the eye ray, its length axis follows the motion
+                    var widthAxis = Vector3.Cross(position - camera.Location, direction);
+                    widthAxis = widthAxis.LengthSquared() > 1e-12f
+                        ? Vector3.Normalize(widthAxis)
+                        : Vector3.Normalize(Vector3.Cross(direction, MathF.Abs(direction.Z) < 0.999f ? Vector3.UnitZ : Vector3.UnitX));
+                    var normal = Vector3.Cross(widthAxis, direction);
+
+                    var halfWidth = particle.Radius * 0.5f;
+                    var halfLength = length * 0.5f;
+                    var center = position + direction * halfLength;
+
+                    modelMatrix = new Matrix4x4(
+                        widthAxis.X * halfWidth, widthAxis.Y * halfWidth, widthAxis.Z * halfWidth, 0f,
+                        direction.X * halfLength, direction.Y * halfLength, direction.Z * halfLength, 0f,
+                        normal.X, normal.Y, normal.Z, 0f,
+                        center.X, center.Y, center.Z, 1f);
+                }
+                else
+                {
+                    // TODO: Other orientation types render as plain unstretched sprites here; the engine
+                    // still stretches them along the motion, constrained to the ground/normal plane
+                    modelMatrix = particle.GetTransformationMatrix();
+                }
 
                 // Position/Radius uniform
                 shader.SetUniform4x4("uModelMatrix", modelMatrix);

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -7,6 +7,11 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
     /// Renders particles as trail segments stretched between the particle's current and previous
     /// positions, with configurable length, fade-in, texture scaling, and blend modes.
     /// </summary>
+    /// <remarks>
+    /// Trails are sprites that stretch based on their speed over time. Traditional use cases
+    /// include bullet tracers and sparks; they are also useful when particles need to be oriented
+    /// in 3D space, which regular sprites handle poorly.
+    /// </remarks>
     /// <seealso href="https://s2v.app/SchemaExplorer/cs2/particles/C_OP_RenderTrails">C_OP_RenderTrails</seealso>
     internal class RenderTrails : ParticleFunctionRenderer
     {

--- a/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
+++ b/Renderer/ParticleRenderer/Renderers/RenderTrails.cs
@@ -143,6 +143,9 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
             }
 
+            // Trail quads are oriented by motion direction, so either side can face the camera
+            GL.Disable(EnableCap.CullFace);
+
             shader.Use();
 
             GL.BindVertexArray(vaoHandle);
@@ -153,15 +156,6 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
             // also todo: pass all of these as vertex parameters (probably just color/alpha combined)
             shader.SetUniform1("uOverbrightFactor", (float)overbrightFactor.NextNumber(systemRenderState));
 
-            // Create billboarding rotation (always facing camera)
-            if (!Matrix4x4.Decompose(camera.CameraViewMatrix, out _, out var modelViewRotation, out _))
-            {
-                throw new InvalidOperationException("Matrix decompose failed");
-            }
-
-            modelViewRotation = Quaternion.Inverse(modelViewRotation);
-            var billboardMatrix = Matrix4x4.CreateFromQuaternion(modelViewRotation);
-
             // Todo: this could be adapted into renderropes without much difficulty
             foreach (ref var particle in particles)
             {
@@ -170,12 +164,10 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 var difference = previousPosition - position;
                 var direction = difference == Vector3.Zero ? Vector3.UnitY : Vector3.Normalize(difference);
 
-                var midPoint = position + (0.5f * difference);
-
                 // Trail width = radius
                 // Trail length = distance between current and previous times trail length divided by 2 (because the base particle is 2 wide)
                 var length = Math.Min(maxLength, particle.TrailLength * difference.Length() / 2f);
-                var t = particle.NormalizedAge;
+                var t = particle.Age; // Fade-in time is in seconds
                 var animatedLength = t >= lengthFadeInTime
                     ? length
                     : t * length / lengthFadeInTime;
@@ -192,7 +184,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                     : Matrix4x4.CreateFromAxisAngle(Vector3.Normalize(cross), MathF.Acos(Math.Clamp(direction.Y, -1f, 1f)));
 
                 var modelMatrix = orientationType == ParticleOrientation.PARTICLE_ORIENTATION_SCREEN_ALIGNED
-                    ? Matrix4x4.Multiply(scaleMatrix, Matrix4x4.Multiply(translationMatrix, rotationMatrix))
+                    ? scaleMatrix * translationMatrix * rotationMatrix * Matrix4x4.CreateTranslation(position)
                     : particle.GetTransformationMatrix();
 
                 // Position/Radius uniform
@@ -225,7 +217,7 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
                 }
                 else
                 {
-                    shader.SetUniform2("uUvOffset", Vector2.One);
+                    shader.SetUniform2("uUvOffset", Vector2.Zero);
                     shader.SetUniform2("uUvScale", new Vector2(finalTextureScaleU, finalTextureScaleV));
                 }
 
@@ -238,6 +230,8 @@ namespace ValveResourceFormat.Renderer.Particles.Renderers
 
             GL.UseProgram(0);
             GL.BindVertexArray(0);
+
+            GL.Enable(EnableCap.CullFace);
         }
 
         public override IEnumerable<string> GetSupportedRenderModes() => shader.RenderModes;

--- a/Renderer/ParticleRenderer/Utils/CurveFitting.cs
+++ b/Renderer/ParticleRenderer/Utils/CurveFitting.cs
@@ -14,7 +14,9 @@ namespace ValveResourceFormat.Renderer.Particles.Utils
 
         public float Evaluate(float x)
         {
-            return a + x * (b + x * (c + x * d));
+            // Coefficients are relative to the segment start
+            var t = x - Start.X;
+            return a + t * (b + t * (c + t * d));
         }
 
         public bool IsInCurve(float x)
@@ -174,7 +176,7 @@ namespace ValveResourceFormat.Renderer.Particles.Utils
             else
             {
                 // Find the two points that we want to interpolate between
-                for (var i = 0; i < CurveSegments.Length - 1; i++)
+                for (var i = 0; i < CurveSegments.Length; i++)
                 {
                     // If the coordinate is in between two points (the biggie!)
                     if (CurveSegments[i].IsInCurve(value))

--- a/Renderer/ParticleRenderer/Utils/Noise.cs
+++ b/Renderer/ParticleRenderer/Utils/Noise.cs
@@ -15,7 +15,11 @@ namespace ValveResourceFormat.Renderer.Particles.Utils
         /// Yes I know it's not actually a proper LCG but I need it to work without knowing the last value.
         /// </summary>
         private static float PseudoRandom(float t)
-            => ((1013904223517 * t) % 1664525) / 1664525f;
+        {
+            // Compute in double and wrap into [0, 1) so large or negative inputs stay well distributed
+            var value = 1013904223517.0 * t % 1664525.0 / 1664525.0;
+            return (float)(value < 0 ? value + 1 : value);
+        }
 
         private static float CosineInterpolate(float start, float end, float mu)
         {

--- a/Renderer/ParticleRenderer/Utils/Noise.cs
+++ b/Renderer/ParticleRenderer/Utils/Noise.cs
@@ -2,13 +2,13 @@ namespace ValveResourceFormat.Renderer.Particles.Utils
 {
     static class Noise
     {
-        // Simple perlin noise implementation
+        // Simple perlin noise implementation, returns a value in [-1, 1] to match Source's NoiseSIMD.
         public static float Simplex1D(float t)
         {
             var previous = PseudoRandom(MathF.Floor(t));
             var next = PseudoRandom(MathF.Ceiling(t));
 
-            return CosineInterpolate(previous, next, MathUtils.Fract(t));
+            return (2f * CosineInterpolate(previous, next, MathUtils.Fract(t))) - 1f;
         }
 
         /// <summary>

--- a/Renderer/Utils/MathUtils.cs
+++ b/Renderer/Utils/MathUtils.cs
@@ -50,6 +50,12 @@ namespace ValveResourceFormat.Renderer.Utils
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float RemapValClamped(float x, float inputMin, float inputMax, float outputMin, float outputMax)
         {
+            // Source treats a degenerate input range as a threshold
+            if (inputMin == inputMax)
+            {
+                return x >= inputMax ? outputMax : outputMin;
+            }
+
             return float.Lerp(outputMin, outputMax, Saturate(Remap(x, inputMin, inputMax)));
         }
 

--- a/Renderer/Utils/MathUtils.cs
+++ b/Renderer/Utils/MathUtils.cs
@@ -62,7 +62,7 @@ namespace ValveResourceFormat.Renderer.Utils
         /// Returns the fractional part of a value (x - floor(x)).
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static float Fract(float x) => x % 1f;
+        public static float Fract(float x) => x - MathF.Floor(x);
 
         /// <summary>
         /// Wraps a value into the half-open range [lowBounds, highBounds).

--- a/Renderer/Utils/MathUtils.cs
+++ b/Renderer/Utils/MathUtils.cs
@@ -38,6 +38,22 @@ namespace ValveResourceFormat.Renderer.Utils
         }
 
         /// <summary>
+        /// Remaps a value from one range to another, holding the output at the range ends
+        /// for inputs outside the input range. Mirrors Source's RemapValClamped.
+        /// </summary>
+        /// <param name="x">Value to remap.</param>
+        /// <param name="inputMin">Input range minimum.</param>
+        /// <param name="inputMax">Input range maximum.</param>
+        /// <param name="outputMin">Output range minimum.</param>
+        /// <param name="outputMax">Output range maximum.</param>
+        /// <returns>Value remapped to the output range, clamped to it.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float RemapValClamped(float x, float inputMin, float inputMax, float outputMin, float outputMax)
+        {
+            return float.Lerp(outputMin, outputMax, Saturate(Remap(x, inputMin, inputMax)));
+        }
+
+        /// <summary>
         /// Swaps min and max if min > max.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
**Crashes / NaN**
- `PointList` path interpolation indexed out of bounds (open and closed paths)
- NaN poisoning from zero-vector normalization in `Particle.Normal`, `RenderTrails`, `NormalizeVector`, `MaxVelocity` and `RingWave` (0 particles per orbit)
- `NoiseEmitter` threw on negative `m_flOutputMax`; random index overflow in `RandomBetweenPerComponent` call sites

**Wrong behavior**
- `CurveFitting`: segment evaluation used absolute x with segment-relative coefficients, and the last curve segment was never interpolated
- Culling: particle AABB subtracted `m_BoundingBoxMin` instead of adding it, producing boxes that didn't contain their particles
- Rotation units unified to radians (constants parsing, `Spin`/`SpinYaw`, `SpinUpdate`) — spins were 57x too fast or slow depending on the writer
- `PositionLock`: per-frame transform delta was computed per particle (only the first particle followed the CP), particles snapped onto the CP instead of translating with it, and the default time window made it a no-op
- `RandomYawFlip` probability was inverted; `RemapSpeedToScalar` remapped particle ID instead of speed
- `ContinuousEmitter` burst all pre-start time on its first emitting frame; `NoiseEmitter` kept emission credit across restarts
- `RenderTrails`: screen-aligned trails rendered at the world origin, length fade-in compared normalized age against seconds, quads were back-face culled, wrong UV offset without a spritesheet
- Light renderers divided already-normalized colors by 255 (near-black lights); literal colors now normalized once in the provider
- `AttributeMapping`: input/output ranges were sorted independently, reversing inverting remaps; `RemapBiased` never clamped in its default input mode
- `MathUtils.Fract` was sign-broken for negative inputs (noise discontinuities); `Noise.PseudoRandom` degenerated at large times
- `SetControlPointRotation` never accumulated (frame-rate-dependent static orientation) and passed degrees as radians
- `RandomUniformOffsetVectorProvider` hid the base method with `new`, so the offset was silently ignored