### PR TITLE
Clamp draw call tints before packing into byte colors

### DIFF
--- a/Renderer/Renderer/MeshBatchRenderer.cs
+++ b/Renderer/Renderer/MeshBatchRenderer.cs
@@ -350,7 +350,10 @@ namespace ValveResourceFormat.Renderer
             if (uniforms.Tint > -1)
             {
                 var instanceTint = (request.Node is SceneAggregate.Fragment fragment) ? fragment.Tint : Vector4.One;
-                var tint = request.Mesh.Tint * request.Call.TintColor * instanceTint;
+
+                // Content can author out-of-range tints (e.g. renderamt above 255 baked into the draw call
+                // alpha); the packed byte color can only represent [0, 1].
+                var tint = Vector4.Clamp(request.Mesh.Tint * request.Call.TintColor * instanceTint, Vector4.Zero, Vector4.One);
 
                 GL.ProgramUniform1((uint)shader.Program, uniforms.Tint, Color32.FromVector4(tint).PackedValue);
             }

--- a/Renderer/Renderer/Scene.cs
+++ b/Renderer/Renderer/Scene.cs
@@ -448,7 +448,8 @@ namespace ValveResourceFormat.Renderer
                 var instanceTint = Vector4.One;
                 if (node is SceneAggregate.Fragment fragment)
                 {
-                    instanceTint = fragment.RenderMesh.Tint * fragment.DrawCall.TintColor * fragment.Tint;
+                    // Content can author out-of-range tints; the packed byte color can only represent [0, 1].
+                    instanceTint = Vector4.Clamp(fragment.RenderMesh.Tint * fragment.DrawCall.TintColor * fragment.Tint, Vector4.Zero, Vector4.One);
                 }
 
                 uint transformIndex;


### PR DESCRIPTION
In the debug build loading dl_streets (deadlock) crashes, because one of the compiled world-node models (n0_lr0_c0_s_cb_b_nomerge303.vmdl_c) has m_flAlpha = 8.627452.

That is 2200/255, so some artist probably typo-ed 220 alpha 🚬 

```<!-- kv3 encoding:text:version{e21c7f3c-8a33-41c5-9977-a76d3a32aa0d} format:generic:version{7412167c-06e9-4698-aff2-e63eb59037e7} -->
{
    _class = "CRenderMesh"
    m_sceneObjects = 
    [
        {
            m_vMinBounds = [ -13775.732422, -15.731947, 512.0 ]
            m_vMaxBounds = [ -13744.267578, 15.731947, 655.383667 ]
            m_drawCalls = 
            [
                {
                    m_flUvDensity = 69.8256
                    m_vTintColor = [ 1.0, 1.0, 1.0 ]
                    m_flAlpha = 8.627452
                    m_nNumMeshlets = 0
                    m_nFirstMeshlet = 0
                    m_nAppliedIndexOffset = 0
                    m_nDepthVertexBufferIndex = 255
                    m_nPrimitiveType = "RENDER_PRIM_TRIANGLES"
                    m_nBaseVertex = 0
                    m_nVertexCount = 387
                    m_nStartIndex = 0
                    m_nIndexCount = 1014
                    m_indexBuffer = 
                    {
                        m_hBuffer = 0
                        m_nBindOffsetBytes = 0
                    }
                    m_material = resource:"materials/abstract/abstract_painted_trim_prop.vmat"
                    m_vertexBuffers = 
                    [
                        {
                            m_hBuffer = 0
                            m_nBindOffsetBytes = 0
                        },
                    ]
                    m_bUseCompressedNormalTangent = true
                    m_bHasBakedLightingFromLightMap = true
                },
            ]
            m_drawBounds = [  ]
            m_meshlets = [  ]
            m_vTintColor = [ 0.0, 0.0, 0.0, 0.0 ]
        },
    ]
    m_constraints = [  ]
    m_skeleton = 
    {
        m_bones = [  ]
        m_boneParents = [  ]
        m_nBoneWeightCount = 4
    }
    m_bUseUV2ForCharting = false
    m_meshDeformParams = 
    {
        m_flTensionCompressScale = 0.0
        m_flTensionStretchScale = 0.0
        m_bRecomputeSmoothNormalsAfterAnimation = false
        m_bComputeDynamicMeshTensionAfterAnimation = false
        m_bSmoothNormalsAcrossUvSeams = false
    }
    m_pGroomData = null
    m_attachments = [  ]
    m_hitboxsets = [  ]
    m_morphSet = resource:""
}