### PR TITLE
Apply env_sky brightnessscale to the rendered sky and cubemap fog

### DIFF
--- a/Renderer/ParticleRenderer/ParticleRenderer.cs
+++ b/Renderer/ParticleRenderer/ParticleRenderer.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using ValveKeyValue;
 using ValveResourceFormat.Blocks;
@@ -42,6 +43,7 @@ namespace ValveResourceFormat.Renderer.Particles
         // invalidate each other. ReadConstraintPasses returns 1 for systems with no constraints.
         private readonly int ConstraintPasses;
 
+        private static readonly Lock LoggedWarningsLock = new();
         private static readonly HashSet<string> loggedWarnings = [];
 
         private readonly Scene scene;
@@ -768,7 +770,14 @@ namespace ValveResourceFormat.Renderer.Particles
         private void LogUniqueUnsupportedWarning(string componentType, string className)
         {
             var message = $"Unsupported {componentType} class '{className}'";
-            if (loggedWarnings.Add(message))
+
+            bool isNewWarning;
+            using (LoggedWarningsLock.EnterScope())
+            {
+                isNewWarning = loggedWarnings.Add(message);
+            }
+
+            if (isNewWarning)
             {
                 RendererContext.Logger.LogWarning("{Message} {File}", message, Name);
             }

--- a/Renderer/Renderer/World/WorldLoader.cs
+++ b/Renderer/Renderer/World/WorldLoader.cs
@@ -567,6 +567,12 @@ namespace ValveResourceFormat.Renderer.World
                         disabled = disabled && Skybox2D != null;
 
                         tintColor = entity.GetColor32Property("tint_color");
+
+                        var skyBrightnessScale = entity.GetFloatProperty("brightnessscale", 1.0f);
+                        if (skyBrightnessScale > 0f)
+                        {
+                            tintColor *= skyBrightnessScale;
+                        }
                     }
 
                     if (!disabled && skyname != null)
@@ -715,6 +721,7 @@ namespace ValveResourceFormat.Renderer.World
                         else
                         {
                             string? material = null;
+                            var skyBrightnessScale = 1.0f;
 
                             if (fogSource == 1) // Cubemap From Env_Sky
                             {
@@ -729,6 +736,12 @@ namespace ValveResourceFormat.Renderer.World
                                         material = skyEntity.GetStringProperty("skyname") ?? skyEntity.GetStringProperty("skybox_material_day");
                                         var rotationOnly = EntityTransformHelper.CalculateTransformationMatrix(skyEntity) with { Translation = transformationMatrix.Translation };
                                         transformationMatrix = rotationOnly;  // steal rotation from env_sky
+
+                                        var scale = skyEntity.GetFloatProperty("brightnessscale", 1.0f);
+                                        if (scale > 0f)
+                                        {
+                                            skyBrightnessScale = scale;
+                                        }
                                     }
                                     else
                                     {
@@ -758,7 +771,7 @@ namespace ValveResourceFormat.Renderer.World
                                     var renderOnlyExposureBias = mat.Material.FloatParams.GetValueOrDefault("g_flRenderOnlyExposureBias", 0f);
 
                                     // These are both logarithms, so this is equivalent to a multiply of the raw value
-                                    exposureBias = brightnessExposureBias + renderOnlyExposureBias;
+                                    exposureBias = brightnessExposureBias + renderOnlyExposureBias + MathF.Log2(skyBrightnessScale);
                                 }
                             }
                         }


### PR DESCRIPTION
Also guard ParticleRenderer.loggedWarnings against concurrent access errors