### PR TITLE
Fix static overlay color correction, mod2x blending

### DIFF
--- a/Renderer/Renderer/Materials/RenderMaterial.cs
+++ b/Renderer/Renderer/Materials/RenderMaterial.cs
@@ -364,6 +364,10 @@ namespace ValveResourceFormat.Renderer.Materials
             {
                 EvalCsgoEnvironmentColorMatrices(shader);
             }
+            else if (Material.ShaderName.EndsWith("static_overlay.vfx", StringComparison.Ordinal))
+            {
+                EvalStaticOverlayColorAdjust(shader);
+            }
 
             SetRenderState();
         }
@@ -443,6 +447,32 @@ namespace ValveResourceFormat.Renderer.Materials
             }
         }
 
+        private void EvalStaticOverlayColorAdjust(Shader shader)
+        {
+            if (!shader.Default.Matrices.ContainsKey("g_mTextureColorAdjust"))
+            {
+                return;
+            }
+
+            var csb = new Vector3(
+                Material.FloatParams.GetValueOrDefault("g_fTextureColorContrast", 1f),
+                Material.FloatParams.GetValueOrDefault("g_fTextureColorSaturation", 1f),
+                Material.FloatParams.GetValueOrDefault("g_fTextureColorBrightness", 1f));
+
+            var tint = Material.VectorParams.GetValueOrDefault("g_vTextureColorCorrectionTint", Vector4.One);
+
+            var textureAverageColor = Vector3.One;
+            if (Textures.TryGetValue("g_tColor", out var colorTexture))
+            {
+                textureAverageColor = colorTexture.Reflectivity.AsVector3();
+            }
+
+            var ccMatrix = VfxEvalFunctions.MatrixColorCorrect2(csb, textureAverageColor);
+            var tintMatrix = VfxEvalFunctions.MatrixColorTint2(tint.AsVector3(), 1f);
+
+            shader.SetUniform4x4("g_mTextureColorAdjust", Matrix4x4.Multiply(tintMatrix, ccMatrix));
+        }
+
         /// <summary>Restores render state and unbinds textures after the draw call for this material has completed.</summary>
         public void PostRender()
         {
@@ -477,17 +507,23 @@ namespace ValveResourceFormat.Renderer.Materials
                     GL.Enable(EnableCap.Blend);
                 }
 
-                if (blendMode >= BlendMode.Mod2x)
+                switch (blendMode)
                 {
-                    GL.BlendFunc(BlendingFactor.DstColor, BlendingFactor.SrcColor);
-                }
-                else if (blendMode >= BlendMode.Additive)
-                {
-                    GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.One);
-                }
-                else
-                {
-                    GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+                    case BlendMode.Additive:
+                        GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.One);
+                        break;
+                    case BlendMode.Multiply:
+                        GL.BlendFunc(BlendingFactor.Zero, BlendingFactor.SrcColor);
+                        break;
+                    case BlendMode.Mod2x:
+                        GL.BlendFunc(BlendingFactor.DstColor, BlendingFactor.SrcColor);
+                        break;
+                    case BlendMode.ModThenAdd:
+                        GL.BlendFunc(BlendingFactor.DstColor, BlendingFactor.OneMinusSrcAlpha);
+                        break;
+                    default:
+                        GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+                        break;
                 }
             }
 

--- a/Renderer/Shaders/complex.frag.slang
+++ b/Renderer/Shaders/complex.frag.slang
@@ -183,6 +183,10 @@ uniform sampler2D g_tTintMask;
     uniform float g_flOpacityScale = 1.0;
 #endif
 
+#if defined(static_overlay_vfx_common)
+    uniform mat4 g_mTextureColorAdjust; // evaluated on the CPU from g_fTextureColor* params
+#endif
+
 #if (selfillum)
     #if (GameVfx_vr_skin == 0) // Shaders that pack the mask into another texture
         uniform sampler2D g_tSelfIllumMask;
@@ -360,6 +364,10 @@ MaterialProperties_t GetMaterial(vec2 texCoord, vec3 vertexNormals)
 #else
     vec4 color = texture(g_tColor, texCoord);
     vec4 normalTexture = texture(g_tNormal, texCoord);
+
+#if defined(static_overlay_vfx_common)
+    color.rgb = (vec4(color.rgb, 1.0) * g_mTextureColorAdjust).rgb;
+#endif
 
     // Blending
 #if defined(terrain_blend_common)
@@ -745,13 +753,12 @@ void main()
         outputColor.rgb = SrgbGammaToLinear(outputColor.rgb);
     }
 
-#if (blendMod2x || blendModThenAdd)
-    vec3 gammaOutput = SrgbLinearToGamma(outputColor.rgb);
-    #if (blendMod2x)
-        outputColor = vec4(mix(vec3(0.5), gammaOutput, vec3(outputColor.a)), outputColor.a);
-    #elif (blendModThenAdd)
-        outputColor = vec4(mix(vec3(0), outputColor.rgb, vec3(0.5)), outputColor.a);
-    #endif
+#if (GameVfx_csgo_decalmodulate != 0)
+    outputColor = vec4(mix(vec3(0.5), SrgbLinearToGamma(outputColor.rgb), vec3(outputColor.a)), outputColor.a);
+#elif (blendMod2x)
+    outputColor.rgb = mix(vec3(0.5), outputColor.rgb, vec3(outputColor.a));
+#elif (blendModThenAdd)
+    outputColor.rgb = mix(vec3(0.0), outputColor.rgb, vec3(outputColor.a));
 #endif
 
     if (HandleMaterialRenderModes(outputColor, mat)

--- a/Renderer/Shaders/complex.vert.slang
+++ b/Renderer/Shaders/complex.vert.slang
@@ -345,7 +345,12 @@ void main()
     vVertexColorOut = GetTintColorLinear(object.vTint);
 
 #if !defined(vFoliageParams) && ((F_VERTEX_COLOR == 1) || (F_PAINT_VERTEX_COLORS == 1))
-    vVertexColorOut *= SrgbGammaToLinear(vCOLOR);
+    #if (GameVfx_csgo_static_overlay != 0) || (GameVfx_vr_static_overlay != 0)
+        // Paint is multiplied without sRGB decode, and all-zero paint means unpainted
+        vVertexColorOut *= mix(vec4(1.0), vCOLOR, sign(dot(vCOLOR, vec4(1.0))));
+    #else
+        vVertexColorOut *= SrgbGammaToLinear(vCOLOR);
+    #endif
 #endif
 
 #if (F_SECONDARY_UV == 1) || (F_FORCE_UV2 == 1)


### PR DESCRIPTION
Fixes static overlay shading for some static overlays (only a few over all maps)

<img width="2560" height="1440" alt="staticoverlay" src="https://github.com/user-attachments/assets/50851adc-f791-4626-9f3c-bb5a71f7b717" />
<img width="2560" height="1440" alt="staticoverlay2" src="https://github.com/user-attachments/assets/441fd930-2918-4140-b1b1-17da5773b5d9" />
