### PR TITLE
boulder crash fix (#1225)

### DIFF
--- a/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Conversion.cs
@@ -71,4 +71,15 @@ public partial class GltfModelExporter
             tangents[i] = new Vector4(rotated, tangents[i].W);
         }
     }
+
+    private static void SanitizeNonFinite(Span<float> values)
+    {
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (!float.IsFinite(values[i]))
+            {
+                values[i] = 0f;
+            }
+        }
+    }
 }

--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -165,6 +165,7 @@ public partial class GltfModelExporter
                         case 1:
                             {
                                 var buffer = VBIB.GetScalarAttributeArray(vertexBuffer, attribute);
+                                SanitizeNonFinite(buffer);
                                 var bufferView = exportedModel.CreateBufferView(4 * buffer.Length, 0, BufferMode.ARRAY_BUFFER);
                                 new ScalarArray(bufferView.Content).Fill(buffer);
                                 var accessor = exportedModel.CreateAccessor();
@@ -607,6 +608,8 @@ public partial class GltfModelExporter
 
     private static Accessor CreateAccessor(ModelRoot exportedModel, Vector2[] vectors)
     {
+        SanitizeNonFinite(MemoryMarshal.Cast<Vector2, float>(vectors.AsSpan()));
+
         var bufferView = exportedModel.CreateBufferView(2 * sizeof(float) * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
         new Vector2Array(bufferView.Content).Fill(vectors);
 
@@ -618,6 +621,8 @@ public partial class GltfModelExporter
 
     private static Accessor CreateAccessor(ModelRoot exportedModel, Vector3[] vectors)
     {
+        SanitizeNonFinite(MemoryMarshal.Cast<Vector3, float>(vectors.AsSpan()));
+
         var bufferView = exportedModel.CreateBufferView(3 * sizeof(float) * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
         new Vector3Array(bufferView.Content).Fill(vectors);
 
@@ -629,6 +634,8 @@ public partial class GltfModelExporter
 
     private static Accessor CreateAccessor(ModelRoot exportedModel, Vector4[] vectors)
     {
+        SanitizeNonFinite(MemoryMarshal.Cast<Vector4, float>(vectors.AsSpan()));
+
         var bufferView = exportedModel.CreateBufferView(4 * sizeof(float) * vectors.Length, 0, BufferMode.ARRAY_BUFFER);
         new Vector4Array(bufferView.Content).Fill(vectors);
 
@@ -644,10 +651,10 @@ public partial class GltfModelExporter
         {
             var vec = vectorArray[i];
 
-            if (Math.Abs(new Vector3(vec.X, vec.Y, vec.Z).Length() - 1.0f) > UnitLengthThresholdVec3)
+            if (!(Math.Abs(new Vector3(vec.X, vec.Y, vec.Z).Length() - 1.0f) <= UnitLengthThresholdVec3))
             {
                 vectorArray[i] = -Vector4.UnitZ;
-                vectorArray[i].W = vec.W;
+                vectorArray[i].W = float.IsFinite(vec.W) ? vec.W : 1f;
             }
         }
     }
@@ -656,7 +663,7 @@ public partial class GltfModelExporter
     {
         for (var i = 0; i < vectorArray.Length; i++)
         {
-            if (Math.Abs(vectorArray[i].Length() - 1.0f) > UnitLengthThresholdVec3)
+            if (!(Math.Abs(vectorArray[i].Length() - 1.0f) <= UnitLengthThresholdVec3))
             {
                 vectorArray[i] = -Vector3.UnitZ;
             }

--- a/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
+++ b/ValveResourceFormat/IO/GltfModelExporter.Mesh.cs
@@ -651,10 +651,10 @@ public partial class GltfModelExporter
         {
             var vec = vectorArray[i];
 
-            if (!(Math.Abs(new Vector3(vec.X, vec.Y, vec.Z).Length() - 1.0f) <= UnitLengthThresholdVec3))
+            if (Math.Abs(new Vector3(vec.X, vec.Y, vec.Z).Length() - 1.0f) > UnitLengthThresholdVec3)
             {
                 vectorArray[i] = -Vector4.UnitZ;
-                vectorArray[i].W = float.IsFinite(vec.W) ? vec.W : 1f;
+                vectorArray[i].W = vec.W;
             }
         }
     }
@@ -663,7 +663,7 @@ public partial class GltfModelExporter
     {
         for (var i = 0; i < vectorArray.Length; i++)
         {
-            if (!(Math.Abs(vectorArray[i].Length() - 1.0f) <= UnitLengthThresholdVec3))
+            if (Math.Abs(vectorArray[i].Length() - 1.0f) > UnitLengthThresholdVec3)
             {
                 vectorArray[i] = -Vector3.UnitZ;
             }


### PR DESCRIPTION
Boulder has NaN/Inf floats in its baked worldnodes, specifically in TEXCOORD0 (UV mapping). Also inverted a few logical conditions so they hit when the float is NaN and can be sanitized. This sanitizes these floats. For boulder the change to sanitize Vector2 would be enough, but I made it generic for the float data in the Mesh GLTF export.