### PR TITLE
Show bone axes

### DIFF
--- a/Renderer/Renderer/LineBuffer.cs
+++ b/Renderer/Renderer/LineBuffer.cs
@@ -1,0 +1,73 @@
+using System.Runtime.InteropServices;
+using OpenTK.Graphics.OpenGL;
+using ValveResourceFormat.Renderer.SceneNodes;
+
+namespace ValveResourceFormat.Renderer
+{
+    /// <summary>
+    /// Vertex array/buffer pair for drawing a colored line list with the default shader.
+    /// </summary>
+    public class LineBuffer
+    {
+        /// <summary>The default shader the vertex layout is bound to.</summary>
+        public Shader Shader { get; }
+
+        /// <summary>Number of vertices currently uploaded.</summary>
+        public int VertexCount { get; private set; }
+
+        private readonly int vaoHandle;
+        private readonly int vboHandle;
+
+        /// <summary>Creates the GL objects and binds the default shader layout.</summary>
+        public LineBuffer(RendererContext rendererContext, string label)
+        {
+            Shader = rendererContext.ShaderLoader.LoadShader("vrf.default");
+
+            GL.CreateVertexArrays(1, out vaoHandle);
+            GL.CreateBuffers(1, out vboHandle);
+            GL.VertexArrayVertexBuffer(vaoHandle, 0, vboHandle, 0, SimpleVertex.SizeInBytes);
+            SimpleVertex.BindDefaultShaderLayout(vaoHandle, Shader.Program);
+
+#if DEBUG
+            GL.ObjectLabel(ObjectLabelIdentifier.VertexArray, vaoHandle, label.Length, label);
+            GL.ObjectLabel(ObjectLabelIdentifier.Buffer, vboHandle, label.Length, label);
+#endif
+        }
+
+        /// <summary>Uploads the line vertices, two per segment.</summary>
+        public void Upload(List<SimpleVertex> vertices, BufferUsageHint usageHint = BufferUsageHint.DynamicDraw)
+            => Upload(CollectionsMarshal.AsSpan(vertices), usageHint);
+
+        /// <summary>Uploads the line vertices, two per segment.</summary>
+        public unsafe void Upload(ReadOnlySpan<SimpleVertex> vertices, BufferUsageHint usageHint = BufferUsageHint.DynamicDraw)
+        {
+            VertexCount = vertices.Length;
+
+            fixed (SimpleVertex* data = vertices)
+            {
+                GL.NamedBufferData(vboHandle, VertexCount * SimpleVertex.SizeInBytes, (nint)data, usageHint);
+            }
+        }
+
+        /// <summary>Drops the uploaded vertices.</summary>
+        public void Clear()
+        {
+            VertexCount = 0;
+        }
+
+        /// <summary>Draws the lines, with the object id as instancing base for picking.</summary>
+        public void Draw(uint objectId = 0)
+        {
+            GL.BindVertexArray(vaoHandle);
+            GL.DrawArraysInstancedBaseInstance(PrimitiveType.Lines, 0, VertexCount, 1, objectId);
+            GL.BindVertexArray(0);
+        }
+
+        /// <summary>Deletes the GL objects.</summary>
+        public void Delete()
+        {
+            GL.DeleteBuffer(vboHandle);
+            GL.DeleteVertexArray(vaoHandle);
+        }
+    }
+}

--- a/Renderer/Renderer/LineDebugRenderer.cs
+++ b/Renderer/Renderer/LineDebugRenderer.cs
@@ -1,0 +1,61 @@
+using OpenTK.Graphics.OpenGL;
+
+namespace ValveResourceFormat.Renderer
+{
+    /// <summary>
+    /// Base class for debug overlays that draw a line batch blended and without depth writes.
+    /// </summary>
+    public abstract class LineDebugRenderer
+    {
+        private readonly LineBuffer lineBuffer;
+
+        /// <summary>Creates the GPU line buffer.</summary>
+        protected LineDebugRenderer(RendererContext rendererContext, string label)
+        {
+            lineBuffer = new LineBuffer(rendererContext, label);
+        }
+
+        /// <summary>Drops the uploaded vertices.</summary>
+        protected void Clear() => lineBuffer.Clear();
+
+        /// <summary>Uploads the line vertices, two per segment.</summary>
+        protected void Upload(List<SimpleVertex> vertices, BufferUsageHint usageHint = BufferUsageHint.DynamicDraw)
+            => lineBuffer.Upload(vertices, usageHint);
+
+        /// <summary>Draws the uploaded lines, on top of everything when depth test is disabled.</summary>
+        protected void RenderLines(bool disableDepthTest = false)
+        {
+            if (lineBuffer.VertexCount == 0)
+            {
+                return;
+            }
+
+            GL.Enable(EnableCap.Blend);
+
+            if (disableDepthTest)
+            {
+                GL.Disable(EnableCap.DepthTest);
+            }
+
+            GL.DepthMask(false);
+            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
+
+            lineBuffer.Shader.Use();
+            lineBuffer.Shader.SetUniform3x4("transform", Matrix4x4.Identity);
+
+            lineBuffer.Draw();
+            GL.UseProgram(0);
+
+            GL.DepthMask(true);
+            GL.Disable(EnableCap.Blend);
+
+            if (disableDepthTest)
+            {
+                GL.Enable(EnableCap.DepthTest);
+            }
+        }
+
+        /// <summary>Deletes the GL objects.</summary>
+        public void Delete() => lineBuffer.Delete();
+    }
+}

--- a/Renderer/Renderer/OctreeDebugRenderer.cs
+++ b/Renderer/Renderer/OctreeDebugRenderer.cs
@@ -6,36 +6,20 @@ namespace ValveResourceFormat.Renderer
     /// <summary>
     /// Debug visualization renderer for octree spatial partitioning structure.
     /// </summary>
-    public class OctreeDebugRenderer
+    public class OctreeDebugRenderer : LineDebugRenderer
     {
-        private readonly Shader shader;
         private readonly Octree octree;
-        private readonly int vaoHandle;
-        private readonly int vboHandle;
         private readonly bool dynamic;
-        private int vertexCount;
 
         /// <summary>Initializes the octree debug renderer and creates GPU resources.</summary>
         /// <param name="octree">The octree to visualize.</param>
         /// <param name="rendererContext">Renderer context for loading shaders.</param>
         /// <param name="dynamic">When <see langword="true"/>, the vertex buffer is rebuilt every frame.</param>
         public OctreeDebugRenderer(Octree octree, RendererContext rendererContext, bool dynamic)
+            : base(rendererContext, nameof(OctreeDebugRenderer))
         {
             this.octree = octree;
             this.dynamic = dynamic;
-
-            shader = rendererContext.ShaderLoader.LoadShader("vrf.default");
-
-            GL.CreateVertexArrays(1, out vaoHandle);
-            GL.CreateBuffers(1, out vboHandle);
-            GL.VertexArrayVertexBuffer(vaoHandle, 0, vboHandle, 0, SimpleVertex.SizeInBytes);
-            SimpleVertex.BindDefaultShaderLayout(vaoHandle, shader.Program);
-
-#if DEBUG
-            var vaoLabel = nameof(OctreeDebugRenderer);
-            GL.ObjectLabel(ObjectLabelIdentifier.VertexArray, vaoHandle, vaoLabel.Length, vaoLabel);
-            GL.ObjectLabel(ObjectLabelIdentifier.Buffer, vboHandle, vaoLabel.Length, vaoLabel);
-#endif
         }
 
         private static void AddOctreeNode(List<SimpleVertex> vertices, Octree.Node node, int depth)
@@ -74,9 +58,8 @@ namespace ValveResourceFormat.Renderer
         {
             var vertices = new List<SimpleVertex>();
             AddOctreeNode(vertices, octree.Root, 0);
-            vertexCount = vertices.Count;
 
-            GL.NamedBufferData(vboHandle, vertexCount * SimpleVertex.SizeInBytes, ListAccessors<SimpleVertex>.GetBackingArray(vertices), dynamic ? BufferUsageHint.DynamicDraw : BufferUsageHint.StaticDraw);
+            Upload(vertices, dynamic ? BufferUsageHint.DynamicDraw : BufferUsageHint.StaticDraw);
         }
 
         /// <summary>Renders the octree visualization for the current frame, rebuilding geometry if dynamic.</summary>
@@ -87,27 +70,7 @@ namespace ValveResourceFormat.Renderer
                 Rebuild();
             }
 
-            GL.Enable(EnableCap.Blend);
-            GL.DepthMask(false);
-            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-
-            shader.Use();
-            shader.SetUniform3x4("transform", Matrix4x4.Identity);
-
-            GL.BindVertexArray(vaoHandle);
-            GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);
-            GL.UseProgram(0);
-            GL.BindVertexArray(0);
-            GL.DepthMask(true);
-            GL.Disable(EnableCap.Blend);
-        }
-
-
-        /// <summary>Deletes the GPU vertex and vertex array objects.</summary>
-        public void Delete()
-        {
-            GL.DeleteBuffer(vboHandle);
-            GL.DeleteVertexArray(vaoHandle);
+            RenderLines();
         }
     }
 }

--- a/Renderer/Renderer/SceneNodes/LineSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/LineSceneNode.cs
@@ -1,5 +1,4 @@
 using OpenTK.Graphics.OpenGL;
-using PrimitiveType = OpenTK.Graphics.OpenGL.PrimitiveType;
 
 namespace ValveResourceFormat.Renderer.SceneNodes
 {
@@ -8,9 +7,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
     /// </summary>
     public class LineSceneNode : SceneNode
     {
-        readonly Shader shader;
-        readonly int vaoHandle;
-        readonly int vertexCount;
+        readonly LineBuffer lineBuffer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LineSceneNode"/> class rendering a single line segment.
@@ -33,8 +30,6 @@ namespace ValveResourceFormat.Renderer.SceneNodes
         public LineSceneNode(Scene scene, SimpleVertex[] vertices)
             : base(scene)
         {
-            vertexCount = vertices.Length;
-
             var boundsMin = vertices.Length > 0 ? vertices[0].Position : Vector3.Zero;
             var boundsMax = boundsMin;
             foreach (var vertex in vertices)
@@ -45,20 +40,14 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
             LocalBoundingBox = new AABB(boundsMin, boundsMax);
 
-            shader = Scene.RendererContext.ShaderLoader.LoadShader("vrf.default");
+            lineBuffer = new LineBuffer(Scene.RendererContext, nameof(LineSceneNode));
+            lineBuffer.Upload(vertices, BufferUsageHint.StaticDraw);
+        }
 
-            GL.CreateVertexArrays(1, out vaoHandle);
-            GL.CreateBuffers(1, out int vboHandle);
-            GL.VertexArrayVertexBuffer(vaoHandle, 0, vboHandle, 0, SimpleVertex.SizeInBytes);
-            SimpleVertex.BindDefaultShaderLayout(vaoHandle, shader.Program);
-
-            GL.NamedBufferData(vboHandle, vertexCount * SimpleVertex.SizeInBytes, vertices, BufferUsageHint.StaticDraw);
-
-#if DEBUG
-            var vaoLabel = nameof(LineSceneNode);
-            GL.ObjectLabel(ObjectLabelIdentifier.VertexArray, vaoHandle, vaoLabel.Length, vaoLabel);
-            GL.ObjectLabel(ObjectLabelIdentifier.Buffer, vboHandle, vaoLabel.Length, vaoLabel);
-#endif
+        /// <inheritdoc/>
+        public override void Delete()
+        {
+            lineBuffer.Delete();
         }
 
         /// <inheritdoc/>
@@ -69,16 +58,14 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            var renderShader = context.ReplacementShader ?? shader;
+            var renderShader = context.ReplacementShader ?? lineBuffer.Shader;
             renderShader.Use();
             renderShader.SetUniform3x4("transform", Transform);
             renderShader.SetBoneAnimationData(false);
 
-            GL.BindVertexArray(vaoHandle);
-            GL.DrawArraysInstancedBaseInstance(PrimitiveType.Lines, 0, vertexCount, 1, Id);
+            lineBuffer.Draw(Id);
 
             GL.UseProgram(0);
-            GL.BindVertexArray(0);
         }
     }
 }

--- a/Renderer/Renderer/SceneNodes/SkeletonSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/SkeletonSceneNode.cs
@@ -1,6 +1,5 @@
 using OpenTK.Graphics.OpenGL;
 using ValveResourceFormat.ResourceTypes.ModelAnimation;
-using PrimitiveType = OpenTK.Graphics.OpenGL.PrimitiveType;
 
 namespace ValveResourceFormat.Renderer.SceneNodes
 {
@@ -14,10 +13,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
 
         readonly AnimationController animationController;
         readonly Skeleton skeleton;
-        readonly Shader shader;
-        readonly int vaoHandle;
-        readonly int vboHandle;
-        int vertexCount;
+        readonly LineBuffer lineBuffer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SkeletonSceneNode"/> class.
@@ -31,18 +27,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             this.animationController = animationController;
             this.skeleton = skeleton;
 
-            shader = Scene.RendererContext.ShaderLoader.LoadShader("vrf.default");
-
-            GL.CreateVertexArrays(1, out vaoHandle);
-            GL.CreateBuffers(1, out vboHandle);
-            GL.VertexArrayVertexBuffer(vaoHandle, 0, vboHandle, 0, SimpleVertex.SizeInBytes);
-            SimpleVertex.BindDefaultShaderLayout(vaoHandle, shader.Program);
-
-#if DEBUG
-            var vaoLabel = nameof(SkeletonSceneNode);
-            GL.ObjectLabel(ObjectLabelIdentifier.VertexArray, vaoHandle, vaoLabel.Length, vaoLabel);
-            GL.ObjectLabel(ObjectLabelIdentifier.Buffer, vboHandle, vaoLabel.Length, vaoLabel);
-#endif
+            lineBuffer = new LineBuffer(Scene.RendererContext, nameof(SkeletonSceneNode));
         }
 
         /// <inheritdoc/>
@@ -78,9 +63,14 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             }
 
             LocalBoundingBox = bounds;
-            vertexCount = vertices.Count;
 
-            GL.NamedBufferData(vboHandle, vertices.Count * SimpleVertex.SizeInBytes, ListAccessors<SimpleVertex>.GetBackingArray(vertices), BufferUsageHint.DynamicDraw);
+            lineBuffer.Upload(vertices);
+        }
+
+        /// <inheritdoc/>
+        public override void Delete()
+        {
+            lineBuffer.Delete();
         }
 
         private void DrawSkeletonRecursive(Bone bone, List<SimpleVertex> vertices, Camera camera, TextRenderer textRenderer, AnimationController animation)
@@ -126,7 +116,7 @@ namespace ValveResourceFormat.Renderer.SceneNodes
                 return;
             }
 
-            var renderShader = context.ReplacementShader ?? shader;
+            var renderShader = context.ReplacementShader ?? lineBuffer.Shader;
 
             GL.DepthFunc(DepthFunction.Always);
 
@@ -134,11 +124,9 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             renderShader.SetUniform3x4("transform", Transform);
             renderShader.SetBoneAnimationData(false);
 
-            GL.BindVertexArray(vaoHandle);
-            GL.DrawArraysInstancedBaseInstance(PrimitiveType.Lines, 0, vertexCount, 1, Id);
+            lineBuffer.Draw(Id);
 
             GL.UseProgram(0);
-            GL.BindVertexArray(0);
             GL.DepthFunc(DepthFunction.Greater);
         }
     }

--- a/Renderer/Renderer/SceneNodes/SkeletonSceneNode.cs
+++ b/Renderer/Renderer/SceneNodes/SkeletonSceneNode.cs
@@ -77,14 +77,24 @@ namespace ValveResourceFormat.Renderer.SceneNodes
         {
             var boneMatrix = animation.Pose[bone.Index];
 
+            // todo: bounding box should be from current frame vertices
+            var sizeCap = LocalBoundingBox.Size.Length();
+            if (sizeCap < 1f)
+            {
+                sizeCap = 100f;
+            }
+
+            var distance = Vector3.Distance(camera.Location, Vector3.Transform(boneMatrix.Translation, Transform));
+            var distanceFade = distance > sizeCap ? sizeCap / distance : 1f;
+
             textRenderer.AddTextBillboard(Vector3.Transform(boneMatrix.Translation, Transform), new TextRenderer.TextRenderRequest
             {
-                Scale = 10f,
+                Scale = 10f * distanceFade,
                 Text = bone.Name,
                 Color = (bone.Parent, bone.Children.Count) switch
                 {
                     (null, _) => new Color32(1.0f, 0.8f, 0.8f, 1.0f),
-                    (_, 0) => new Color32(0.3f, 0.8f, 0.3f, 1.0f),
+                    (_, 0) => new Color32(0.8f, 1.0f, 0.8f, 1.0f),
                     _ => Color32.White,
                 },
             }, camera);
@@ -93,9 +103,17 @@ namespace ValveResourceFormat.Renderer.SceneNodes
             {
                 var parentMatrix = animation.Pose[bone.Parent.Index];
 
-                var fade = Random.Shared.NextSingle() * 0.5f + 0.5f;
-                ShapeSceneNode.AddLine(vertices, boneMatrix.Translation, parentMatrix.Translation, new(1f - fade, 1f, fade, 1f));
+                ShapeSceneNode.AddLine(vertices, boneMatrix.Translation, parentMatrix.Translation, Color32.White);
             }
+
+            // Bone space axes, normalized to strip any scale from the pose.
+            // Sized proportionally to camera distance so they stay constant on screen.
+            var origin = boneMatrix.Translation;
+            var axisLength = 0.04f * MathF.Min(distance, sizeCap);
+
+            ShapeSceneNode.AddLine(vertices, origin, origin + Vector3.Normalize(new Vector3(boneMatrix.M11, boneMatrix.M12, boneMatrix.M13)) * axisLength, new(1.0f, 0.2f, 0.2f, 1.0f));
+            ShapeSceneNode.AddLine(vertices, origin, origin + Vector3.Normalize(new Vector3(boneMatrix.M21, boneMatrix.M22, boneMatrix.M23)) * axisLength, new(0.2f, 0.8f, 0.2f, 1.0f));
+            ShapeSceneNode.AddLine(vertices, origin, origin + Vector3.Normalize(new Vector3(boneMatrix.M31, boneMatrix.M32, boneMatrix.M33)) * axisLength, new(0.2f, 0.2f, 1.0f, 1.0f));
 
             foreach (var child in bone.Children)
             {

--- a/Renderer/Renderer/SelectedNodeRenderer.cs
+++ b/Renderer/Renderer/SelectedNodeRenderer.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Linq;
-using OpenTK.Graphics.OpenGL;
 using ValveResourceFormat.Renderer.SceneEnvironment;
 using ValveResourceFormat.Renderer.SceneNodes;
 using ValveResourceFormat.Renderer.World;
@@ -11,12 +10,8 @@ namespace ValveResourceFormat.Renderer
     /// <summary>
     /// Renders selection outlines and debug information for selected scene nodes.
     /// </summary>
-    public class SelectedNodeRenderer
+    public class SelectedNodeRenderer : LineDebugRenderer
     {
-        private readonly Shader shader;
-        private readonly int vaoHandle;
-        private readonly int vboHandle;
-        private int vertexCount;
         private bool disableDepth;
         private bool debugCubeMaps;
         private bool debugLightProbes;
@@ -31,19 +26,8 @@ namespace ValveResourceFormat.Renderer
         /// <summary>Initializes the selected node renderer and creates GPU resources.</summary>
         /// <param name="rendererContext">Renderer context for loading shaders.</param>
         public SelectedNodeRenderer(RendererContext rendererContext)
+            : base(rendererContext, nameof(SelectedNodeRenderer))
         {
-            shader = rendererContext.ShaderLoader.LoadShader("vrf.default");
-
-            GL.CreateVertexArrays(1, out vaoHandle);
-            GL.CreateBuffers(1, out vboHandle);
-            GL.VertexArrayVertexBuffer(vaoHandle, 0, vboHandle, 0, SimpleVertex.SizeInBytes);
-            SimpleVertex.BindDefaultShaderLayout(vaoHandle, shader.Program);
-
-#if DEBUG
-            var vaoLabel = nameof(SelectedNodeRenderer);
-            GL.ObjectLabel(ObjectLabelIdentifier.VertexArray, vaoHandle, vaoLabel.Length, vaoLabel);
-            GL.ObjectLabel(ObjectLabelIdentifier.Buffer, vboHandle, vaoLabel.Length, vaoLabel);
-#endif
         }
 
         /// <summary>Toggles selection of the given node, adding it if not selected or removing it if already selected.</summary>
@@ -86,7 +70,7 @@ namespace ValveResourceFormat.Renderer
 
             if (node == null)
             {
-                vertexCount = 0;
+                Clear();
                 return;
             }
 
@@ -201,7 +185,7 @@ namespace ValveResourceFormat.Renderer
             if (selectedNodes.Count == 0)
             {
                 // We don't need to reupload an empty array
-                vertexCount = 0;
+                Clear();
                 return;
             }
 
@@ -339,9 +323,7 @@ namespace ValveResourceFormat.Renderer
                 }, renderContext.Camera);
             }
 
-            vertexCount = vertices.Count;
-
-            GL.NamedBufferData(vboHandle, vertexCount * SimpleVertex.SizeInBytes, ListAccessors<SimpleVertex>.GetBackingArray(vertices), BufferUsageHint.DynamicDraw);
+            Upload(vertices);
 
             vertices.Clear();
         }
@@ -357,31 +339,7 @@ namespace ValveResourceFormat.Renderer
         /// <summary>Renders the wireframe selection overlay for the current frame.</summary>
         public void Render()
         {
-            if (vertexCount == 0)
-            {
-                return;
-            }
-
-            GL.Enable(EnableCap.Blend);
-
-            if (disableDepth)
-            {
-                GL.Disable(EnableCap.DepthTest);
-            }
-
-            GL.DepthMask(false);
-            GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
-
-            shader.Use();
-            shader.SetUniform3x4("transform", Matrix4x4.Identity);
-
-            GL.BindVertexArray(vaoHandle);
-            GL.DrawArrays(PrimitiveType.Lines, 0, vertexCount);
-            GL.UseProgram(0);
-            GL.BindVertexArray(0);
-            GL.DepthMask(true);
-            GL.Disable(EnableCap.Blend);
-            GL.Enable(EnableCap.DepthTest);
+            RenderLines(disableDepth);
         }
 
         /// <summary>Updates which debug overlays (cubemaps, light probes) are drawn based on the active render mode.</summary>


### PR DESCRIPTION
- Extracted some line rendering code to base class
- Show bone local axes like in S2 tools
- Fade away bone name and axis gizmo sizes when too far from the skeleton node
- Lightened leaf text color

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/c833d8b0-6c70-4a7c-a65d-e6fa5bcad8e9" />
