### PR TITLE
Render particles referenced by models and allow parenting to bones

### DIFF
--- a/GUI/Types/GLViewers/GLModelViewer.cs
+++ b/GUI/Types/GLViewers/GLModelViewer.cs
@@ -26,6 +26,7 @@ namespace GUI.Types.GLViewers
         protected CheckBox? animationPlayPause;
         private CheckBox? rootMotionCheckBox;
         private CheckBox? showSkeletonCheckbox;
+        private CheckBox? showParticlesCheckbox;
         private ComboBox? hitboxComboBox;
         private Label? animationTimeLabel;
         private GLViewerSliderControl? animationTrackBar;
@@ -41,6 +42,7 @@ namespace GUI.Types.GLViewers
         protected AnimationController? animationController;
         protected SkeletonSceneNode? skeletonSceneNode;
         private HitboxSetSceneNode? hitboxSetSceneNode;
+        private List<ParticleSceneNode> modelParticleNodes = [];
         private CheckedListBox? physicsGroupsComboBox;
         private int animationComboBoxCurrentIndex = -1;
 
@@ -74,6 +76,7 @@ namespace GUI.Types.GLViewers
             physicsGroupsComboBox?.Dispose();
             rootMotionCheckBox?.Dispose();
             showSkeletonCheckbox?.Dispose();
+            showParticlesCheckbox?.Dispose();
             hitboxComboBox?.Dispose();
         }
 
@@ -213,6 +216,12 @@ namespace GUI.Types.GLViewers
                     Scene.Add(hitboxSetSceneNode, true);
                 }
 
+                modelParticleNodes = ParticleSceneNode.CreateModelParticles(Scene, model, modelSceneNode);
+                foreach (var particleNode in modelParticleNodes)
+                {
+                    Scene.Add(particleNode, true);
+                }
+
                 phys = model.GetEmbeddedPhys();
                 if (phys == null)
                 {
@@ -290,6 +299,21 @@ namespace GUI.Types.GLViewers
                     {
                         using var lockedGl = MakeCurrent();
                         skeletonSceneNode?.Enabled = isChecked;
+                    });
+                }
+
+                if (modelParticleNodes.Count > 0)
+                {
+                    using var _ = UiControl.BeginGroup("Model");
+
+                    showParticlesCheckbox = UiControl.AddCheckBox("Show particles", true, isChecked =>
+                    {
+                        using var lockedGl = MakeCurrent();
+
+                        foreach (var particleNode in modelParticleNodes)
+                        {
+                            particleNode.LayerEnabled = isChecked;
+                        }
                     });
                 }
 

--- a/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ModelSceneNode.cs
@@ -231,9 +231,10 @@ namespace ValveResourceFormat.Renderer.SceneNodes
         public override void Update(Scene.UpdateContext context)
         {
             UpdateAutoLod(context.Camera);
+            var animationUpdated = AnimationController.Update(context.Timestep);
             UpdateAttachments(context);
 
-            if (!AnimationController.Update(context.Timestep))
+            if (!animationUpdated)
             {
                 return;
             }
@@ -327,11 +328,35 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             }
         }
 
-        // The parent anchor for an attached child: the attachment point's world transform, or the model's
-        // own transform when no attachment is named. Rigid (no scale) because Source 2 does not propagate the
+        // The parent anchor for an attached child: the attachment point's world transform, the world
+        // transform of a bone with that name when no attachment matches, or the model's own transform when
+        // no name is given or it matches neither. Rigid (no scale) because Source 2 does not propagate the
         // parent's scale to attachment-parented children.
         private Matrix4x4 GetAttachmentOrSelfTransform(string attachmentName)
-            => GetRigidTransform(string.IsNullOrEmpty(attachmentName) ? Transform : GetAttachmentTransform(attachmentName));
+        {
+            if (!string.IsNullOrEmpty(attachmentName))
+            {
+                if (Attachments.ContainsKey(attachmentName))
+                {
+                    return GetRigidTransform(GetAttachmentTransform(attachmentName));
+                }
+
+                var boneIndex = AnimationController.Skeleton.GetBoneIndex(attachmentName);
+                if (boneIndex != -1)
+                {
+                    return GetRigidTransform(AnimationController.Pose[boneIndex] * Transform);
+                }
+            }
+
+            return GetRigidTransform(Transform);
+        }
+
+        /// <summary>
+        /// Whether the given name resolves to an anchor on this model: an attachment point,
+        /// or a bone when no attachment has that name.
+        /// </summary>
+        public bool HasAttachmentOrBone(string name)
+            => Attachments.ContainsKey(name) || AnimationController.Skeleton.GetBoneIndex(name) != -1;
 
         // Rotation and translation only, with scale removed.
         private static Matrix4x4 GetRigidTransform(Matrix4x4 transform)
@@ -562,6 +587,16 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             node.Parent = this;
             AttachedNodes.RemoveAll(entry => entry.Node == node);
             AttachedNodes.Add((node, attachmentName, offset, rotation));
+        }
+
+        /// <summary>
+        /// Places <paramref name="child"/> once at the named attachment point or bone (or the model's own
+        /// transform when no name is given), with <paramref name="offset"/> applied in that anchor's frame.
+        /// Unlike <c>AttachNode</c>, the child does not track the model afterwards. Works for any scene node.
+        /// </summary>
+        public void PlaceNode(SceneNode child, string attachmentName, Vector3 offset)
+        {
+            child.Transform = Matrix4x4.CreateTranslation(offset) * GetAttachmentOrSelfTransform(attachmentName);
         }
 
         /// <summary>

--- a/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/ParticleSceneNode.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using ValveKeyValue;
 using ValveResourceFormat.Blocks;
 using ValveResourceFormat.Renderer.Particles;
@@ -52,6 +53,102 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 {
                     Scene.Add(PreviewModel, true);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Creates particle nodes for the particle systems referenced by a model's keyvalues
+        /// (<c>particles_list</c>) and wires each one to the given model node according to the entry's
+        /// <c>attachment_type</c>. Follow types track the model or attachment point while it animates;
+        /// the other types are placed once at spawn. Entries with an unknown type are skipped.
+        /// </summary>
+        /// <param name="scene">The scene the nodes belong to.</param>
+        /// <param name="model">The model referencing the particle systems.</param>
+        /// <param name="modelNode">The model node providing the attachment points.</param>
+        /// <returns>The created particle nodes. The caller adds them to the scene.</returns>
+        public static List<ParticleSceneNode> CreateModelParticles(Scene scene, Model model, ModelSceneNode modelNode)
+        {
+            var particlesList = model.KeyValues.GetArray("particles_list");
+            if (particlesList == null)
+            {
+                return [];
+            }
+
+            var nodes = new List<ParticleSceneNode>(particlesList.Count);
+
+            foreach (var entry in particlesList)
+            {
+                var particleName = entry.GetStringProperty("name");
+                if (string.IsNullOrEmpty(particleName))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    if (scene.RendererContext.FileLoader.LoadFileCompiled(particleName)?.DataBlock is not ParticleSystem particleSystem)
+                    {
+                        continue;
+                    }
+
+                    var attachmentPoint = entry.GetStringProperty("attachment_point") ?? string.Empty;
+                    var attachmentTypeName = entry.GetStringProperty("attachment_type");
+                    // The keyvalue name is the enum member without the PATTACH_ prefix (e.g. point_follow).
+                    var attachmentType = Enum.TryParse<ParticleAttachment>("PATTACH_" + attachmentTypeName, ignoreCase: true, out var parsedType)
+                        ? parsedType
+                        : ParticleAttachment.PATTACH_INVALID;
+                    var offset = ReadDriverVector(entry, "attachment_offset");
+
+                    if (attachmentType == ParticleAttachment.PATTACH_INVALID)
+                    {
+                        scene.RendererContext.Logger.LogWarning("Unknown attachment type '{Type}' for model particle '{Particle}'", attachmentTypeName, particleName);
+                        continue;
+                    }
+
+                    var particleNode = new ParticleSceneNode(scene, particleSystem)
+                    {
+                        Name = particleName,
+                    };
+
+                    AttachOnModel(modelNode, particleNode, attachmentType, attachmentPoint, offset);
+                    nodes.Add(particleNode);
+                }
+                catch (Exception e)
+                {
+                    scene.RendererContext.Logger.LogError(e, "Failed to setup model particle '{Particle}'", particleName);
+                }
+            }
+
+            return nodes;
+        }
+
+        // Maps a ParticleAttachment_t kind onto the model's generic attach primitives (no placement math
+        // of its own): *_follow kinds track the model or a named attachment point, the rest are placed once,
+        // and kinds with no distinct viewer anchor (eyes/overhead/rootbone/center/...) fall back to the model origin.
+        private static void AttachOnModel(ModelSceneNode modelNode, SceneNode node, ParticleAttachment attachType, string attachmentName, Vector3 offset)
+        {
+            switch (attachType)
+            {
+                case ParticleAttachment.PATTACH_POINT_FOLLOW:
+                    modelNode.AttachNode(node, attachmentName, offset);
+                    break;
+
+                case ParticleAttachment.PATTACH_POINT:
+                    modelNode.PlaceNode(node, attachmentName, offset);
+                    break;
+
+                case ParticleAttachment.PATTACH_WORLDORIGIN:
+                    node.Transform = Matrix4x4.CreateTranslation(offset);
+                    break;
+
+                case ParticleAttachment.PATTACH_ABSORIGIN:
+                case ParticleAttachment.PATTACH_CUSTOMORIGIN:
+                    modelNode.PlaceNode(node, string.Empty, offset);
+                    break;
+
+                default:
+                    modelNode.AttachNode(node, string.Empty, offset);
+                    break;
             }
         }
 

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -232,9 +232,10 @@ namespace ValveResourceFormat.Renderer.World
 
         /// <summary>
         /// Parents entities with a <c>parentname</c> to that parent each frame — snapping onto the
-        /// <c>parentattachmentname</c> attachment when one is given, otherwise following the parent's
-        /// transform. <c>uselocaloffset</c> is ignored, as the engine does here too. Done after all
-        /// entities are loaded so the parent is registered regardless of spawn order.
+        /// <c>parentattachmentname</c> attachment (or the bone with that name when no attachment matches)
+        /// when one is given, otherwise following the parent's transform. <c>uselocaloffset</c> is ignored,
+        /// as the engine does here too. Done after all entities are loaded so the parent is registered
+        /// regardless of spawn order.
         /// </summary>
         private void ResolveAttachmentParenting()
         {
@@ -269,13 +270,13 @@ namespace ValveResourceFormat.Renderer.World
                     continue;
                 }
 
-                if (!parentNode.Attachments.ContainsKey(attachmentName))
+                if (!parentNode.HasAttachmentOrBone(attachmentName))
                 {
-                    RendererContext.Logger.LogWarning("Parent {ParentName} has no attachment {AttachmentName} to parent {NodeName} to", parentName, attachmentName, node.Name);
+                    RendererContext.Logger.LogWarning("Parent {ParentName} has no attachment or bone {AttachmentName} to parent {NodeName} to", parentName, attachmentName, node.Name);
                     continue;
                 }
 
-                // attachment parenting snaps the child onto the attachment point
+                // attachment parenting snaps the child onto the attachment point or bone
                 parentNode.AttachNode(node, attachmentName);
             }
         }
@@ -1168,8 +1169,21 @@ namespace ValveResourceFormat.Renderer.World
                         var groups = modelNode.GetMeshGroups();
                         modelNode.SetActiveMeshGroups(groups.Skip((int)body).Take(1));
                     }
+                }
 
+                // Model-referenced particles spawn regardless of meshes; a particle-only model is
+                // still added so its follow attachments get updated (the scene skips parented nodes).
+                var modelParticleNodes = ParticleSceneNode.CreateModelParticles(scene, newModel, modelNode);
+
+                if (modelNode.HasMeshes || modelParticleNodes.Count > 0)
+                {
                     scene.Add(modelNode, true);
+
+                    foreach (var modelParticleNode in modelParticleNodes)
+                    {
+                        modelParticleNode.LayerName = "Particles";
+                        scene.Add(modelParticleNode, true);
+                    }
                 }
 
                 var phys = newModel?.GetEmbeddedPhys();
@@ -1197,9 +1211,9 @@ namespace ValveResourceFormat.Renderer.World
                         scene.Add(physSceneNode, true);
                     }
                 }
-                else if (!modelNode.HasMeshes)
+                else if (!modelNode.HasMeshes && modelParticleNodes.Count == 0)
                 {
-                    // If the loaded model has no meshes and has no physics, fallback to default entity
+                    // If the loaded model has no meshes, particles, or physics, fallback to default entity
                     CreateDefaultEntity(entity, classname, transformationMatrix, layerName: toolEntityLayer);
                 }
             }

--- a/Renderer/Renderer/World/WorldNodeLoader.cs
+++ b/Renderer/Renderer/World/WorldNodeLoader.cs
@@ -106,12 +106,6 @@ namespace ValveResourceFormat.Renderer.World
                     };
 
                     scene.Add(modelNode, false);
-
-                    foreach (var modelParticleNode in ParticleSceneNode.CreateModelParticles(scene, model, modelNode))
-                    {
-                        modelParticleNode.LayerName = "Particles";
-                        scene.Add(modelParticleNode, true);
-                    }
                 }
 
                 var renderable = sceneObject.GetStringProperty("m_renderable");

--- a/Renderer/Renderer/World/WorldNodeLoader.cs
+++ b/Renderer/Renderer/World/WorldNodeLoader.cs
@@ -106,6 +106,12 @@ namespace ValveResourceFormat.Renderer.World
                     };
 
                     scene.Add(modelNode, false);
+
+                    foreach (var modelParticleNode in ParticleSceneNode.CreateModelParticles(scene, model, modelNode))
+                    {
+                        modelParticleNode.LayerName = "Particles";
+                        scene.Add(modelParticleNode, true);
+                    }
                 }
 
                 var renderable = sceneObject.GetStringProperty("m_renderable");


### PR DESCRIPTION
Implements #257

Renders the particle systems listed in a model's `particles_list`.

Also fixes the entity `parentname` path so it now falls back to a bone when no attachment of that name exists.

Implements only the 4 particle attachment types actually used by any shipped particles.

See e.g.
HLA -> `models/creatures/combine_dropship/dropship.vmdl_c`
Deadlock -> `models/abilities/familiar/familiar_helpinghands_aura_statue.vmdl_c` and `models/npc/shrine_sapphire/shrine_sapphire.vmdl_c`