### PR TITLE
Fix local addons not being loaded as workshop dependencies

### DIFF
--- a/ValveResourceFormat/IO/GameFileLoader.cs
+++ b/ValveResourceFormat/IO/GameFileLoader.cs
@@ -54,7 +54,7 @@ namespace ValveResourceFormat.IO
         private bool ShaderPackagesScanned;
         private bool AttemptToLoadWorkshopDependencies;
         private bool StoredSurfacePropertyStringTokens;
-        private string SteamVRDir;
+        private string? SteamVRDir;
 
         /// <summary>
         /// Gets or sets the current package being processed.

--- a/ValveResourceFormat/IO/GameFileLoader.cs
+++ b/ValveResourceFormat/IO/GameFileLoader.cs
@@ -54,6 +54,7 @@ namespace ValveResourceFormat.IO
         private bool ShaderPackagesScanned;
         private bool AttemptToLoadWorkshopDependencies;
         private bool StoredSurfacePropertyStringTokens;
+        private string SteamVRDir;
 
         /// <summary>
         /// Gets or sets the current package being processed.
@@ -189,12 +190,19 @@ namespace ValveResourceFormat.IO
                         {
                             foreach (var (_, dependency) in dependencies)
                             {
-                                var dependencyId = (uint)dependency;
-                                var dependencyVpkPath = Path.Join(workshopRoot, $"{dependencyId}", $"{dependencyId}.vpk");
-
-                                if (File.Exists(dependencyVpkPath))
+                                if (dependency.ToString() == "steamvr_home")
                                 {
-                                    AddPackageToSearch(dependencyVpkPath);
+                                    var svrHome = Path.Join((SteamVRDir + "_addons"), $"steamvr_home", $"pak01_dir.vpk");
+                                    AddPackageToSearch(svrHome);
+                                }
+                                else
+                                {
+                                    var dependencyId = (uint)dependency;
+                                    var dependencyVpkPath = Path.Join(workshopRoot, $"{dependencyId}", $"{dependencyId}.vpk");
+                                    if (File.Exists(dependencyVpkPath))
+                                    {
+                                        AddPackageToSearch(dependencyVpkPath);
+                                    }
                                 }
                             }
                         }
@@ -791,6 +799,7 @@ namespace ValveResourceFormat.IO
             foreach (var gameInfo in gameInfos)
             {
                 var directory = Path.GetDirectoryName(gameInfo);
+                SteamVRDir = directory;
                 var modName = Path.GetFileName(directory);
                 var assumedGameRoot = Path.GetDirectoryName(directory)!;
 

--- a/ValveResourceFormat/IO/GameFileLoader.cs
+++ b/ValveResourceFormat/IO/GameFileLoader.cs
@@ -48,13 +48,13 @@ namespace ValveResourceFormat.IO
         private readonly Lock CachedShadersLock = new();
         private readonly HashSet<string> CurrentGameSearchPaths = [];
         private readonly HashSet<string> CurrentGameOfficialAddonsPaths = [];
+        private readonly HashSet<string> CurrentGameAddonsPaths = [];
         private readonly List<Package> CurrentGamePackages = [];
         private readonly string? CurrentFileName;
         private string? PreferredAddonFolderOnDisk;
         private bool ShaderPackagesScanned;
         private bool AttemptToLoadWorkshopDependencies;
         private bool StoredSurfacePropertyStringTokens;
-        private string? SteamVRDir;
 
         /// <summary>
         /// Gets or sets the current package being processed.
@@ -190,10 +190,11 @@ namespace ValveResourceFormat.IO
                         {
                             foreach (var (_, dependency) in dependencies)
                             {
-                                if (dependency.ToString() == "steamvr_home")
+                                uint addon = 0;
+                                bool workshopAddon = uint.TryParse((string?)dependency, out addon);
+                                if (workshopAddon == false)
                                 {
-                                    var svrHome = Path.Join((SteamVRDir + "_addons"), $"steamvr_home", $"pak01_dir.vpk");
-                                    AddPackageToSearch(svrHome);
+                                    FindAndLoadGameAddonPackage(dependency.ToString());
                                 }
                                 else
                                 {
@@ -440,6 +441,10 @@ namespace ValveResourceFormat.IO
                 else if (key == "OfficialAddonRoot")
                 {
                     CurrentGameOfficialAddonsPaths.Add(Path.Combine(gameRoot, searchPath.ToString()!));
+                }
+                else if (key == "AddonRoot")
+                {
+                    CurrentGameAddonsPaths.Add(Path.Combine(gameRoot, searchPath.ToString()!));
                 }
             }
         }
@@ -715,6 +720,43 @@ namespace ValveResourceFormat.IO
             }
         }
 
+        private void FindAndLoadGameAddonPackage(string fileName)
+        {
+            if (CurrentFileName == null || CurrentGameAddonsPaths.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var addonPath in CurrentGameAddonsPaths)
+            {
+                var addonFolder = Path.Combine(addonPath, fileName);
+                if (!Directory.Exists(addonFolder))
+                {
+                    continue;
+                }
+
+                for (var i = 1; i < 99; i++)
+                {
+                    var vpk = Path.Combine(addonFolder, $"pak{i:D2}_dir.vpk");
+
+                    if (!File.Exists(vpk))
+                    {
+                        break;
+                    }
+
+                    if (CurrentFileName == vpk)
+                    {
+#if DEBUG_FILE_LOAD
+                        Console.WriteLine($"VPK \"{vpk}\" is the same we just opened, skipping");
+#endif
+                        continue;
+                    }
+
+                    AddPackageToSearch(vpk);
+                }
+            }
+        }
+
         private HashSet<string> FindGameFoldersForWorkshopFile()
         {
             // If we're loading a file from steamapps/workshop folder, attempt to discover gameinfos and load vpks for the game
@@ -799,7 +841,6 @@ namespace ValveResourceFormat.IO
             foreach (var gameInfo in gameInfos)
             {
                 var directory = Path.GetDirectoryName(gameInfo);
-                SteamVRDir = directory;
                 var modName = Path.GetFileName(directory);
                 var assumedGameRoot = Path.GetDirectoryName(directory)!;
 

--- a/ValveResourceFormat/IO/GameFileLoader.cs
+++ b/ValveResourceFormat/IO/GameFileLoader.cs
@@ -192,7 +192,7 @@ namespace ValveResourceFormat.IO
                             {
                                 if (dependency.ValueType == KVValueType.String)
                                 {
-                                    FindAndLoadGameAddonPackage(dependency.ToString());
+                                    FindAndLoadGameAddonPackage(CurrentGameAddonsPaths, dependency.ToString());
                                 }
                                 else
                                 {
@@ -587,31 +587,7 @@ namespace ValveResourceFormat.IO
                 }
             }
 
-            foreach (var folder in folders)
-            {
-                // Scan for vpks in folder, same logic as in source engine
-                for (var i = 1; i < 99; i++)
-                {
-                    var vpk = Path.Combine(folder, $"pak{i:D2}_dir.vpk");
-
-                    if (!File.Exists(vpk))
-                    {
-                        break;
-                    }
-
-                    if (CurrentFileName == vpk)
-                    {
-#if DEBUG_FILE_LOAD
-                        Console.WriteLine($"VPK \"{vpk}\" is the same we just opened, skipping");
-#endif
-                        continue;
-                    }
-
-                    AddPackageToSearch(vpk);
-                }
-
-                AddDiskPathToSearch(folder);
-            }
+            FindAndLoadGameAddonPackage(folders, null);
         }
 
         private string? GetModIdentifierFile()
@@ -718,21 +694,23 @@ namespace ValveResourceFormat.IO
             }
         }
 
-        private void FindAndLoadGameAddonPackage(string fileName)
+        private void FindAndLoadGameAddonPackage(HashSet<string> folders, string? fileName = null)
         {
-            if (CurrentFileName == null || CurrentGameAddonsPaths.Count == 0)
+            foreach (var folder in folders)
             {
-                return;
-            }
+                string addonFolder;
 
-            foreach (var addonPath in CurrentGameAddonsPaths)
-            {
-                var addonFolder = Path.Combine(addonPath, fileName);
+                if (fileName == null)
+                    addonFolder = folder;
+                else
+                    addonFolder = Path.Combine(folder, fileName);
+
                 if (!Directory.Exists(addonFolder))
                 {
                     continue;
                 }
 
+                // Scan for vpks in folder, same logic as in source engine
                 for (var i = 1; i < 99; i++)
                 {
                     var vpk = Path.Combine(addonFolder, $"pak{i:D2}_dir.vpk");
@@ -752,6 +730,8 @@ namespace ValveResourceFormat.IO
 
                     AddPackageToSearch(vpk);
                 }
+
+                AddDiskPathToSearch(folder);
             }
         }
 

--- a/ValveResourceFormat/IO/GameFileLoader.cs
+++ b/ValveResourceFormat/IO/GameFileLoader.cs
@@ -190,9 +190,7 @@ namespace ValveResourceFormat.IO
                         {
                             foreach (var (_, dependency) in dependencies)
                             {
-                                uint addon = 0;
-                                bool workshopAddon = uint.TryParse((string?)dependency, out addon);
-                                if (workshopAddon == false)
+                                if (dependency.ValueType == KVValueType.String)
                                 {
                                     FindAndLoadGameAddonPackage(dependency.ToString());
                                 }


### PR DESCRIPTION
Previously when loading in the Summit Pavilion Remix maps from SteamVR Home, they'd fail to load their assets due to the first entry being for the included steamvr_home addon. The program would try and fail to find that in the external workshop folder which would also lead to not loading the other addon that is within the external workshop folder.
So I added a check for the steamvr_home string and direct it to load from the proper location.
I definitely feel like this is a dirty hack that could be cleaned and simplified but though I'd at least open this PR and see what else I could do to improve it.

Before the fix:
<img width="1696" height="898" alt="image" src="https://github.com/user-attachments/assets/a8b4361b-548d-4ca8-b3cc-5ea0d4904923" />

After the fix:
<img width="1696" height="898" alt="image" src="https://github.com/user-attachments/assets/f4e79abf-16ce-4546-936b-25c2751fceed" />
