### PR TITLE
Hide cursor while dragging the camera in GL viewers

### DIFF
--- a/GUI/NativeMethods.txt
+++ b/GUI/NativeMethods.txt
@@ -7,6 +7,7 @@ FindWindowEx
 DwmGetWindowAttribute
 DwmSetWindowAttribute
 GetComboBoxInfo
+GetMessageExtraInfo
 GetSystemMenu
 GetWindowThreadProcessId
 GetSystemMetricsForDpi

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 using GUI.Controls;
@@ -13,7 +14,7 @@ using ValveResourceFormat.Renderer.Input;
 
 namespace GUI.Types.GLViewers;
 
-internal abstract class GLBaseControl : IDisposable
+internal abstract partial class GLBaseControl : IDisposable
 {
     protected RendererControl? UiControl;
 
@@ -37,6 +38,8 @@ internal abstract class GLBaseControl : IDisposable
     private Point pendingMouseDelta;
     private int pendingMouseWheelDelta;
     private bool cursorHiddenForDrag;
+    private bool currentDragIsTouch;
+    private bool mouseLookNeedsRebase;
 
     public bool GrabbedMouse
     {
@@ -45,8 +48,14 @@ internal abstract class GLBaseControl : IDisposable
         {
             if (field != value)
             {
-                Action changeCursorVisibility = value ? Cursor.Hide : Cursor.Show;
-                GLControl?.BeginInvoke(changeCursorVisibility);
+                if (value)
+                {
+                    mouseLookNeedsRebase = true;
+                }
+                else
+                {
+                    GLControl?.BeginInvoke(RestoreCursorAfterDrag);
+                }
             }
 
             field = value;
@@ -255,6 +264,8 @@ internal abstract class GLBaseControl : IDisposable
     {
         CurrentlyPressedKeys = TrackedKeys.None;
         MouseDelta = Point.Empty;
+        currentDragIsTouch = false;
+        mouseLookNeedsRebase = true;
         GrabbedMouse = false;
         RestoreCursorAfterDrag();
     }
@@ -298,6 +309,13 @@ internal abstract class GLBaseControl : IDisposable
     public virtual void Dispose()
     {
         using var lockedGl = glLock.EnterScope();
+
+        // Restore the cursor if we're torn down mid-drag, otherwise the process-wide hide count leaks.
+        if (cursorHiddenForDrag)
+        {
+            cursorHiddenForDrag = false;
+            Cursor.Show();
+        }
 
         if (GLControl is not null)
         {
@@ -349,6 +367,8 @@ internal abstract class GLBaseControl : IDisposable
         InitialMousePosition = new Point(e.X, e.Y);
         MouseDelta = Point.Empty;
         MouseDragged = false;
+        currentDragIsTouch = IsTouchOrPenInput();
+        mouseLookNeedsRebase = true;
 
         if (GLControl != null)
         {
@@ -383,7 +403,13 @@ internal abstract class GLBaseControl : IDisposable
         {
             pendingMouseDelta = Point.Empty;
             MouseDelta = Point.Empty;
-            RestoreCursorAfterDrag();
+            currentDragIsTouch = false;
+            mouseLookNeedsRebase = true;
+
+            if (!GrabbedMouse)
+            {
+                RestoreCursorAfterDrag();
+            }
         }
     }
 
@@ -395,25 +421,21 @@ internal abstract class GLBaseControl : IDisposable
         }
 
         cursorHiddenForDrag = false;
-
-        if (GLControl != null)
-        {
-            // Put the cursor back where the drag started so it doesn't appear to jump.
-            Cursor.Position = GLControl.PointToScreen(InitialMousePosition);
-            GLControl.BeginInvoke(Cursor.Show);
-        }
+        Cursor.Position = MousePreviousPosition;
+        Cursor.Show();
     }
 
     protected virtual void OnMouseMove(object? sender, MouseEventArgs e)
     {
-        var dragging = (CurrentlyPressedKeys & TrackedKeys.MouseLeftOrRight) != 0;
-
-        if (!GrabbedMouse && !dragging)
+        if (GLControl == null)
         {
             return;
         }
 
-        if (GLControl == null)
+        var dragging = (CurrentlyPressedKeys & TrackedKeys.MouseLeftOrRight) != 0;
+        var touch = currentDragIsTouch || IsTouchOrPenInput();
+
+        if (!dragging && !(GrabbedMouse && !touch))
         {
             return;
         }
@@ -421,6 +443,13 @@ internal abstract class GLBaseControl : IDisposable
         using var _ = inputStateLock.EnterScope();
 
         var position = GLControl.PointToScreen(new Point(e.X, e.Y));
+
+        if (mouseLookNeedsRebase)
+        {
+            mouseLookNeedsRebase = false;
+            MousePreviousPosition = position;
+            return;
+        }
 
         var delta = new Point(
             position.X - MousePreviousPosition.X,
@@ -434,23 +463,33 @@ internal abstract class GLBaseControl : IDisposable
         {
             MouseDragged = true;
 
-            // Hide the cursor once dragging the camera starts so it isn't distracting and doesn't drift.
-            if (dragging && !GrabbedMouse && !cursorHiddenForDrag)
+            if (!cursorHiddenForDrag)
             {
                 cursorHiddenForDrag = true;
-                GLControl.BeginInvoke(Cursor.Hide);
+                Cursor.Hide();
             }
         }
 
-        // Keep the cursor pinned in place while looking around: centered in grabbed (noclip) mode,
-        // otherwise locked to where the drag started so it stays hidden and doesn't move.
-        var lockPoint = GrabbedMouse
-            ? GLControl.PointToScreen(new Point(GLControl.Width / 2, GLControl.Height / 2))
-            : GLControl.PointToScreen(InitialMousePosition);
+        // Touch and pen are absolute digitizers: warping the cursor doesn't move the contact point
+        if (touch)
+        {
+            MousePreviousPosition = position;
+            return;
+        }
 
-        MousePreviousPosition = lockPoint;
-        Cursor.Position = lockPoint;
+        // Relative mouse: pin the cursor so the look can continue past the screen edges
+        Cursor.Position = MousePreviousPosition;
     }
+
+    // Signature Windows stamps onto mouse messages synthesized from touch or pen input.
+    // See "Distinguishing Pen and Touch Input from Mouse Input" in the Windows docs.
+    private const long MouseEventFromTouchOrPen = 0xFF515700;
+
+    [LibraryImport("user32.dll")]
+    private static partial IntPtr GetMessageExtraInfo();
+
+    private static bool IsTouchOrPenInput()
+        => ((long)GetMessageExtraInfo() & 0xFFFFFF00) == MouseEventFromTouchOrPen;
 
     protected virtual void OnMouseWheel(object? sender, MouseEventArgs e)
     {

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Windows.Forms;
 using GUI.Controls;
@@ -11,10 +10,11 @@ using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using ValveResourceFormat.Renderer;
 using ValveResourceFormat.Renderer.Input;
+using Windows.Win32;
 
 namespace GUI.Types.GLViewers;
 
-internal abstract partial class GLBaseControl : IDisposable
+internal abstract class GLBaseControl : IDisposable
 {
     protected RendererControl? UiControl;
 
@@ -484,11 +484,8 @@ internal abstract partial class GLBaseControl : IDisposable
     // See "Distinguishing Pen and Touch Input from Mouse Input" in the Windows docs.
     private const long MouseEventFromTouchOrPen = 0xFF515700;
 
-    [LibraryImport("user32.dll")]
-    private static partial IntPtr GetMessageExtraInfo();
-
     private static bool IsTouchOrPenInput()
-        => ((long)GetMessageExtraInfo() & 0xFFFFFF00) == MouseEventFromTouchOrPen;
+        => ((long)(nint)PInvoke.GetMessageExtraInfo() & 0xFFFFFF00) == MouseEventFromTouchOrPen;
 
     protected virtual void OnMouseWheel(object? sender, MouseEventArgs e)
     {

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -310,7 +310,6 @@ internal abstract partial class GLBaseControl : IDisposable
     {
         using var lockedGl = glLock.EnterScope();
 
-        // Restore the cursor if we're torn down mid-drag, otherwise the process-wide hide count leaks.
         if (cursorHiddenForDrag)
         {
             cursorHiddenForDrag = false;

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -485,7 +485,7 @@ internal abstract class GLBaseControl : IDisposable
     private const long MouseEventFromTouchOrPen = 0xFF515700;
 
     private static bool IsTouchOrPenInput()
-        => ((long)(nint)PInvoke.GetMessageExtraInfo() & 0xFFFFFF00) == MouseEventFromTouchOrPen;
+        => ((nint)PInvoke.GetMessageExtraInfo() & 0xFFFFFF00) == MouseEventFromTouchOrPen;
 
     protected virtual void OnMouseWheel(object? sender, MouseEventArgs e)
     {

--- a/GUI/Types/GLViewers/GLBaseControl.cs
+++ b/GUI/Types/GLViewers/GLBaseControl.cs
@@ -30,9 +30,13 @@ internal abstract class GLBaseControl : IDisposable
     protected TrackedKeys CurrentlyPressedKeys;
     public Point LastMouseDelta { get; protected set; }
 
+    /// <summary>Whether the mouse has moved while a button was held since the last mouse down.</summary>
+    protected bool MouseDragged;
+
     private readonly Lock inputStateLock = new();
     private Point pendingMouseDelta;
     private int pendingMouseWheelDelta;
+    private bool cursorHiddenForDrag;
 
     public bool GrabbedMouse
     {
@@ -252,6 +256,7 @@ internal abstract class GLBaseControl : IDisposable
         CurrentlyPressedKeys = TrackedKeys.None;
         MouseDelta = Point.Empty;
         GrabbedMouse = false;
+        RestoreCursorAfterDrag();
     }
 
     private static TrackedKeys RemapKey(Keys key) => key switch
@@ -343,6 +348,7 @@ internal abstract class GLBaseControl : IDisposable
 
         InitialMousePosition = new Point(e.X, e.Y);
         MouseDelta = Point.Empty;
+        MouseDragged = false;
 
         if (GLControl != null)
         {
@@ -377,12 +383,32 @@ internal abstract class GLBaseControl : IDisposable
         {
             pendingMouseDelta = Point.Empty;
             MouseDelta = Point.Empty;
+            RestoreCursorAfterDrag();
+        }
+    }
+
+    private void RestoreCursorAfterDrag()
+    {
+        if (!cursorHiddenForDrag)
+        {
+            return;
+        }
+
+        cursorHiddenForDrag = false;
+
+        if (GLControl != null)
+        {
+            // Put the cursor back where the drag started so it doesn't appear to jump.
+            Cursor.Position = GLControl.PointToScreen(InitialMousePosition);
+            GLControl.BeginInvoke(Cursor.Show);
         }
     }
 
     protected virtual void OnMouseMove(object? sender, MouseEventArgs e)
     {
-        if (!GrabbedMouse && (CurrentlyPressedKeys & TrackedKeys.MouseLeftOrRight) == 0)
+        var dragging = (CurrentlyPressedKeys & TrackedKeys.MouseLeftOrRight) != 0;
+
+        if (!GrabbedMouse && !dragging)
         {
             return;
         }
@@ -395,66 +421,35 @@ internal abstract class GLBaseControl : IDisposable
         using var _ = inputStateLock.EnterScope();
 
         var position = GLControl.PointToScreen(new Point(e.X, e.Y));
-        var topLeft = GLControl.PointToScreen(Point.Empty);
-        var bottomRight = topLeft + GLControl.Size;
 
-        // Windows has a 1px edge on bottom and right of the screen where cursor can't reach
-        // (assuming that there is no secondary screen past these edges)
-        bottomRight.X -= 1;
-        bottomRight.Y -= 1;
-
-        var positionWrapped = position;
-
-        var delta = Point.Empty;
-
-        if (position.X <= topLeft.X)
-        {
-            delta.X--;
-            positionWrapped.X = bottomRight.X - 1;
-        }
-        else if (position.X >= bottomRight.X)
-        {
-            delta.X++;
-            positionWrapped.X = topLeft.X + 1;
-        }
-
-        if (position.Y <= topLeft.Y)
-        {
-            delta.Y--;
-            positionWrapped.Y = bottomRight.Y - 1;
-        }
-        else if (position.Y >= bottomRight.Y)
-        {
-            delta.Y++;
-            positionWrapped.Y = topLeft.Y + 1;
-        }
-
-        if (positionWrapped != position)
-        {
-            // When wrapping cursor, add only 1px delta movement above
-            pendingMouseDelta.X += delta.X;
-            pendingMouseDelta.Y += delta.Y;
-
-            MousePreviousPosition = positionWrapped;
-            Cursor.Position = positionWrapped;
-            return;
-        }
-
-        delta.X += position.X - MousePreviousPosition.X;
-        delta.Y += position.Y - MousePreviousPosition.Y;
+        var delta = new Point(
+            position.X - MousePreviousPosition.X,
+            position.Y - MousePreviousPosition.Y
+        );
 
         pendingMouseDelta.X += delta.X;
         pendingMouseDelta.Y += delta.Y;
 
-        MousePreviousPosition = position;
-
-        if (GrabbedMouse)
+        if (delta != Point.Empty)
         {
-            var centerPoint = new Point(GLControl.Width / 2, GLControl.Height / 2);
-            var screenCenter = GLControl.PointToScreen(centerPoint);
-            MousePreviousPosition = screenCenter;
-            Cursor.Position = screenCenter;
+            MouseDragged = true;
+
+            // Hide the cursor once dragging the camera starts so it isn't distracting and doesn't drift.
+            if (dragging && !GrabbedMouse && !cursorHiddenForDrag)
+            {
+                cursorHiddenForDrag = true;
+                GLControl.BeginInvoke(Cursor.Hide);
+            }
         }
+
+        // Keep the cursor pinned in place while looking around: centered in grabbed (noclip) mode,
+        // otherwise locked to where the drag started so it stays hidden and doesn't move.
+        var lockPoint = GrabbedMouse
+            ? GLControl.PointToScreen(new Point(GLControl.Width / 2, GLControl.Height / 2))
+            : GLControl.PointToScreen(InitialMousePosition);
+
+        MousePreviousPosition = lockPoint;
+        Cursor.Position = lockPoint;
     }
 
     protected virtual void OnMouseWheel(object? sender, MouseEventArgs e)

--- a/GUI/Types/GLViewers/GLSceneViewer.cs
+++ b/GUI/Types/GLViewers/GLSceneViewer.cs
@@ -253,9 +253,9 @@ namespace GUI.Types.GLViewers
                 return;
             }
 
-            if (InitialMousePosition == new Point(e.X, e.Y))
+            if (!MouseDragged)
             {
-                Picker?.RequestNextFrame(e.X, e.Y, PickingIntent.Select);
+                Picker?.RequestNextFrame(InitialMousePosition.X, InitialMousePosition.Y, PickingIntent.Select);
             }
         }
 


### PR DESCRIPTION
Hides the cursor while dragging in the viewers, so it doesn't drift around and wrap around the screen, which is distracting. It gets locked in place.

The behaviour in the PR is closer to how I (and most people) would expect the dragging to work, since most applications (like Hammer) implement it / behave like this.